### PR TITLE
[Gateway] feat: 공통 에러 응답 처리

### DIFF
--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/exception/GatewayErrorCode.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/exception/GatewayErrorCode.java
@@ -11,7 +11,10 @@ public enum GatewayErrorCode {
     TOKEN_EXPIRED(401, "COMMON_003", "토큰이 만료되었습니다."),
     INVALID_TOKEN(401, "COMMON_004", "유효하지 않은 토큰입니다."),
     ACCESS_DENIED(403, "COMMON_005", "접근 권한이 없습니다."),
-    INTERNAL_SERVER_ERROR(500, "COMMON_006", "서버 내부 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(500, "COMMON_006", "서버 내부 오류가 발생했습니다."),
+    SERVICE_CONNECT_FAILED(502, "COMMON_007", "외부 서비스 연동에 실패했습니다."),
+    SERVICE_UNAVAILABLE(503, "COMMON_008", "서비스를 일시적으로 이용할 수 없습니다."),
+    RATE_LIMIT_EXCEEDED(429, "COMMON_009", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.");
 
     private final int status;
     private final String code;

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/exception/GatewayExceptionHandler.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/exception/GatewayExceptionHandler.java
@@ -1,0 +1,89 @@
+package com.devticket.apigateway.infrastructure.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.net.ConnectException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.webflux.error.ErrorWebExceptionHandler;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@Order(-1)
+public class GatewayExceptionHandler implements ErrorWebExceptionHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public GatewayExceptionHandler() {
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    @Override
+    public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+        ServerHttpResponse response = exchange.getResponse();
+
+        if (response.isCommitted()) {
+            return Mono.error(ex);
+        }
+
+        GatewayErrorCode errorCode = resolveErrorCode(ex);
+
+        log.error("Gateway 예외 발생: path={}, errorCode={}, message={}",
+            exchange.getRequest().getURI().getPath(),
+            errorCode.getCode(),
+            ex.getMessage());
+
+        response.setStatusCode(HttpStatus.valueOf(errorCode.getStatus()));
+        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+            errorCode.getStatus(),
+            errorCode.getCode(),
+            errorCode.getMessage()
+        );
+
+        try {
+            byte[] bytes = objectMapper.writeValueAsBytes(errorResponse);
+            DataBuffer buffer = response.bufferFactory().wrap(bytes);
+            return response.writeWith(Mono.just(buffer));
+        } catch (Exception e) {
+            log.error("에러 응답 직렬화 실패", e);
+            return response.setComplete();
+        }
+    }
+
+    private GatewayErrorCode resolveErrorCode(Throwable ex) {
+
+        if (ex instanceof ConnectException) {
+            return GatewayErrorCode.SERVICE_UNAVAILABLE;
+        }
+
+        if (ex.getCause() instanceof ConnectException) {
+            return GatewayErrorCode.SERVICE_UNAVAILABLE;
+        }
+
+        if (ex instanceof ResponseStatusException rse) {
+            HttpStatus status = HttpStatus.resolve(rse.getStatusCode().value());
+            if (status != null) {
+                return switch (status) {
+                    case NOT_FOUND -> GatewayErrorCode.SERVICE_CONNECT_FAILED;
+                    case SERVICE_UNAVAILABLE -> GatewayErrorCode.SERVICE_UNAVAILABLE;
+                    case UNAUTHORIZED -> GatewayErrorCode.AUTHENTICATION_REQUIRED;
+                    case FORBIDDEN -> GatewayErrorCode.ACCESS_DENIED;
+                    default -> GatewayErrorCode.INTERNAL_SERVER_ERROR;
+                };
+            }
+        }
+
+        return GatewayErrorCode.INTERNAL_SERVER_ERROR;
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #55 

## 작업 내용
- Gateway 레벨 글로벌 예외 핸들러(ErrorWebExceptionHandler) 구현
- 하위 서비스 연결 실패 시 503(COMMON_008) JSON 응답 반환
- 라우팅 매칭 실패 시 502(COMMON_007) JSON 응답 반환
- 기타 미처리 예외 시 500(COMMON_006) JSON 응답 반환
- 모든 에러 응답이 예외 처리 정책 문서의 JSON 포맷을 따름

## 변경 사항
- `GatewayExceptionHandler.java` — (신규) 글로벌 예외 핸들러
- `GatewayErrorCode.java` — (수정) SERVICE_CONNECT_FAILED, SERVICE_UNAVAILABLE 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)

## 참고 사항
- 인증/인가/Rate Limit 에러는 각 필터에서 직접 처리, 이 핸들러는 나머지를 잡는 안전망
- @Order(-1)로 Spring Boot 기본 에러 핸들러보다 우선 실행
- 응답이 이미 커밋된 경우(필터에서 처리 완료) 중복 쓰기 방지