### PR TITLE
[Event] test: 이벤트 상세 조회 API 단위 테스트 작성

### DIFF
--- a/event/src/test/java/com/devticket/event/application/EventServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventServiceTest.java
@@ -11,8 +11,10 @@ import com.devticket.event.domain.exception.EventErrorCode;
 import com.devticket.event.domain.model.Event;
 import com.devticket.event.fixture.EventTestFixture;
 import com.devticket.event.infrastructure.persistence.EventRepository;
+import com.devticket.event.presentation.dto.EventDetailResponse;
 import com.devticket.event.presentation.dto.SellerEventCreateRequest;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +30,8 @@ class EventServiceTest {
 
     @InjectMocks
     private EventService eventService;
+
+    // 이벤트 생성 테스트
 
     @Test
     void 정상적인_조건일_경우_이벤트가_성공적으로_생성되고_UUID를_반환한다() {
@@ -98,5 +102,38 @@ class EventServiceTest {
         assertThatThrownBy(() -> eventService.createEvent(sellerId, request))
             .isInstanceOf(BusinessException.class)
             .hasMessageContaining(EventErrorCode.INVALID_EVENT_DATE.getMessage());
+    }
+
+    // 이벤트 상세 조회 테스트
+
+    @Test
+    void 존재하는_이벤트_조회시_상세정보를_반환한다() {
+        // given
+        Long sellerId = 1L;
+
+        Event event = EventTestFixture.createEvent(sellerId);
+        UUID eventId = event.getEventId();
+
+        when(eventRepository.findByEventId(eventId)).thenReturn(Optional.of(event));
+
+        // when
+        EventDetailResponse response = eventService.getEvent(eventId);
+
+        // then
+        assertThat(response.eventId()).isEqualTo(eventId);
+        assertThat(response.title()).isEqualTo("상세 조회 테스트 밋업");
+        verify(eventRepository).findByEventId(eventId);
+    }
+
+    @Test
+    void 존재하지_않는_이벤트_조회시_예외가_발생한다() {
+        // given
+        UUID invalidEventId = UUID.randomUUID(); // 아무 UUID나 생성
+        when(eventRepository.findByEventId(invalidEventId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> eventService.getEvent(invalidEventId))
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(EventErrorCode.EVENT_NOT_FOUND.getMessage());
     }
 }

--- a/event/src/test/java/com/devticket/event/fixture/EventTestFixture.java
+++ b/event/src/test/java/com/devticket/event/fixture/EventTestFixture.java
@@ -1,6 +1,8 @@
 package com.devticket.event.fixture;
 
 import com.devticket.event.domain.enums.EventCategory;
+import com.devticket.event.domain.model.Event;
+import com.devticket.event.presentation.dto.EventDetailResponse;
 import com.devticket.event.presentation.dto.SellerEventCreateRequest;
 
 import java.time.LocalDateTime;
@@ -19,6 +21,22 @@ public class EventTestFixture {
             50000, totalQty, maxQty, EventCategory.MEETUP,
             List.of(UUID.randomUUID(), UUID.randomUUID()),
             List.of("url1")
+        );
+    }
+
+    public static Event createEvent(Long sellerId) {
+        return Event.create(
+            sellerId, "상세 조회 테스트 밋업", "설명", "강남역",
+            LocalDateTime.now().plusDays(15), LocalDateTime.now().plusDays(4), LocalDateTime.now().plusDays(10),
+            50000, 100, 4, EventCategory.MEETUP
+        );
+    }
+
+    public static EventDetailResponse createEventDetailResponse(UUID eventId) {
+        return new EventDetailResponse(
+            eventId, "상세 조회 테스트 밋업", "설명", "강남역",
+            LocalDateTime.now().plusDays(15), LocalDateTime.now().plusDays(4), LocalDateTime.now().plusDays(10),
+            50000, 100, 4, EventCategory.MEETUP
         );
     }
 }

--- a/event/src/test/java/com/devticket/event/presentation/controller/EventControllerTest.java
+++ b/event/src/test/java/com/devticket/event/presentation/controller/EventControllerTest.java
@@ -3,6 +3,7 @@ package com.devticket.event.presentation.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -10,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.devticket.event.application.EventService;
 import com.devticket.event.fixture.EventTestFixture;
+import com.devticket.event.presentation.dto.EventDetailResponse;
 import com.devticket.event.presentation.dto.SellerEventCreateRequest;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -32,6 +34,8 @@ class EventControllerTest {
 
     @MockitoBean
     private EventService eventService;
+
+    // 이벤트 생성 테스트
 
     @Test
     void 정상적인_요청시_201_응답과_UUID를_반환한다() throws Exception {
@@ -91,5 +95,24 @@ class EventControllerTest {
                 .content(objectMapper.writeValueAsString(badRequest)))
             .andDo(print())
             .andExpect(status().isBadRequest()); // @Valid 에 의한 400 반환 확인
+    }
+
+    // 이벤트 상세 조회 테스트
+
+    @Test
+    void 이벤트_상세조회_성공시_200_응답을_반환한다() throws Exception {
+        // given
+        UUID eventId = UUID.randomUUID();
+        EventDetailResponse mockResponse = EventTestFixture.createEventDetailResponse(eventId);
+
+        when(eventService.getEvent(eventId)).thenReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/events/{eventId}", eventId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk()) // 200 OK 검증
+            .andExpect(jsonPath("$.data.eventId").value(eventId.toString()))
+            .andExpect(jsonPath("$.data.title").value("상세 조회 테스트 밋업"));
     }
 }


### PR DESCRIPTION
## 서비스
- [ ] Gateway
- [ ] Member
- [x] Event
- [ ] Commerce
- [ ] Payment
- [ ] Settlement
- [ ] Log
- [ ] Admin

## 기능 설명
구현이 완료된 '이벤트 상세 조회 API (`GET /api/v1/events/{eventId}`)'의 안정성을 검증하기 위한 단위 테스트(Unit Test)를 추가했습니다.
또한, 테스트 코드의 가독성을 높이고 중복 코드를 제거하기 위해 테스트 픽스처(Test Fixture) 패턴을 도입했습니다.

## 작업 내용
- [x] **테스트 픽스처(`EventTestFixture`) 확장**
  - 상세 조회 테스트에서 반복적으로 사용되는 `Event` 엔티티와 `EventDetailResponse` 응답 객체의 가짜(Mock) 데이터를 생성하는 정적 팩토리 메서드 추가
- [x] **비즈니스 로직 테스트 (`EventServiceTest`)**
  - [정상] 존재하는 `eventId` 조회 시, 정확한 이벤트 상세 정보(`EventDetailResponse`)를 반환하는지 검증
  - [예외] 존재하지 않는 `eventId` 조회 시, `EVENT_NOT_FOUND` 비즈니스 예외가 정상적으로 발생하는지 검증
- [x] **웹 계층 테스트 (`EventControllerTest`)**
  - [정상] API 요청 시 HTTP 상태 코드 `200 OK`와 함께 공통 응답 포맷(`SuccessResponse`)으로 데이터를 반환하는지 검증 (`jsonPath` 활용)

## API 엔드포인트
- 테스트 대상: `GET /api/v1/events/{eventId}`
