### PR TITLE
[Gateway] feat: 권한별 접근 제어 구현

### DIFF
--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/security/RoleAuthorizationFilter.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/security/RoleAuthorizationFilter.java
@@ -1,0 +1,65 @@
+package com.devticket.apigateway.infrastructure.security;
+
+import com.devticket.apigateway.infrastructure.config.RoutePolicy;
+import com.devticket.apigateway.infrastructure.exception.GatewayErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoleAuthorizationFilter implements GlobalFilter, Ordered {
+
+    private static final String HEADER_USER_ROLE = "X-User-Role";
+    private static final String ROLE_SELLER = "SELLER";
+    private static final String ROLE_ADMIN = "ADMIN";
+
+    private final GatewayAuthenticationEntryPoint entryPoint;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String path = exchange.getRequest().getURI().getPath();
+        String role = exchange.getRequest().getHeaders().getFirst(HEADER_USER_ROLE);
+
+        if (role == null) {
+            return chain.filter(exchange);
+        }
+
+        if (isAdminPath(path) && !ROLE_ADMIN.equals(role)) {
+            log.debug("ADMIN 권한 필요: path={}, role={}", path, role);
+            return entryPoint.writeErrorResponse(
+                exchange.getResponse(), GatewayErrorCode.ACCESS_DENIED);
+        }
+
+        if (isSellerPath(path) && !ROLE_SELLER.equals(role) && !ROLE_ADMIN.equals(role)) {
+            log.debug("SELLER 권한 필요: path={}, role={}", path, role);
+            return entryPoint.writeErrorResponse(
+                exchange.getResponse(), GatewayErrorCode.ACCESS_DENIED);
+        }
+
+        return chain.filter(exchange);
+    }
+    
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 2;
+    }
+
+    private boolean isAdminPath(String path) {
+        return RoutePolicy.ADMIN_PATHS.stream()
+            .anyMatch(pattern -> pathMatcher.match(pattern, path));
+    }
+
+    private boolean isSellerPath(String path) {
+        return RoutePolicy.SELLER_PATHS.stream()
+            .anyMatch(pattern -> pathMatcher.match(pattern, path));
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #65 

## 작업 내용
- JWT 필터가 세팅한 X-User-Role 헤더를 읽어 URL 패턴별 권한 검사
- /api/seller/** 경로는 SELLER, ADMIN만 접근 허용
- /api/admin/** 경로는 ADMIN만 접근 허용
- 나머지 인증 필요 경로는 USER/SELLER/ADMIN 전부 허용 (별도 검사 없음)
- 권한 부족 시 403(COMMON_005) JSON 에러 응답 반환

## 변경 사항
- `RoleAuthorizationFilter.java` — (신규) role 기반 접근 제어 GlobalFilter

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)

## 참고 사항
- RoutePolicy.SELLER_PATHS, ADMIN_PATHS 상수 참조
- role이 null이면 공개 경로 → 통과 (JWT 필터에서 이미 처리됨)