### PR TITLE
[Gateway]test: JWT 인증/인가 및 내부 차단 통합 테스트 작성

### DIFF
--- a/apigateway/build.gradle
+++ b/apigateway/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/apigateway/src/main/resources/application-test.yml
+++ b/apigateway/src/main/resources/application-test.yml
@@ -2,3 +2,10 @@ jwt:
   secret-key: test-jwt-secret-key-devticket-2025-must-be-256-bits
   access-token-ttl: 1800000
   refresh-token-ttl: 604800000
+
+gateway:
+  rate-limit:
+    default-capacity: 100
+    default-refill-tokens: 50
+    default-refill-duration: 1s
+    routes: [ ]

--- a/apigateway/src/test/java/com/devticket/apigateway/infrastructure/security/InternalApiBlockFilterTest.java
+++ b/apigateway/src/test/java/com/devticket/apigateway/infrastructure/security/InternalApiBlockFilterTest.java
@@ -1,0 +1,75 @@
+package com.devticket.apigateway.infrastructure.security;
+
+import com.devticket.apigateway.support.JwtTestHelper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+class InternalApiBlockFilterTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void internal_경로_토큰없이_접근시_403() {
+        webTestClient.get()
+            .uri("/internal/members/1")
+            .exchange()
+            .expectStatus().isForbidden()
+            .expectBody()
+            .jsonPath("$.status").isEqualTo(403)
+            .jsonPath("$.code").isEqualTo("COMMON_005")
+            .jsonPath("$.message").isEqualTo("접근 권한이 없습니다.");
+    }
+
+    @Test
+    void internal_경로_유효한_토큰으로_접근시에도_403() {
+        String token = JwtTestHelper.createValidToken("99", "admin@test.com", "ADMIN");
+
+        webTestClient.get()
+            .uri("/internal/members/1")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().isForbidden()
+            .expectBody()
+            .jsonPath("$.code").isEqualTo("COMMON_005");
+    }
+
+    @Test
+    void internal_events_경로_차단() {
+        webTestClient.get()
+            .uri("/internal/events/1/validate-purchase")
+            .exchange()
+            .expectStatus().isForbidden();
+    }
+
+    @Test
+    void internal_orders_경로_차단() {
+        webTestClient.get()
+            .uri("/internal/orders/1")
+            .exchange()
+            .expectStatus().isForbidden();
+    }
+
+    @Test
+    void internal_payments_경로_차단() {
+        webTestClient.get()
+            .uri("/internal/payments/by-order/1")
+            .exchange()
+            .expectStatus().isForbidden();
+    }
+
+    @Test
+    void internal_wallets_경로_차단() {
+        webTestClient.get()
+            .uri("/internal/wallets/1/balance")
+            .exchange()
+            .expectStatus().isForbidden();
+    }
+}

--- a/apigateway/src/test/java/com/devticket/apigateway/infrastructure/security/JwtAuthenticationFilterTest.java
+++ b/apigateway/src/test/java/com/devticket/apigateway/infrastructure/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,147 @@
+package com.devticket.apigateway.infrastructure.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.devticket.apigateway.support.JwtTestHelper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+class JwtAuthenticationFilterTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    // ──────────────────────────────────────────────
+    // 유효한 JWT 테스트
+    // ──────────────────────────────────────────────
+
+    @Test
+    void 유효한_JWT_요청시_인증_통과() {
+        String token = JwtTestHelper.createValidToken("42", "user@test.com", "USER");
+
+        webTestClient.get()
+            .uri("/api/cart")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void 유효한_JWT_요청시_하위서비스_헤더_전달_확인() {
+        String token = JwtTestHelper.createValidToken("42", "user@test.com", "USER");
+
+        // Gateway가 401/403을 반환하지 않으면 하위 서비스로 헤더를 전달한 것
+        // (하위 서비스가 없어서 502/503이 올 수 있지만, 인증은 통과한 상태)
+        webTestClient.get()
+            .uri("/api/orders")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    // ──────────────────────────────────────────────
+    // 인증 실패 테스트
+    // ──────────────────────────────────────────────
+
+    @Test
+    void Authorization_헤더_누락시_401_COMMON_002() {
+        webTestClient.get()
+            .uri("/api/cart")
+            .exchange()
+            .expectStatus().isUnauthorized()
+            .expectBody()
+            .jsonPath("$.status").isEqualTo(401)
+            .jsonPath("$.code").isEqualTo("COMMON_002")
+            .jsonPath("$.message").isEqualTo("인증이 필요합니다.")
+            .jsonPath("$.timestamp").exists();
+    }
+
+    @Test
+    void Bearer_형식_아닌_토큰시_401_COMMON_002() {
+        webTestClient.get()
+            .uri("/api/cart")
+            .header("Authorization", "Basic some-token")
+            .exchange()
+            .expectStatus().isUnauthorized()
+            .expectBody()
+            .jsonPath("$.code").isEqualTo("COMMON_002");
+    }
+
+    @Test
+    void 만료된_토큰_요청시_401_COMMON_003() {
+        String token = JwtTestHelper.createExpiredToken("42", "user@test.com", "USER");
+
+        webTestClient.get()
+            .uri("/api/cart")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().isUnauthorized()
+            .expectBody()
+            .jsonPath("$.status").isEqualTo(401)
+            .jsonPath("$.code").isEqualTo("COMMON_003")
+            .jsonPath("$.message").isEqualTo("토큰이 만료되었습니다.");
+    }
+
+    @Test
+    void 위조된_토큰_요청시_401_COMMON_004() {
+        String token = JwtTestHelper.createInvalidSignatureToken("42", "user@test.com", "USER");
+
+        webTestClient.get()
+            .uri("/api/cart")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().isUnauthorized()
+            .expectBody()
+            .jsonPath("$.status").isEqualTo(401)
+            .jsonPath("$.code").isEqualTo("COMMON_004")
+            .jsonPath("$.message").isEqualTo("유효하지 않은 토큰입니다.");
+    }
+
+    @Test
+    void 잘못된_형식의_토큰_요청시_401_COMMON_004() {
+        webTestClient.get()
+            .uri("/api/cart")
+            .header("Authorization", "Bearer not.a.valid.jwt.token")
+            .exchange()
+            .expectStatus().isUnauthorized()
+            .expectBody()
+            .jsonPath("$.code").isEqualTo("COMMON_004");
+    }
+
+    // ──────────────────────────────────────────────
+    // 에러 응답 포맷 검증
+    // ──────────────────────────────────────────────
+
+    @Test
+    void 에러_응답_JSON_Content_Type_확인() {
+        webTestClient.get()
+            .uri("/api/cart")
+            .exchange()
+            .expectHeader().contentType("application/json");
+    }
+
+    @Test
+    void 에러_응답_포맷_status_code_message_timestamp_포함() {
+        webTestClient.get()
+            .uri("/api/cart")
+            .exchange()
+            .expectBody()
+            .jsonPath("$.status").isNumber()
+            .jsonPath("$.code").isNotEmpty()
+            .jsonPath("$.message").isNotEmpty()
+            .jsonPath("$.timestamp").isNotEmpty();
+    }
+}

--- a/apigateway/src/test/java/com/devticket/apigateway/infrastructure/security/PublicPathTest.java
+++ b/apigateway/src/test/java/com/devticket/apigateway/infrastructure/security/PublicPathTest.java
@@ -1,0 +1,102 @@
+package com.devticket.apigateway.infrastructure.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+class PublicPathTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void POST_auth_회원가입_인증없이_통과() {
+        webTestClient.post()
+            .uri("/api/auth/signup")
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void POST_auth_로그인_인증없이_통과() {
+        webTestClient.post()
+            .uri("/api/auth/login")
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void POST_auth_토큰재발급_인증없이_통과() {
+        webTestClient.post()
+            .uri("/api/auth/reissue")
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void GET_events_목록조회_인증없이_통과() {
+        webTestClient.get()
+            .uri("/api/events")
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void GET_events_검색_인증없이_통과() {
+        webTestClient.get()
+            .uri("/api/events/search")
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void GET_events_상세조회_인증없이_통과() {
+        webTestClient.get()
+            .uri("/api/events/123")
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void GET_health_인증없이_통과() {
+        webTestClient.get()
+            .uri("/health")
+            .exchange()
+            .expectStatus().isOk();
+    }
+
+    @Test
+    void POST_events_는_인증_필요() {
+        // GET은 공개지만 POST는 인증 필요 (판매자 이벤트 생성)
+        webTestClient.post()
+            .uri("/api/events")
+            .exchange()
+            .expectStatus().isUnauthorized();
+    }
+}

--- a/apigateway/src/test/java/com/devticket/apigateway/infrastructure/security/RoleAuthorizationFilterTest.java
+++ b/apigateway/src/test/java/com/devticket/apigateway/infrastructure/security/RoleAuthorizationFilterTest.java
@@ -1,0 +1,189 @@
+package com.devticket.apigateway.infrastructure.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.devticket.apigateway.support.JwtTestHelper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+class RoleAuthorizationFilterTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    // ──────────────────────────────────────────────
+    // USER 접근 제어
+    // ──────────────────────────────────────────────
+
+    @Test
+    void USER가_seller_API_접근시_403_COMMON_005() {
+        String token = JwtTestHelper.createValidToken("1", "user@test.com", "USER");
+
+        webTestClient.get()
+            .uri("/api/seller/events")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().isForbidden()
+            .expectBody()
+            .jsonPath("$.status").isEqualTo(403)
+            .jsonPath("$.code").isEqualTo("COMMON_005")
+            .jsonPath("$.message").isEqualTo("접근 권한이 없습니다.");
+    }
+
+    @Test
+    void USER가_admin_API_접근시_403_COMMON_005() {
+        String token = JwtTestHelper.createValidToken("1", "user@test.com", "USER");
+
+        webTestClient.get()
+            .uri("/api/admin/users")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().isForbidden()
+            .expectBody()
+            .jsonPath("$.code").isEqualTo("COMMON_005");
+    }
+
+    @Test
+    void USER가_일반_API_접근시_통과() {
+        String token = JwtTestHelper.createValidToken("1", "user@test.com", "USER");
+
+        webTestClient.get()
+            .uri("/api/cart")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    // ──────────────────────────────────────────────
+    // SELLER 접근 제어
+    // ──────────────────────────────────────────────
+
+    @Test
+    void SELLER가_seller_API_접근시_통과() {
+        String token = JwtTestHelper.createValidToken("2", "seller@test.com", "SELLER");
+
+        webTestClient.get()
+            .uri("/api/seller/events")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void SELLER가_admin_API_접근시_403() {
+        String token = JwtTestHelper.createValidToken("2", "seller@test.com", "SELLER");
+
+        webTestClient.get()
+            .uri("/api/admin/users")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().isForbidden()
+            .expectBody()
+            .jsonPath("$.code").isEqualTo("COMMON_005");
+    }
+
+    @Test
+    void SELLER가_일반_API_접근시_통과() {
+        String token = JwtTestHelper.createValidToken("2", "seller@test.com", "SELLER");
+
+        webTestClient.get()
+            .uri("/api/orders")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN 접근 제어
+    // ──────────────────────────────────────────────
+
+    @Test
+    void ADMIN이_admin_API_접근시_통과() {
+        String token = JwtTestHelper.createValidToken("99", "admin@test.com", "ADMIN");
+
+        webTestClient.get()
+            .uri("/api/admin/users")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void ADMIN이_seller_API_접근시_통과() {
+        String token = JwtTestHelper.createValidToken("99", "admin@test.com", "ADMIN");
+
+        webTestClient.get()
+            .uri("/api/seller/events")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void ADMIN이_일반_API_접근시_통과() {
+        String token = JwtTestHelper.createValidToken("99", "admin@test.com", "ADMIN");
+
+        webTestClient.get()
+            .uri("/api/cart")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void 토큰_없이_seller_경로_접근시_차단됨() {
+        webTestClient.get()
+            .uri("/api/seller/events")
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isIn(401, 403);
+            });
+    }
+
+    @Test
+    void role_없이_seller_경로_접근시_403() {
+        // JWT 필터 설정 실수로 공개 경로가 된 상황 가정
+        // role 헤더 없이 seller 경로에 도달하면 차단
+        webTestClient.get()
+            .uri("/api/seller/events")
+            .exchange()
+            .expectStatus().isForbidden()
+            .expectBody()
+            .jsonPath("$.code").isEqualTo("COMMON_005");
+    }
+
+    @Test
+    void role_없이_admin_경로_접근시_403() {
+        webTestClient.get()
+            .uri("/api/admin/users")
+            .exchange()
+            .expectStatus().isForbidden()
+            .expectBody()
+            .jsonPath("$.code").isEqualTo("COMMON_005");
+    }
+}

--- a/apigateway/src/test/java/com/devticket/apigateway/support/JwtTestHelper.java
+++ b/apigateway/src/test/java/com/devticket/apigateway/support/JwtTestHelper.java
@@ -1,0 +1,59 @@
+package com.devticket.apigateway.support;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+
+public class JwtTestHelper {
+
+    private static final String SECRET = "test-jwt-secret-key-devticket-2025-must-be-256-bits";
+    private static final SecretKey SECRET_KEY =
+        Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+
+    /**
+     * 유효한 토큰 생성.
+     */
+    public static String createValidToken(String userId, String email, String role) {
+        return Jwts.builder()
+            .subject(userId)
+            .claim("email", email)
+            .claim("role", role)
+            .issuedAt(new Date())
+            .expiration(new Date(System.currentTimeMillis() + 1800000))
+            .signWith(SECRET_KEY)
+            .compact();
+    }
+
+    /**
+     * 이미 만료된 토큰 생성.
+     */
+    public static String createExpiredToken(String userId, String email, String role) {
+        return Jwts.builder()
+            .subject(userId)
+            .claim("email", email)
+            .claim("role", role)
+            .issuedAt(new Date(System.currentTimeMillis() - 3600000))
+            .expiration(new Date(System.currentTimeMillis() - 1800000))
+            .signWith(SECRET_KEY)
+            .compact();
+    }
+
+    /**
+     * 다른 키로 서명한 위조 토큰 생성.
+     */
+    public static String createInvalidSignatureToken(String userId, String email, String role) {
+        SecretKey wrongKey = Keys.hmacShaKeyFor(
+            "wrong-secret-key-devticket-2025-totally-different-key"
+                .getBytes(StandardCharsets.UTF_8));
+        return Jwts.builder()
+            .subject(userId)
+            .claim("email", email)
+            .claim("role", role)
+            .issuedAt(new Date())
+            .expiration(new Date(System.currentTimeMillis() + 1800000))
+            .signWith(wrongKey)
+            .compact();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #66 

## 작업 내용
- Gateway 필터 체인 전체에 대한 통합 테스트 작성 (총 31개 케이스)
- WebTestClient로 실제 Gateway 컨텍스트를 올려 필터 체인 동작 검증
- 테스트용 JWT 토큰 생성 헬퍼(JwtTestHelper) 구현

## 변경 사항
- `JwtAuthenticationFilterTest.java` — (신규) 인증 필터 테스트 8개
- `PublicPathTest.java` — (신규) 공개 경로 테스트 8개
- `RoleAuthorizationFilterTest.java` — (신규) 권한 접근 제어 테스트 9개
- `InternalApiBlockFilterTest.java` — (신규) Internal 차단 테스트 6개
- `JwtTestHelper.java` — (신규) 테스트 유틸
- `application-test.yml` — (수정) secret-key 256 bits, rate-limit 설정
- `build.gradle` — (수정) webflux-test 의존성 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)

## 참고 사항
- 하위 서비스 미실행으로 인증 통과 후 502/503은 정상
- Filter 빈 생성 이슈(#이슈번호)로 internal 차단 테스트는 해당 수정 후 통과 예정