### PR TITLE
feat(settlement) : BaseEntity 적용 및 그에 따른 entity 수정

### DIFF
--- a/settlement/src/main/java/com/devticket/settlement/common/entity/BaseEntity.java
+++ b/settlement/src/main/java/com/devticket/settlement/common/entity/BaseEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
@@ -17,7 +18,7 @@ public class BaseEntity {
     @Column(name = "create_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @CreatedDate
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 

--- a/settlement/src/main/java/com/devticket/settlement/domain/model/Settlement.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/model/Settlement.java
@@ -1,5 +1,6 @@
 package com.devticket.settlement.domain.model;
 
+import com.devticket.settlement.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "settlement")
-public class Settlement {
+public class Settlement extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementItem.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementItem.java
@@ -1,6 +1,7 @@
 package com.devticket.settlement.domain.model;
 
 
+import com.devticket.settlement.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -13,7 +14,7 @@ import lombok.Getter;
 @Getter
 @Entity
 @Table(name = "settlement_item")
-public class SettlementItem {
+public class SettlementItem extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 서비스
- [x] Settlement

## 기능 설명
공통 BaseEntity를 도입하고, 정산 관련 DTO를 수정합니다.

## 작업 내용
- [x] BaseEntity 생성 (createdAt, updatedAt 공통 관리)
- [x] Settlement 엔티티에 BaseEntity 적용
- [x] SettlementItem 엔티티에 BaseEntity 적용
- [ x] Getter 메서드 삭제 후 @Getter로 통일 

## API 엔드포인트
해당 없음

## 참고 문서
해당 없음