### PR TITLE
fix(member) : teck_stack테이블의 uuid키 제거

### DIFF
--- a/member/src/main/java/com/devticket/member/application/UserService.java
+++ b/member/src/main/java/com/devticket/member/application/UserService.java
@@ -35,7 +35,7 @@ public class UserService {
 
     public ChangePasswordResponse changePassword(Long userId, ChangePasswordRequest request) {
         // TODO: Phase 4에서 구현
-        return new ChangePasswordResponse();
+        return new ChangePasswordResponse(false);
     }
 
     public WithdrawResponse withdraw(Long userId) {

--- a/member/src/main/java/com/devticket/member/presentation/domain/model/TechStack.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/model/TechStack.java
@@ -7,7 +7,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,10 +19,8 @@ public class TechStack {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
     @Column(name = "tech_stack_id", unique = true, nullable = false, updatable = false)
-    private UUID techStackId;
+    private Long id;
 
     @Column(nullable = false, length = 100)
     private String name;

--- a/member/src/main/java/com/devticket/member/presentation/dto/request/SignUpProfileRequest.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/request/SignUpProfileRequest.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.List;
-import java.util.UUID;
 
 public record SignUpProfileRequest(
     @NotBlank(message = "닉네임은 필수입니다.")
@@ -16,7 +15,7 @@ public record SignUpProfileRequest(
     @NotNull(message = "포지션은 필수입니다.")
     String position,
 
-    List<UUID> techStackIds,
+    List<Long> techStackIds,
 
     String profileImageUrl,
 

--- a/member/src/main/java/com/devticket/member/presentation/dto/request/UpdateProfileRequest.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/request/UpdateProfileRequest.java
@@ -3,7 +3,6 @@ package com.devticket.member.presentation.dto.request;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.List;
-import java.util.UUID;
 
 public record UpdateProfileRequest(
     @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이하여야 합니다.")
@@ -14,7 +13,7 @@ public record UpdateProfileRequest(
 
     String profileImageUrl,
 
-    List<UUID> techStackIds,
+    List<Long> techStackIds,
 
     String bio
 ) {

--- a/member/src/main/java/com/devticket/member/presentation/dto/response/GetProfileResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/response/GetProfileResponse.java
@@ -18,14 +18,14 @@ public record GetProfileResponse(
     String providerType
 ) {
 
-    public record TechStackInfo(UUID techStackId, String name) {
+    public record TechStackInfo(Long techStackId, String name) {
 
     }
 
     public static GetProfileResponse from(User user, UserProfile profile,
         List<TechStack> techStacks) {
         List<TechStackInfo> techStackInfos = techStacks.stream()
-            .map(ts -> new TechStackInfo(ts.getTechStackId(), ts.getName()))
+            .map(ts -> new TechStackInfo(ts.getId(), ts.getName()))
             .toList();
 
         return new GetProfileResponse(


### PR DESCRIPTION
## 관련 이슈
- close #170 

## 작업 내용
- `SignUpProfileRequest`, `UpdateProfileRequest`의 `techStackIds` 타입을 `List<UUID>` → `List<Long>`으로 변경
- `UserTechStack` 엔티티가 `Long techStackId`를 사용하므로 타입 통일

## 변경 사항
- `com.devticket.member.presentation.dto.user.SignUpProfileRequest` — `List<UUID>` → `List<Long>`
- `com.devticket.member.presentation.dto.user.UpdateProfileRequest` — `List<UUID>` → `List<Long>`
- 엔티티에서 uuid 컬럼 삭제

## 테스트
- [X] 단위 테스트 통과
- [X] Swagger 동작 확인