### PR TITLE
[Member] feat: 도메인 엔티티 및 Repository 정의

### DIFF
--- a/member/src/main/java/com/devticket/member/presentation/domain/model/RefreshToken.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/model/RefreshToken.java
@@ -1,0 +1,51 @@
+package com.devticket.member.presentation.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "refresh_token", schema = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "refresh_token_id", unique = true, nullable = false, updatable = false)
+    private UUID refreshTokenId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public RefreshToken(Long userId, String token, LocalDateTime expiresAt) {
+        this.refreshTokenId = UUID.randomUUID();
+        this.userId = userId;
+        this.token = token;
+        this.expiresAt = expiresAt;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiresAt);
+    }
+}

--- a/member/src/main/java/com/devticket/member/presentation/domain/model/SellerApplication.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/model/SellerApplication.java
@@ -1,0 +1,73 @@
+package com.devticket.member.presentation.domain.model;
+
+import com.devticket.member.presentation.domain.SellerApplicationStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "seller_application", schema = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SellerApplication {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "seller_application_id", unique = true, nullable = false, updatable = false)
+    private UUID sellerApplicationId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "bank_name", nullable = false, length = 100)
+    private String bankName;
+
+    @Column(name = "account_number", nullable = false, length = 100)
+    private String accountNumber;
+
+    @Column(name = "account_holder", nullable = false, length = 100)
+    private String accountHolder;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SellerApplicationStatus status;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public SellerApplication(Long userId, String bankName,
+        String accountNumber, String accountHolder) {
+        this.sellerApplicationId = UUID.randomUUID();
+        this.userId = userId;
+        this.bankName = bankName;
+        this.accountNumber = accountNumber;
+        this.accountHolder = accountHolder;
+        this.status = SellerApplicationStatus.PENDING;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void approve() {
+        this.status = SellerApplicationStatus.APPROVED;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void reject() {
+        this.status = SellerApplicationStatus.REJECTED;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/member/src/main/java/com/devticket/member/presentation/domain/model/TechStack.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/model/TechStack.java
@@ -1,0 +1,36 @@
+package com.devticket.member.presentation.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tech_stack", schema = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TechStack {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "tech_stack_id", unique = true, nullable = false, updatable = false)
+    private UUID techStackId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/member/src/main/java/com/devticket/member/presentation/domain/model/User.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/model/User.java
@@ -1,0 +1,114 @@
+package com.devticket.member.presentation.domain.model;
+
+import com.devticket.member.common.exception.BusinessException;
+import com.devticket.member.presentation.domain.MemberErrorCode;
+import com.devticket.member.presentation.domain.ProviderType;
+import com.devticket.member.presentation.domain.UserRole;
+import com.devticket.member.presentation.domain.UserStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "\"user\"", schema = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", unique = true, nullable = false, updatable = false)
+    private UUID userId;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider_type", nullable = false)
+    private ProviderType providerType;
+
+    @Column(name = "provider_id")
+    private String providerId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "withdrawn_at")
+    private LocalDateTime withdrawnAt;
+
+    // 일반 가입
+    public User(String email, String password) {
+        this.userId = UUID.randomUUID();
+        this.email = email;
+        this.password = password;
+        this.role = UserRole.USER;
+        this.status = UserStatus.ACTIVE;
+        this.providerType = ProviderType.LOCAL;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // 소셜 가입
+    public User(String email, ProviderType providerType, String providerId) {
+        this.userId = UUID.randomUUID();
+        this.email = email;
+        this.password = null;
+        this.role = UserRole.USER;
+        this.status = UserStatus.ACTIVE;
+        this.providerType = providerType;
+        this.providerId = providerId;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void suspend() {
+        if (this.status == UserStatus.WITHDRAWN) {
+            throw new BusinessException(MemberErrorCode.ACCOUNT_WITHDRAWN);
+        }
+        this.status = UserStatus.SUSPENDED;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void withdraw() {
+        this.status = UserStatus.WITHDRAWN;
+        this.withdrawnAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void changePassword(String newPassword) {
+        this.password = newPassword;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void changeRole(UserRole newRole) {
+        this.role = newRole;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public boolean isActive() {
+        return this.status == UserStatus.ACTIVE;
+    }
+}

--- a/member/src/main/java/com/devticket/member/presentation/domain/model/UserProfile.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/model/UserProfile.java
@@ -1,0 +1,71 @@
+package com.devticket.member.presentation.domain.model;
+
+import com.devticket.member.presentation.domain.Position;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_profile", schema = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_profile_id", unique = true, nullable = false, updatable = false)
+    private UUID userProfileId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, unique = true, length = 12)
+    private String nickname;
+
+    @Column(name = "profile_img_url")
+    private String profileImgUrl;
+
+    @Enumerated(EnumType.STRING)
+    private Position position;
+
+    @Column(columnDefinition = "TEXT")
+    private String bio;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public UserProfile(Long userId, String nickname, Position position,
+        String profileImgUrl, String bio) {
+        this.userProfileId = UUID.randomUUID();
+        this.userId = userId;
+        this.nickname = nickname;
+        this.position = position;
+        this.profileImgUrl = profileImgUrl;
+        this.bio = bio;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void update(String nickname, Position position,
+        String profileImgUrl, String bio) {
+        this.nickname = nickname;
+        this.position = position;
+        this.profileImgUrl = profileImgUrl;
+        this.bio = bio;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/member/src/main/java/com/devticket/member/presentation/domain/model/UserTechStack.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/model/UserTechStack.java
@@ -1,0 +1,39 @@
+package com.devticket.member.presentation.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_tech_stack", schema = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserTechStack {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "tech_stack_id", nullable = false)
+    private Long techStackId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public UserTechStack(Long userId, Long techStackId) {
+        this.userId = userId;
+        this.techStackId = techStackId;
+        this.createdAt = LocalDateTime.now();
+    }
+}
+

--- a/member/src/main/java/com/devticket/member/presentation/domain/repository/RefreshTokenRepository.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,22 @@
+package com.devticket.member.presentation.domain.repository;
+
+import com.devticket.member.presentation.domain.model.RefreshToken;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByToken(String token);
+
+    void deleteAllByUserId(Long userId);
+
+    @Modifying
+    @Query("DELETE FROM RefreshToken r WHERE r.expiresAt < :now")
+    void deleteAllExpired(@Param("now") LocalDateTime now);
+}

--- a/member/src/main/java/com/devticket/member/presentation/domain/repository/SellerApplicationRepository.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/repository/SellerApplicationRepository.java
@@ -1,0 +1,16 @@
+package com.devticket.member.presentation.domain.repository;
+
+import com.devticket.member.presentation.domain.SellerApplicationStatus;
+import com.devticket.member.presentation.domain.model.SellerApplication;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SellerApplicationRepository extends JpaRepository<SellerApplication, Long> {
+
+    Optional<SellerApplication> findByUserId(Long userId);
+
+    Optional<SellerApplication> findBySellerApplicationId(UUID sellerApplicationId);
+
+    boolean existsByUserIdAndStatus(Long userId, SellerApplicationStatus status);
+}

--- a/member/src/main/java/com/devticket/member/presentation/domain/repository/TechStackRepository.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/repository/TechStackRepository.java
@@ -1,0 +1,11 @@
+package com.devticket.member.presentation.domain.repository;
+
+import com.devticket.member.presentation.domain.model.TechStack;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TechStackRepository extends JpaRepository<TechStack, Long> {
+
+    List<TechStack> findByIdIn(List<Long> ids);
+}
+

--- a/member/src/main/java/com/devticket/member/presentation/domain/repository/UserProfileRepository.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/repository/UserProfileRepository.java
@@ -1,0 +1,12 @@
+package com.devticket.member.presentation.domain.repository;
+
+import com.devticket.member.presentation.domain.model.UserProfile;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+
+    Optional<UserProfile> findByUserId(Long userId);
+
+    boolean existsByNickname(String nickname);
+}

--- a/member/src/main/java/com/devticket/member/presentation/domain/repository/UserRepository.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package com.devticket.member.presentation.domain.repository;
+
+import com.devticket.member.presentation.domain.model.User;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByUserId(UUID userId);
+
+    boolean existsByEmail(String email);
+}
+

--- a/member/src/main/java/com/devticket/member/presentation/domain/repository/UserTechStackRepository.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/repository/UserTechStackRepository.java
@@ -1,0 +1,12 @@
+package com.devticket.member.presentation.domain.repository;
+
+import com.devticket.member.presentation.domain.model.UserTechStack;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTechStackRepository extends JpaRepository<UserTechStack, Long> {
+
+    List<UserTechStack> findByUserId(Long userId);
+
+    void deleteByUserId(Long userId);
+}


### PR DESCRIPTION
## 관련 이슈
- close #90 

## 작업 내용
- Member 도메인 JPA 엔티티 6종 생성 (도메인 비즈니스 로직 포함)
- Spring Data JPA Repository 6종 정의
- 전체 엔티티에 `schema = "member"` 적용하여 다른 모듈과 스키마 격리

## 변경 사항
- `com.devticket.member.domain` — User, UserProfile, UserTechStack, TechStack, RefreshToken, SellerApplication
- `com.devticket.member.repository` — UserRepository, UserProfileRepository, UserTechStackRepository, TechStackRepository, RefreshTokenRepository, SellerApplicationRepository

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 참고 사항
- `user` 테이블은 PostgreSQL 예약어이므로 `@Table(name = "\"user\"", schema = "member")` 사용
- PK는 Long AUTO_INCREMENT, 외부 노출용 UUID 별도 컬럼
- UserTechStack은 복합 키 대신 단독 Long PK 사용 (개발 편의성)
- TechStack은 마스터 데이터로 비즈니스 메서드 없음
- `@Setter` 미사용 — 상태 변경은 도메인 메서드를 통해서만 처리