### PR TITLE
[Member] test: AuthService 단위 테스트 작성 + JWT profileCompleted 클레임 추가

### DIFF
--- a/member/src/main/java/com/devticket/member/infrastructure/jwt/JwtTokenProvider.java
+++ b/member/src/main/java/com/devticket/member/infrastructure/jwt/JwtTokenProvider.java
@@ -36,7 +36,7 @@ public class JwtTokenProvider {
         this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
     }
 
-    public String createAccessToken(Long userId, String email, UserRole role) {
+    public String createAccessToken(Long userId, String email, UserRole role, boolean profileCompleted) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + accessTokenTtl);
 
@@ -44,6 +44,7 @@ public class JwtTokenProvider {
             .subject(String.valueOf(userId))
             .claim("email", email)
             .claim("role", role.name())
+            .claim("profileCompleted", profileCompleted)
             .issuedAt(now)
             .expiration(expiry)
             .signWith(key)
@@ -64,6 +65,10 @@ public class JwtTokenProvider {
 
     public String getRole(String token) {
         return getClaims(token).get("role", String.class);
+    }
+
+    public Boolean getProfileCompleted(String token) {
+        return getClaims(token).get("profileCompleted", Boolean.class);
     }
 
     public boolean validateToken(String token) {


### PR DESCRIPTION
## 관련 이슈
- close #143 

## 작업 내용
- JwtTokenProvider에 `profileCompleted` 클레임 추가 (Gateway 프로필 미완성 차단 대비)

## 변경 사항
— createAccessToken에 profileCompleted 파라미터 추가, getProfileCompleted() 메서드 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 참고 사항
- JWT payload 변경: `profileCompleted` 클레임 추가됨 → Gateway 필터 이슈 별도 생성함
