### PR TITLE
[Gateway] feat: Bucket4j 기반 Rate Limiting 구현

### DIFF
--- a/apigateway/build.gradle
+++ b/apigateway/build.gradle
@@ -45,6 +45,10 @@ dependencies {
     // Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // Rate Limiting (Bucket4j + Caffeine 인메모리)
+    implementation 'com.bucket4j:bucket4j_jdk17-core:8.17.0'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/config/RateLimitConfig.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/config/RateLimitConfig.java
@@ -1,0 +1,48 @@
+package com.devticket.apigateway.infrastructure.config;
+
+import java.time.Duration;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Rate Limiting 설정.
+ *
+ * <p>application.yml에서 정책을 외부화하여 재배포 없이 수치 변경이 가능합니다.</p>
+ *
+ * <pre>
+ * gateway:
+ *   rate-limit:
+ *     default-capacity: 100
+ *     default-refill-tokens: 50
+ *     default-refill-duration: 1s
+ *     routes:
+ *       - path-pattern: /api/orders/**
+ *         capacity: 20
+ *         refill-tokens: 10
+ *         refill-duration: 1s
+ * </pre>
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "gateway.rate-limit")
+public class RateLimitConfig {
+
+    private int defaultCapacity;
+    private int defaultRefillTokens;
+    private Duration defaultRefillDuration;
+    private List<RouteRateLimit> routes = List.of();
+
+    @Getter
+    @Setter
+    public static class RouteRateLimit {
+
+        private String pathPattern;
+        private int capacity;
+        private int refillTokens;
+        private Duration refillDuration;
+    }
+}

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/security/RateLimitFilter.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/security/RateLimitFilter.java
@@ -1,0 +1,120 @@
+package com.devticket.apigateway.infrastructure.security;
+
+import com.devticket.apigateway.infrastructure.config.RateLimitConfig;
+import com.devticket.apigateway.infrastructure.config.RateLimitConfig.RouteRateLimit;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+public class RateLimitFilter implements GlobalFilter, Ordered {
+
+    private final RateLimitConfig config;
+    private final GatewayAuthenticationEntryPoint entryPoint;
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    public RateLimitFilter(RateLimitConfig config, GatewayAuthenticationEntryPoint entryPoint) {
+        this.config = config;
+        this.entryPoint = entryPoint;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String clientIp = resolveClientIp(exchange);
+        String path = exchange.getRequest().getURI().getPath();
+
+        // 경로별 매칭된 정책 또는 글로벌 기본 정책으로 버킷 생성
+        String bucketKey = clientIp + ":" + resolvePolicyKey(path);
+        Bucket bucket = buckets.computeIfAbsent(bucketKey, k -> createBucket(path));
+
+        ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+
+        if (probe.isConsumed()) {
+            ServerHttpResponse response = exchange.getResponse();
+            response.getHeaders().add("X-RateLimit-Remaining",
+                String.valueOf(probe.getRemainingTokens()));
+            return chain.filter(exchange);
+        }
+
+        // Rate Limit 초과
+        log.warn("Rate limit 초과: clientIp={}, path={}, retryAfterNanos={}",
+            clientIp, path, probe.getNanosToWaitForRefill());
+
+        exchange.getResponse().getHeaders().add("Retry-After",
+            String.valueOf(probe.getNanosToWaitForRefill() / 1_000_000_000));
+        return entryPoint.writeErrorResponse(
+            exchange.getResponse(), GatewayErrorCode.RATE_LIMIT_EXCEEDED);
+    }
+
+    /**
+     * 인증/인가 필터 이후에 실행됩니다. 인증되지 않은 요청은 이미 401/403으로 거부된 상태이므로 Rate Limit은 인증된 요청에만 적용됩니다.
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 10;
+    }
+
+    private Bucket createBucket(String path) {
+        // 경로별 개별 정책 확인
+        for (RouteRateLimit route : config.getRoutes()) {
+            if (pathMatcher.match(route.getPathPattern(), path)) {
+                return Bucket.builder()
+                    .addLimit(Bandwidth.builder()
+                        .capacity(route.getCapacity())
+                        .refillGreedy(route.getRefillTokens(), route.getRefillDuration())
+                        .build())
+                    .build();
+            }
+        }
+
+        // 글로벌 기본 정책
+        return Bucket.builder()
+            .addLimit(Bandwidth.builder()
+                .capacity(config.getDefaultCapacity())
+                .refillGreedy(config.getDefaultRefillTokens(),
+                    config.getDefaultRefillDuration())
+                .build())
+            .build();
+    }
+
+    private String resolvePolicyKey(String path) {
+        for (RouteRateLimit route : config.getRoutes()) {
+            if (pathMatcher.match(route.getPathPattern(), path)) {
+                return route.getPathPattern();
+            }
+        }
+        return "global";
+    }
+
+    private String resolveClientIp(ServerWebExchange exchange) {
+        // X-Forwarded-For 헤더 우선 (프록시/로드밸런서 뒤에 있을 경우)
+        String xForwardedFor = exchange.getRequest().getHeaders().getFirst("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isBlank()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+
+        InetSocketAddress remoteAddress = exchange.getRequest().getRemoteAddress();
+        if (remoteAddress != null) {
+            InetAddress address = remoteAddress.getAddress();
+            if (address != null) {
+                return address.getHostAddress();
+            }
+        }
+        return "unknown";
+    }
+}

--- a/apigateway/src/main/resources/application.yml
+++ b/apigateway/src/main/resources/application.yml
@@ -74,3 +74,19 @@ springdoc:
     path: /swagger-ui.html
   api-docs:
     path: /v1/api-docs
+
+# Rate Limiting
+gateway:
+  rate-limit:
+    default-capacity: 100
+    default-refill-tokens: 50
+    default-refill-duration: 1s
+    routes:
+      - path-pattern: /api/orders/**
+        capacity: 20
+        refill-tokens: 10
+        refill-duration: 1s
+      - path-pattern: /api/payments/**
+        capacity: 20
+        refill-tokens: 10
+        refill-duration: 1s


### PR DESCRIPTION
## 관련 이슈
- close #56 

## 작업 내용
- Bucket4j Token Bucket 알고리즘 기반 Rate Limiting 구현
- 클라이언트 IP별 버킷 생성 (X-Forwarded-For 우선, 없으면 remoteAddress)
- 경로별 차등 제한: 주문/결제 API는 별도 정책, 나머지는 글로벌 기본
- Rate Limit 수치를 application.yml로 외부화하여 재배포 없이 조정 가능
- 성공 시 X-RateLimit-Remaining 헤더, 초과 시 429 + Retry-After 헤더 반환

## 변경 사항
- `RateLimitFilter.java` — (신규) Bucket4j 기반 GlobalFilter
- `RateLimitConfig.java` — (신규) yml Rate Limit 설정 바인딩
- `build.gradle` — (수정) bucket4j_jdk17-core, caffeine 의존성 추가
- `application.yml` — (수정) gateway.rate-limit 설정 블록 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)

## 참고 사항
- 인메모리(ConcurrentHashMap) 방식, Gateway 1대 기준
- Gateway 다중화 시 Redis 기반으로 전환 필요 (Bucket4j Redis 어댑터 지원)
- Rate Limit 수치는 부하 테스트 이후 조정 예정
- 인증 필터 이후에 실행되므로 인증 실패 요청은 토큰 소비 안 함