### PR TITLE
[Event] feat: 이벤트 생성 기능 구현

### DIFF
--- a/event/build.gradle
+++ b/event/build.gradle
@@ -1,44 +1,47 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '4.0.4'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '4.0.4'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.devticket'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-kafka'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    runtimeOnly 'com.h2database:h2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // 테스트 환경을 위한 H2 인메모리 DB
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/event/src/main/java/com/devticket/event/EventApplication.java
+++ b/event/src/main/java/com/devticket/event/EventApplication.java
@@ -2,8 +2,10 @@ package com.devticket.event;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class EventApplication {
 
 	public static void main(String[] args) {

--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -1,0 +1,65 @@
+package com.devticket.event.application;
+
+import com.devticket.event.domain.exception.BusinessException;
+import com.devticket.event.domain.exception.EventErrorCode;
+import com.devticket.event.domain.model.Event;
+import com.devticket.event.domain.model.EventStatus;
+import com.devticket.event.infrastructure.persistence.EventRepository;
+import com.devticket.event.presentation.dto.SellerEventCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+
+    private final EventRepository eventRepository;
+
+    @Transactional
+    public UUID createEvent(Long sellerId, SellerEventCreateRequest request) {
+
+        // 1. 비즈니스 정책 검증
+        if (request.saleStartAt().isAfter(request.saleEndAt()) || request.saleStartAt().isEqual(request.saleEndAt())) {
+            throw new BusinessException(EventErrorCode.INVALID_SALE_PERIOD);
+        }
+        if (request.saleEndAt().isAfter(request.eventDateTime())) {
+            throw new BusinessException(EventErrorCode.INVALID_EVENT_DATE);
+        }
+
+        LocalDateTime deadline = request.saleStartAt().minusDays(3);
+        if (LocalDateTime.now().isAfter(deadline)) {
+            throw new BusinessException(EventErrorCode.REGISTRATION_TIME_EXCEEDED);
+        }
+
+        if (request.maxQuantity() > request.totalQuantity()) {
+            throw new BusinessException(EventErrorCode.MAX_QUANTITY_EXCEEDED);
+        }
+
+        // 2. Event 엔티티 생성
+        Event event = Event.builder()
+            .eventId(UUID.randomUUID()) // 👈 v3 반영: 외부 노출용 고유 UUID 직접 생성
+            .sellerId(sellerId)
+            .title(request.title())
+            .description(request.description())
+            .location(request.location())
+            .eventDateTime(request.eventDateTime())
+            .saleStartAt(request.saleStartAt())
+            .saleEndAt(request.saleEndAt())
+            .price(request.price())
+            .totalQuantity(request.totalQuantity())
+            .maxQuantity(request.maxQuantity())
+            .remainingQuantity(request.totalQuantity())
+            .status(EventStatus.DRAFT)
+            .category(request.category())
+            .build();
+
+        // 3. 이벤트 저장
+        Event savedEvent = eventRepository.save(event);
+
+        return savedEvent.getEventId();
+    }
+}

--- a/event/src/main/java/com/devticket/event/domain/common/BaseEntity.java
+++ b/event/src/main/java/com/devticket/event/domain/common/BaseEntity.java
@@ -1,0 +1,37 @@
+package com.devticket.event.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class) // JPA Auditing 활성화
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    // Soft Delete 처리를 위한 편의 메서드
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+}

--- a/event/src/main/java/com/devticket/event/domain/exception/EventErrorCode.java
+++ b/event/src/main/java/com/devticket/event/domain/exception/EventErrorCode.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum EventErrorCode implements ErrorCode {
+public enum EventErrorCode implements ErrorCode{
 
     EVENT_NOT_FOUND(404, "EVENT_001", "존재하지 않는 이벤트입니다."),
     INVALID_PRICE(400, "EVENT_003", "이벤트 가격은 0원 이상 9,999,999원 이하여야 합니다."),
@@ -13,7 +13,11 @@ public enum EventErrorCode implements ErrorCode {
     INVALID_EVENT_DATES(400, "EVENT_005", "판매 시작일, 종료일, 행사일의 순서가 올바르지 않습니다."),
     OUT_OF_STOCK(409, "EVENT_006", "티켓 잔여 수량이 부족합니다."),
     CANNOT_CHANGE_STATUS(400, "EVENT_007", "변경할 수 없는 이벤트 상태입니다."),
-    UNAUTHORIZED_SELLER(403, "EVENT_008", "해당 이벤트에 대한 권한이 없습니다.");
+    UNAUTHORIZED_SELLER(403, "EVENT_008", "해당 이벤트에 대한 권한이 없습니다."),
+    REGISTRATION_TIME_EXCEEDED(400, "EVENT_005", "이벤트는 판매 시작일 기준 3일 전까지 등록 가능합니다."),
+    INVALID_SALE_PERIOD(400, "EVENT_014", "판매 시작 시각은 판매 종료 시각 이전이어야 합니다."),
+    INVALID_EVENT_DATE(400, "EVENT_015", "판매 종료 시각은 행사 일시 이전이어야 합니다."),
+    MAX_QUANTITY_EXCEEDED(400, "EVENT_016", "인당 최대 구매 수량은 총 수량을 초과할 수 없습니다.");
 
     private final int status;
     private final String code;

--- a/event/src/main/java/com/devticket/event/domain/model/Event.java
+++ b/event/src/main/java/com/devticket/event/domain/model/Event.java
@@ -1,73 +1,72 @@
 package com.devticket.event.domain.model;
 
-import com.devticket.event.domain.exception.BusinessException;
-import com.devticket.event.domain.exception.EventErrorCode;
-import jakarta.persistence.CascadeType;
+import com.devticket.event.domain.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
+
+import lombok.*;
 
 @Entity
 @Table(name = "events")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
-public class Event {
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@SQLRestriction("deleted_at IS NULL") // Soft Delete: 조회 시 삭제된 데이터 제외
+public class Event extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-    @Column(name = "seller_id", nullable = false)
-    private UUID sellerId;
+    @Column(nullable = false, unique = true, updatable = false)
+    private UUID eventId;
 
     @Column(nullable = false)
+    private Long sellerId;
+
+    @Column(nullable = false, length = 255)
     private String title;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String description;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 255)
     private String location;
 
-    @Column(name = "event_date_time", nullable = false)
+    @Column(nullable = false)
     private LocalDateTime eventDateTime;
 
-    @Column(name = "sale_start_at", nullable = false)
+    @Column(nullable = false)
     private LocalDateTime saleStartAt;
 
-    @Column(name = "sale_end_at", nullable = false)
+    @Column(nullable = false)
     private LocalDateTime saleEndAt;
 
     @Column(nullable = false)
     private Integer price;
 
-    @Column(name = "total_quantity", nullable = false)
+    @Column(nullable = false)
     private Integer totalQuantity;
 
-    @Column(name = "max_quantity", nullable = false)
+    @Column(nullable = false)
     private Integer maxQuantity;
 
-    @Column(name = "remaining_quantity", nullable = false)
+    @Column(nullable = false)
     private Integer remainingQuantity;
 
     @Enumerated(EnumType.STRING)
@@ -77,54 +76,4 @@ public class Event {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private EventCategory category;
-
-    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<EventImage> images = new ArrayList<>();
-
-    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<EventTechStack> eventTechStacks = new ArrayList<>();
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @Builder
-    public Event(UUID sellerId, String title, String description, String location,
-        LocalDateTime eventDateTime, LocalDateTime saleStartAt, LocalDateTime saleEndAt,
-        Integer price, Integer totalQuantity, Integer maxQuantity, EventCategory category) {
-
-        validateConstraints(price, totalQuantity, saleStartAt, saleEndAt, eventDateTime);
-
-        this.sellerId = sellerId;
-        this.title = title;
-        this.description = description;
-        this.location = location;
-        this.eventDateTime = eventDateTime;
-        this.saleStartAt = saleStartAt;
-        this.saleEndAt = saleEndAt;
-        this.price = price;
-        this.totalQuantity = totalQuantity;
-        this.maxQuantity = maxQuantity;
-        this.remainingQuantity = totalQuantity;
-        this.status = EventStatus.ON_SALE;
-        this.category = category;
-    }
-
-    private void validateConstraints(Integer price, Integer totalQuantity,
-        LocalDateTime saleStartAt, LocalDateTime saleEndAt,
-        LocalDateTime eventDateTime) {
-        if (price < 0 || price > 9999999) {
-            throw new BusinessException(EventErrorCode.INVALID_PRICE); // EVENT_003
-        }
-        if (totalQuantity < 5 || totalQuantity > 9999) {
-            throw new BusinessException(EventErrorCode.INVALID_QUANTITY); // EVENT_004
-        }
-        if (saleStartAt.isAfter(saleEndAt) || saleEndAt.isAfter(eventDateTime)) {
-            throw new BusinessException(EventErrorCode.INVALID_EVENT_DATES);
-        }
-    }
 }

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
@@ -1,0 +1,10 @@
+package com.devticket.event.infrastructure.persistence;
+
+import com.devticket.event.domain.model.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventRepository extends JpaRepository<Event, Long> {
+    // 기본적인 save(), findById() 등은 JpaRepository가 기본 제공합니다.
+}

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
@@ -1,0 +1,33 @@
+package com.devticket.event.presentation.controller;
+
+import com.devticket.event.application.EventService;
+import com.devticket.event.presentation.dto.SellerEventCreateRequest;
+import com.devticket.event.presentation.dto.SellerEventCreateResponse;
+import com.devticket.support.response.SuccessResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/events")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final EventService eventService;
+
+    // 인증 필수 API이므로 required = true (기본값)
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SuccessResponse<SellerEventCreateResponse> createEvent(
+        @RequestHeader("X-User-Id") Long sellerId, // 내부 식별자는 Long 유지
+        @Valid @RequestBody SellerEventCreateRequest request) {
+
+        // Service가 반환하는 외부용 식별자 UUID를 받음!
+        UUID eventId = eventService.createEvent(sellerId, request);
+
+        // UUID를 Response DTO에 담아서 반환
+        return SuccessResponse.created(SellerEventCreateResponse.from(eventId));
+    }
+}

--- a/event/src/main/java/com/devticket/event/presentation/dto/SellerEventCreateRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/SellerEventCreateRequest.java
@@ -1,0 +1,52 @@
+package com.devticket.event.presentation.dto;
+
+import com.devticket.event.domain.model.EventCategory;
+import jakarta.validation.constraints.*;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record SellerEventCreateRequest(
+    @NotBlank(message = "이벤트 제목은 필수입니다.")
+    @Size(min = 2, max = 50, message = "이벤트 제목은 2자 이상 50자 이하여야 합니다.")
+    String title,
+
+    @NotBlank(message = "상세 설명은 필수입니다.")
+    String description,
+
+    @NotBlank(message = "장소는 필수입니다.")
+    String location,
+
+    @NotNull(message = "행사 일시는 필수입니다.")
+    LocalDateTime eventDateTime,
+
+    @NotNull(message = "판매 시작 시각은 필수입니다.")
+    LocalDateTime saleStartAt,
+
+    @NotNull(message = "판매 종료 시각은 필수입니다.")
+    LocalDateTime saleEndAt,
+
+    @NotNull(message = "가격은 필수입니다.")
+    @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+    @Max(value = 9999999, message = "가격은 9,999,999원 이하여야 합니다.")
+    Integer price,
+
+    @NotNull(message = "총 수량은 필수입니다.")
+    @Min(value = 5, message = "총 수량은 5명 이상이어야 합니다.")
+    @Max(value = 9999, message = "총 수량은 9,999명 이하여야 합니다.")
+    Integer totalQuantity,
+
+    @NotNull(message = "인당 최대 구매 수량은 필수입니다.")
+    @Min(value = 1, message = "인당 최대 구매 수량은 1 이상이어야 합니다.")
+    Integer maxQuantity,
+
+    @NotNull(message = "카테고리는 필수입니다.")
+    EventCategory category,
+
+    @NotNull(message = "기술 스택은 1개 이상 선택해야 합니다.")
+    @Size(min = 1, max = 5, message = "기술 스택은 1개에서 5개까지 선택 가능합니다.")
+    List<UUID> techStackIds,
+
+    @Size(max = 2, message = "이미지는 최대 2장까지 업로드 가능합니다.")
+    List<String> imageUrls
+) {}

--- a/event/src/main/java/com/devticket/event/presentation/dto/SellerEventCreateResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/SellerEventCreateResponse.java
@@ -1,0 +1,11 @@
+package com.devticket.event.presentation.dto;
+
+import java.util.UUID;
+
+public record SellerEventCreateResponse(
+    UUID eventId
+) {
+    public static SellerEventCreateResponse from(UUID eventId) {
+        return new SellerEventCreateResponse(eventId);
+    }
+}

--- a/event/src/main/java/com/devticket/support/response/SuccessResponse.java
+++ b/event/src/main/java/com/devticket/support/response/SuccessResponse.java
@@ -1,0 +1,26 @@
+package com.devticket.support.response;
+
+import lombok.Getter;
+
+@Getter
+public class SuccessResponse<T> {
+    private final int status;
+    private final String message;
+    private final T data;
+
+    private SuccessResponse(int status, String message, T data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    // 일반적인 200 OK 응답
+    public static <T> SuccessResponse<T> success(T data) {
+        return new SuccessResponse<>(200, "성공", data);
+    }
+
+    // 201 Created 응답 (생성 시 사용)
+    public static <T> SuccessResponse<T> created(T data) {
+        return new SuccessResponse<>(201, "생성 성공", data);
+    }
+}

--- a/event/src/main/resources/application-test.yml
+++ b/event/src/main/resources/application-test.yml
@@ -1,5 +1,18 @@
+#spring:
+#  autoconfigure:
+#    exclude:
+#      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+#      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+
 spring:
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+  datasource:
+    # H2 메모리 DB를 사용하되, PostgreSQL 모드로 동작하도록 설정
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop # 테스트 시작 시 테이블 생성, 종료 시 삭제
+    show-sql: true

--- a/event/src/test/java/com/devticket/event/EventApplicationTests.java
+++ b/event/src/test/java/com/devticket/event/EventApplicationTests.java
@@ -2,8 +2,10 @@ package com.devticket.event;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class EventApplicationTests {
 
 	@Test


### PR DESCRIPTION
## 작업 내용
- **판매자 이벤트 등록 API 구현 (`POST /api/v1/events`)**
  - 판매 시작일, 종료일, 행사일 선후 관계 검증 로직 추가
  - 행사 등록 마감 기한(판매 시작일 기준 3일 전) 예외 처리 적용
  - 인당 최대 구매 수량 및 총 수량 정합성 검증
- **ERD v3 설계 원칙 전면 적용**
  - 공통 Audit 필드(`created_at`, `updated_at`) 및 Soft Delete(`deleted_at`) 처리를 위한 `BaseEntity` 구현
  - `Event` 엔티티 최적화를 위해 내부 PK를 `Long`으로 변경하고, 외부 노출용 `eventId(UUID)` 컬럼 분리 적용
  - `@SQLRestriction`을 활용한 Soft Delete 조회 필터링 적용
- **테스트 환경 구축**
  - CI 및 로컬 테스트를 위한 H2 인메모리 DB 환경 세팅 (`application-test.yml`)

## 변경 사항
- `domain/common/BaseEntity.java` : JPA Auditing 및 Soft Delete 공통 속성 클래스 신규 추가
- `domain/Event.java` : 식별자 분리(Long/UUID), `BaseEntity` 상속 및 `@SQLRestriction` 적용
- `presentation/controller/dto/SellerEventCreate*.java` : 외부 통신용 식별자 타입을 `UUID`로 변경 및 `@Valid` 제약 조건 추가
- `application/EventService.java` : 이벤트 생성 비즈니스 로직, 예외 처리 및 UUID 생성 로직 구현
- `presentation/controller/EventController.java` : Gateway 인증 헤더(`X-User-Id`) 연동 및 엔드포인트 매핑
- `build.gradle`, `application-test.yml` : H2 의존성 및 테스트 전용 프로필 설정 추가

## 테스트
- [x] 단위 테스트 통과 (비즈니스 정책 검증 및 예외 발생 테스트 완료)
- [x] 통합 테스트 통과 (해당 시 - H2 DB 기반 컨텍스트 로드 및 로컬 Swagger 테스트 완료)

## 관련 문서
- Resolves: #69
- 참고 문서: ERD v3.md (BaseEntity, UUID, Soft Delete 정책 반영 완료)
- API 명세서: 이벤트 생성 POST API 연동