### PR TITLE
chore(global) : 각 서비스별 8개 CI 워크플로우 생성

### DIFF
--- a/.github/workflows/ci-admin.yml
+++ b/.github/workflows/ci-admin.yml
@@ -1,0 +1,34 @@
+name: CI - Admin Service
+
+# 트리거: 명시된 브랜치로 PR이 생성되거나 업데이트될 때 실행
+on:
+  pull_request:
+    branches:
+      - 'develop/admin'
+      - 'devticket-admin'
+    # paths:
+    #   - 'devticket-admin/**' # (선택) 해당 서비스 디렉토리의 코드가 변경될 때만 트리거되도록 제한
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 1. Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 2. Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle' # 의존성 다운로드 캐싱 (빌드 속도 최적화)
+
+      - name: 3. Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: 4. Gradle Test
+        run: ./gradlew :devticket-admin:test
+
+      - name: 5. Gradle Build
+        run: ./gradlew :devticket-admin:build -x test

--- a/.github/workflows/ci-admin.yml
+++ b/.github/workflows/ci-admin.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: 4. Gradle Test
         run: ./gradlew :devticket-admin:test
+        env:
+          SPRING_PROFILES_ACTIVE: test
 
       - name: 5. Gradle Build
         run: ./gradlew :devticket-admin:build -x test

--- a/.github/workflows/ci-commerce.yml
+++ b/.github/workflows/ci-commerce.yml
@@ -1,0 +1,34 @@
+name: CI - Commerce Service
+
+# 트리거: 명시된 브랜치로 PR이 생성되거나 업데이트될 때 실행
+on:
+  pull_request:
+    branches:
+      - 'develop/commerce'
+      - 'devticket-commerce'
+    # paths:
+    #   - 'devticket-commerce/**' # (선택) 해당 서비스 디렉토리의 코드가 변경될 때만 트리거되도록 제한
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 1. Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 2. Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle' # 의존성 다운로드 캐싱 (빌드 속도 최적화)
+
+      - name: 3. Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: 4. Gradle Test
+        run: ./gradlew :devticket-commerce:test
+
+      - name: 5. Gradle Build
+        run: ./gradlew :devticket-commerce:build -x test

--- a/.github/workflows/ci-commerce.yml
+++ b/.github/workflows/ci-commerce.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: 4. Gradle Test
         run: ./gradlew :devticket-commerce:test
+        env:
+          SPRING_PROFILES_ACTIVE: test
 
       - name: 5. Gradle Build
         run: ./gradlew :devticket-commerce:build -x test

--- a/.github/workflows/ci-event.yml
+++ b/.github/workflows/ci-event.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: 4. Gradle Test
         run: ./gradlew :devticket-event:test
+        env:
+          SPRING_PROFILES_ACTIVE: test
 
       - name: 5. Gradle Build
         run: ./gradlew :devticket-event:build -x test

--- a/.github/workflows/ci-event.yml
+++ b/.github/workflows/ci-event.yml
@@ -1,0 +1,34 @@
+name: CI - Event Service
+
+# 트리거: 명시된 브랜치로 PR이 생성되거나 업데이트될 때 실행
+on:
+  pull_request:
+    branches:
+      - 'develop/event'
+      - 'devticket-event'
+    # paths:
+    #   - 'devticket-event/**' # (선택) 해당 서비스 디렉토리의 코드가 변경될 때만 트리거되도록 제한
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 1. Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 2. Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle' # 의존성 다운로드 캐싱 (빌드 속도 최적화)
+
+      - name: 3. Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: 4. Gradle Test
+        run: ./gradlew :devticket-event:test
+
+      - name: 5. Gradle Build
+        run: ./gradlew :devticket-event:build -x test

--- a/.github/workflows/ci-gateway.yml
+++ b/.github/workflows/ci-gateway.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: 4. Gradle Test
         run: ./gradlew :devticket-gateway:test
+        env:
+          SPRING_PROFILES_ACTIVE: test
 
       - name: 5. Gradle Build
         run: ./gradlew :devticket-gateway:build -x test

--- a/.github/workflows/ci-gateway.yml
+++ b/.github/workflows/ci-gateway.yml
@@ -1,0 +1,34 @@
+name: CI - Gateway Service
+
+# 트리거: 명시된 브랜치로 PR이 생성되거나 업데이트될 때 실행
+on:
+  pull_request:
+    branches:
+      - 'develop/gateway'
+      - 'devticket-gateway'
+    # paths:
+    #   - 'devticket-gateway/**' # (선택) 해당 서비스 디렉토리의 코드가 변경될 때만 트리거되도록 제한
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 1. Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 2. Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle' # 의존성 다운로드 캐싱 (빌드 속도 최적화)
+
+      - name: 3. Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: 4. Gradle Test
+        run: ./gradlew :devticket-gateway:test
+
+      - name: 5. Gradle Build
+        run: ./gradlew :devticket-gateway:build -x test

--- a/.github/workflows/ci-log.yml
+++ b/.github/workflows/ci-log.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: 4. Gradle Test
         run: ./gradlew :devticket-log:test
+        env:
+          SPRING_PROFILES_ACTIVE: test
 
       - name: 5. Gradle Build
         run: ./gradlew :devticket-log:build -x test

--- a/.github/workflows/ci-log.yml
+++ b/.github/workflows/ci-log.yml
@@ -1,0 +1,34 @@
+name: CI - Log Service
+
+# 트리거: 명시된 브랜치로 PR이 생성되거나 업데이트될 때 실행
+on:
+  pull_request:
+    branches:
+      - 'develop/log'
+      - 'devticket-log'
+    # paths:
+    #   - 'devticket-log/**' # (선택) 해당 서비스 디렉토리의 코드가 변경될 때만 트리거되도록 제한
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 1. Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 2. Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle' # 의존성 다운로드 캐싱 (빌드 속도 최적화)
+
+      - name: 3. Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: 4. Gradle Test
+        run: ./gradlew :devticket-log:test
+
+      - name: 5. Gradle Build
+        run: ./gradlew :devticket-log:build -x test

--- a/.github/workflows/ci-member.yml
+++ b/.github/workflows/ci-member.yml
@@ -1,0 +1,34 @@
+name: CI - Member Service
+
+# 트리거: 명시된 브랜치로 PR이 생성되거나 업데이트될 때 실행
+on:
+  pull_request:
+    branches:
+      - 'develop/member'
+      - 'devticket-member'
+    # paths:
+    #   - 'devticket-member/**' # (선택) 해당 서비스 디렉토리의 코드가 변경될 때만 트리거되도록 제한
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 1. Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 2. Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle' # 의존성 다운로드 캐싱 (빌드 속도 최적화)
+
+      - name: 3. Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: 4. Gradle Test
+        run: ./gradlew :devticket-member:test
+
+      - name: 5. Gradle Build
+        run: ./gradlew :devticket-member:build -x test

--- a/.github/workflows/ci-member.yml
+++ b/.github/workflows/ci-member.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: 4. Gradle Test
         run: ./gradlew :devticket-member:test
+        env:
+          SPRING_PROFILES_ACTIVE: test
 
       - name: 5. Gradle Build
         run: ./gradlew :devticket-member:build -x test

--- a/.github/workflows/ci-payment.yml
+++ b/.github/workflows/ci-payment.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: 4. Gradle Test
         run: ./gradlew :devticket-payment:test
+        env:
+          SPRING_PROFILES_ACTIVE: test
 
       - name: 5. Gradle Build
         run: ./gradlew :devticket-payment:build -x test

--- a/.github/workflows/ci-payment.yml
+++ b/.github/workflows/ci-payment.yml
@@ -1,0 +1,34 @@
+name: CI - Payment Service
+
+# 트리거: 명시된 브랜치로 PR이 생성되거나 업데이트될 때 실행
+on:
+  pull_request:
+    branches:
+      - 'develop/payment'
+      - 'devticket-payment'
+    # paths:
+    #   - 'devticket-payment/**' # (선택) 해당 서비스 디렉토리의 코드가 변경될 때만 트리거되도록 제한
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 1. Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 2. Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle' # 의존성 다운로드 캐싱 (빌드 속도 최적화)
+
+      - name: 3. Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: 4. Gradle Test
+        run: ./gradlew :devticket-payment:test
+
+      - name: 5. Gradle Build
+        run: ./gradlew :devticket-payment:build -x test

--- a/.github/workflows/ci-settlement.yml
+++ b/.github/workflows/ci-settlement.yml
@@ -1,0 +1,34 @@
+name: CI - Settlement Service
+
+# 트리거: 명시된 브랜치로 PR이 생성되거나 업데이트될 때 실행
+on:
+  pull_request:
+    branches:
+      - 'develop/settlement'
+      - 'devticket-settlement'
+    # paths:
+    #   - 'devticket-settlement/**' # (선택) 해당 서비스 디렉토리의 코드가 변경될 때만 트리거되도록 제한
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 1. Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 2. Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle' # 의존성 다운로드 캐싱 (빌드 속도 최적화)
+
+      - name: 3. Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: 4. Gradle Test
+        run: ./gradlew :devticket-settlement:test
+
+      - name: 5. Gradle Build
+        run: ./gradlew :devticket-settlement:build -x test

--- a/.github/workflows/ci-settlement.yml
+++ b/.github/workflows/ci-settlement.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: 4. Gradle Test
         run: ./gradlew :devticket-settlement:test
+        env:
+          SPRING_PROFILES_ACTIVE: test
 
       - name: 5. Gradle Build
         run: ./gradlew :devticket-settlement:build -x test


### PR DESCRIPTION
## 작업 내용
- MSA 모노레포 환경을 위한 8개 마이크로서비스 독립 CI(GitHub Actions) 파이프라인 구축
- 각 서비스의 대상 브랜치(`develop/{서비스}`, `devticket-{서비스}`)로 PR 생성 시, 해당 도메인 모듈만 격리하여 자동 테스트 및 빌드 수행
- 빌드 최적화 적용 (Gradle 의존성 캐싱, 빌드 단계에서의 테스트 중복 실행 방지)

## 변경 사항
- `.github/workflows/` 디렉토리 하위에 다음 8개의 CI 스크립트 신규 추가
  - `ci-gateway.yml`
  - `ci-member.yml`
  - `ci-event.yml`
  - `ci-commerce.yml`
  - `ci-payment.yml`
  - `ci-settlement.yml`
  - `ci-log.yml`
  - `ci-admin.yml`