### PR TITLE
[Event] refactor: 패키지 구조 변경

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -1,9 +1,9 @@
 package com.devticket.event.application;
 
-import com.devticket.event.domain.exception.BusinessException;
+import com.devticket.event.common.exception.BusinessException;
 import com.devticket.event.domain.exception.EventErrorCode;
 import com.devticket.event.domain.model.Event;
-import com.devticket.event.domain.model.EventStatus;
+import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.infrastructure.persistence.EventRepository;
 import com.devticket.event.presentation.dto.SellerEventCreateRequest;
 import lombok.RequiredArgsConstructor;

--- a/event/src/main/java/com/devticket/event/common/config/JpaAuditingConfig.java
+++ b/event/src/main/java/com/devticket/event/common/config/JpaAuditingConfig.java
@@ -1,4 +1,4 @@
-package com.devticket.event.infrastructure.config;
+package com.devticket.event.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/event/src/main/java/com/devticket/event/common/config/OpenApiConfig.java
+++ b/event/src/main/java/com/devticket/event/common/config/OpenApiConfig.java
@@ -1,4 +1,4 @@
-package com.devticket.event.infrastructure.config;
+package com.devticket.event.common.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;

--- a/event/src/main/java/com/devticket/event/common/entity/BaseEntity.java
+++ b/event/src/main/java/com/devticket/event/common/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.devticket.event.domain.common;
+package com.devticket.event.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/event/src/main/java/com/devticket/event/common/exception/BusinessException.java
+++ b/event/src/main/java/com/devticket/event/common/exception/BusinessException.java
@@ -1,4 +1,4 @@
-package com.devticket.event.domain.exception;
+package com.devticket.event.common.exception;
 
 import lombok.Getter;
 

--- a/event/src/main/java/com/devticket/event/common/exception/ErrorCode.java
+++ b/event/src/main/java/com/devticket/event/common/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.devticket.event.domain.exception;
+package com.devticket.event.common.exception;
 
 public interface ErrorCode {
     int getStatus();

--- a/event/src/main/java/com/devticket/event/common/exception/ErrorResponse.java
+++ b/event/src/main/java/com/devticket/event/common/exception/ErrorResponse.java
@@ -1,6 +1,5 @@
-package com.devticket.event.presentation.dto;
+package com.devticket.event.common.exception;
 
-import com.devticket.event.domain.exception.ErrorCode;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/event/src/main/java/com/devticket/event/common/exception/GlobalExceptionHandler.java
+++ b/event/src/main/java/com/devticket/event/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
-package com.devticket.event.domain.exception;
+package com.devticket.event.common.exception;
 
-import com.devticket.event.presentation.dto.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/event/src/main/java/com/devticket/event/common/response/SuccessResponse.java
+++ b/event/src/main/java/com/devticket/event/common/response/SuccessResponse.java
@@ -1,4 +1,4 @@
-package com.devticket.support.response;
+package com.devticket.event.common.response;
 
 import lombok.Getter;
 

--- a/event/src/main/java/com/devticket/event/domain/enums/EventCategory.java
+++ b/event/src/main/java/com/devticket/event/domain/enums/EventCategory.java
@@ -1,4 +1,4 @@
-package com.devticket.event.domain.model;
+package com.devticket.event.domain.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/event/src/main/java/com/devticket/event/domain/enums/EventStatus.java
+++ b/event/src/main/java/com/devticket/event/domain/enums/EventStatus.java
@@ -1,4 +1,4 @@
-package com.devticket.event.domain.model;
+package com.devticket.event.domain.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/event/src/main/java/com/devticket/event/domain/exception/EventErrorCode.java
+++ b/event/src/main/java/com/devticket/event/domain/exception/EventErrorCode.java
@@ -1,11 +1,12 @@
 package com.devticket.event.domain.exception;
 
+import com.devticket.event.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum EventErrorCode implements ErrorCode{
+public enum EventErrorCode implements ErrorCode {
 
     EVENT_NOT_FOUND(404, "EVENT_001", "존재하지 않는 이벤트입니다."),
     INVALID_PRICE(400, "EVENT_003", "이벤트 가격은 0원 이상 9,999,999원 이하여야 합니다."),

--- a/event/src/main/java/com/devticket/event/domain/model/Event.java
+++ b/event/src/main/java/com/devticket/event/domain/model/Event.java
@@ -1,6 +1,8 @@
 package com.devticket.event.domain.model;
 
-import com.devticket.event.domain.common.BaseEntity;
+import com.devticket.event.common.entity.BaseEntity;
+import com.devticket.event.domain.enums.EventCategory;
+import com.devticket.event.domain.enums.EventStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
@@ -3,7 +3,7 @@ package com.devticket.event.presentation.controller;
 import com.devticket.event.application.EventService;
 import com.devticket.event.presentation.dto.SellerEventCreateRequest;
 import com.devticket.event.presentation.dto.SellerEventCreateResponse;
-import com.devticket.support.response.SuccessResponse;
+import com.devticket.event.common.response.SuccessResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/event/src/main/java/com/devticket/event/presentation/dto/SellerEventCreateRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/SellerEventCreateRequest.java
@@ -1,6 +1,6 @@
 package com.devticket.event.presentation.dto;
 
-import com.devticket.event.domain.model.EventCategory;
+import com.devticket.event.domain.enums.EventCategory;
 import jakarta.validation.constraints.*;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/event/src/test/java/com/devticket/event/application/EventServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.devticket.event.domain.exception.BusinessException;
+import com.devticket.event.common.exception.BusinessException;
 import com.devticket.event.domain.exception.EventErrorCode;
 import com.devticket.event.domain.model.Event;
 import com.devticket.event.fixture.EventTestFixture;

--- a/event/src/test/java/com/devticket/event/fixture/EventTestFixture.java
+++ b/event/src/test/java/com/devticket/event/fixture/EventTestFixture.java
@@ -1,6 +1,6 @@
 package com.devticket.event.fixture;
 
-import com.devticket.event.domain.model.EventCategory;
+import com.devticket.event.domain.enums.EventCategory;
 import com.devticket.event.presentation.dto.SellerEventCreateRequest;
 
 import java.time.LocalDateTime;


### PR DESCRIPTION
## 💡 작업 목적
- 패키지 컨벤션과 일치시키기 위해 `event` 도메인의 패키지 구조를 전면 리팩토링했습니다.
- 특정 도메인에 종속되지 않는 전역 설정, 공통 예외 처리, 공통 응답 객체 등을 `common` 패키지로 분리하여 프로젝트의 가독성과 응집도를 높였습니다.

## 🛠️ 작업 내용
**1. `common` 패키지 신설 및 공통 클래스 이동**
- `config`: `infrastructure/config` ➡️ `common/config` (`JpaAuditingConfig`, `OpenApiConfig`)
- `entity`: `domain/common/BaseEntity` ➡️ `common/entity/BaseEntity`
- `exception`: 전역 예외 처리 및 공통 에러 응답 객체 통합
  - `domain/exception` ➡️ `common/exception` (`BusinessException`, `ErrorCode`, `GlobalExceptionHandler`)
  - `presentation/dto/ErrorResponse` ➡️ `common/exception/ErrorResponse`
- `response`: `support/response/SuccessResponse` ➡️ `common/response/SuccessResponse`

**2. `domain` 패키지 내부 응집도 개선**
- `enums`: 열거형(Enum) 클래스 분리 (`EventCategory`, `EventStatus`)
- 도메인 특화 예외인 `EventErrorCode`는 기존 `domain/exception` 하위에 유지하여 비즈니스 로직과의 응집도 유지

**3. 패키지 이동에 따른 Import 경로 수정 및 정상 동작 확인**

## ✅ 테스트
- [x] 패키지 이동 후 빌드 정상 통과 (`./gradlew build`)
- [x] 기존 작성된 유닛 테스트(`EventServiceTest`, `EventControllerTest`) 정상 통과 확인 (import 꼬임 없음)

## 📎 관련 문서
- Resolves: #93 