### PR TITLE
feat(settlement): 전역 예외 처리 구조 추가 및 서비스 예외 적용

### DIFF
--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
@@ -1,5 +1,8 @@
 package com.devticket.settlement.application.service;
 
+import com.devticket.settlement.common.exception.BusinessException;
+import com.devticket.settlement.common.exception.CommonErrorCode;
+import com.devticket.settlement.domain.exception.SettlementErrorCode;
 import com.devticket.settlement.domain.model.Settlement;
 import com.devticket.settlement.domain.model.SettlementItem;
 import com.devticket.settlement.domain.repository.SettlementItemRepository;
@@ -10,10 +13,8 @@ import com.devticket.settlement.presentation.dto.SettlementResponse;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
@@ -26,16 +27,21 @@ public class SettlementServiceImpl implements SettlementService {
     // 정산 내역 목록 조회
     @Override
     public List<SettlementResponse> getSellerSettlements(Long sellerId) {
+        List<Settlement> settlements = settlementRepository.findBySellerId(sellerId);
+        if (settlements.isEmpty()) {
+            throw new BusinessException(SettlementErrorCode.SETTLEMENT_NOT_FOUND);
+        }
         return settlementRepository.findBySellerId(sellerId).stream()
             .map(this::toResponse)
             .toList();
     }
 
+
     // 정산 내역 상세 조회
     @Override
     public SellerSettlementDetailResponse getSellerSettlementDetail(Long sellerId, UUID settlementId) {
         Settlement settlement = settlementRepository.findBySettlementId(settlementId)
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "정산 없음"));
+            .orElseThrow(() -> new BusinessException(SettlementErrorCode.SETTLEMENT_BAD_REQUEST));
 
         validateSellerAccess(sellerId, settlement);
 
@@ -43,14 +49,13 @@ public class SettlementServiceImpl implements SettlementService {
             settlement.getSettlementId());
 
         return toResponse(settlement, settlementItems);
-
     }
 
 
     //    사용자 인가 확인 메서드
     private void validateSellerAccess(Long sellerId, Settlement settlement) {
         if (!sellerId.equals(settlement.getSellerId())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "권한 없음");
+            throw new BusinessException(CommonErrorCode.ACCESS_DENIED);
         }
     }
 

--- a/settlement/src/main/java/com/devticket/settlement/common/exception/BusinessException.java
+++ b/settlement/src/main/java/com/devticket/settlement/common/exception/BusinessException.java
@@ -1,0 +1,16 @@
+package com.devticket.settlement.common.exception;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/settlement/src/main/java/com/devticket/settlement/common/exception/CommonErrorCode.java
+++ b/settlement/src/main/java/com/devticket/settlement/common/exception/CommonErrorCode.java
@@ -1,0 +1,21 @@
+package com.devticket.settlement.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+    INVALID_INPUT_VALUE(400, "COMMON_001", "입력값이 올바르지 않습니다."),
+    UNAUTHORIZED(401, "COMMON_002", "인증이 필요합니다."),
+    TOKEN_EXPIRED(401, "COMMON_003", "토큰이 만료되었습니다."),
+    INVALID_TOKEN(401, "COMMON_004", "유효하지 않은 토큰입니다."),
+    ACCESS_DENIED(403, "COMMON_005", "접근 권한이 없습니다."),
+    INTERNAL_SERVER_ERROR(500, "COMMON_006", "서버 내부 오류가 발생했습니다."),
+    EXTERNAL_SERVICE_ERROR(502, "COMMON_007", "외부 서비스 연동에 실패했습니다."),
+    SERVICE_UNAVAILABLE(503, "COMMON_008", "서비스를 일시적으로 이용할 수 없습니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/settlement/src/main/java/com/devticket/settlement/common/exception/ErrorCode.java
+++ b/settlement/src/main/java/com/devticket/settlement/common/exception/ErrorCode.java
@@ -1,0 +1,10 @@
+package com.devticket.settlement.common.exception;
+
+public interface ErrorCode {
+
+    int getStatus();
+
+    String getCode();
+
+    String getMessage();
+}

--- a/settlement/src/main/java/com/devticket/settlement/common/exception/GlobalExceptionHandler.java
+++ b/settlement/src/main/java/com/devticket/settlement/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.devticket.settlement.common.exception;
+
+import com.devticket.settlement.common.exception.response.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 비즈니스 예외
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+            .status(e.getErrorCode().getStatus())
+            .body(ErrorResponse.from(errorCode));
+    }
+
+    // 유효성 검증 예외
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        return ResponseEntity
+            .badRequest()
+            .body(ErrorResponse.from(CommonErrorCode.INVALID_INPUT_VALUE));
+    }
+
+    // 알 수 없는 오류
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity
+            .internalServerError()
+            .body(ErrorResponse.from(CommonErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/settlement/src/main/java/com/devticket/settlement/common/exception/response/ErrorResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/common/exception/response/ErrorResponse.java
@@ -1,0 +1,22 @@
+package com.devticket.settlement.common.exception.response;
+
+import com.devticket.settlement.common.exception.ErrorCode;
+import java.time.LocalDateTime;
+
+public record ErrorResponse(
+    int status,
+    String code,
+    String message,
+    LocalDateTime timeStamp
+) {
+
+    public static ErrorResponse from(ErrorCode errorCode) {
+        return new ErrorResponse(
+            errorCode.getStatus(),
+            errorCode.getCode(),
+            errorCode.getMessage(),
+            LocalDateTime.now()
+        );
+    }
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/domain/exception/SettlementErrorCode.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/exception/SettlementErrorCode.java
@@ -1,0 +1,18 @@
+package com.devticket.settlement.domain.exception;
+
+import com.devticket.settlement.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SettlementErrorCode implements ErrorCode {
+    SETTLEMENT_NOT_FOUND(404, "SETTLEMENT_001", "정산 내역을 찾을 수 없습니다."),
+    SETTLEMENT_BAD_REQUEST(400, "SETTLEMENT_002", "정산 대상 이벤트가 없습니다."),
+    SETTLEMENT_MIN_AMMOUNT(400, "SETTLEMENT_003", "최소 정산 금액(10,000원) 미달입니다.");
+
+
+    private final int status;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
## 개요
전역 예외 처리 구조를 추가하고, 기존 서비스의 예외 처리를 통일된 방식으로 수정

## 변경 사항
- `settlement/common` 패키지 추가
- `ErrorResponse` record 추가 (공통 에러 응답 포맷)
- `ErrorCode` 인터페이스 추가
- `BusinessException` 추가 (ErrorCode를 감싸는 공통 예외 클래스)
- `CommonErrorCode` enum 추가 (공통 에러 코드)
- `GlobalExceptionHandler` 추가 (`@RestControllerAdvice` 전역 예외 처리)
- `SettlementErrorCode` enum 추가 (정산 도메인 에러 코드)
- `SettlementServiceImpl` 예외 처리 `ResponseStatusException` → `BusinessException`으로 수정

## 에러 응답 포맷
```json
{
  "status": 403,
  "code": "COMMON_005",
  "message": "접근 권한이 없습니다.",
  "timestamp": "2025-08-15T14:32:00"
}
```