### PR TITLE
[Gateway] feat: Internal API 외부 차단 설정

### DIFF
--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/security/InternalApiBlockFilter.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/security/InternalApiBlockFilter.java
@@ -18,6 +18,9 @@ import reactor.core.publisher.Mono;
 public class InternalApiBlockFilter implements GlobalFilter, Ordered {
 
     private final GatewayAuthenticationEntryPoint entryPoint;
+
+    // TODO: 성능 최적화 시 AntPathMatcher → PathPatternParser 전환 검토
+    // WebFlux 기반 Gateway에서는 PathPattern이 더 효율적
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override


### PR DESCRIPTION
## 관련 이슈
- close #54 

## 작업 내용
- /internal/** 경로에 대한 외부 요청을 Gateway에서 403으로 차단
- JWT 인증 필터보다 우선순위 높게 설정하여 토큰 검증 전에 차단

## 변경 사항
- `InternalApiBlockFilter.java` — (신규) /internal/** 외부 차단 GlobalFilter

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)

## 참고 사항
- 내부 서비스 간 호출은 Gateway를 경유하지 않고 직접 포트로 통신하므로 이 필터에 걸리지 않음
- RoutePolicy.INTERNAL_PATHS 상수를 참조하여 경로 판단
- 차단 시 접근자 IP를 warn 로그로 남김