### PR TITLE
[Member] feat: UserService 구현 (프로필 CRUD/비밀번호 변경/회원 탈퇴)

### DIFF
--- a/member/src/main/java/com/devticket/member/application/UserService.java
+++ b/member/src/main/java/com/devticket/member/application/UserService.java
@@ -1,5 +1,18 @@
 package com.devticket.member.application;
 
+import com.devticket.member.common.exception.BusinessException;
+import com.devticket.member.presentation.domain.MemberErrorCode;
+import com.devticket.member.presentation.domain.Position;
+import com.devticket.member.presentation.domain.ProviderType;
+import com.devticket.member.presentation.domain.model.TechStack;
+import com.devticket.member.presentation.domain.model.User;
+import com.devticket.member.presentation.domain.model.UserProfile;
+import com.devticket.member.presentation.domain.model.UserTechStack;
+import com.devticket.member.presentation.domain.repository.RefreshTokenRepository;
+import com.devticket.member.presentation.domain.repository.TechStackRepository;
+import com.devticket.member.presentation.domain.repository.UserProfileRepository;
+import com.devticket.member.presentation.domain.repository.UserRepository;
+import com.devticket.member.presentation.domain.repository.UserTechStackRepository;
 import com.devticket.member.presentation.dto.request.ChangePasswordRequest;
 import com.devticket.member.presentation.dto.request.SignUpProfileRequest;
 import com.devticket.member.presentation.dto.request.UpdateProfileRequest;
@@ -8,38 +21,164 @@ import com.devticket.member.presentation.dto.response.GetProfileResponse;
 import com.devticket.member.presentation.dto.response.SignUpProfileResponse;
 import com.devticket.member.presentation.dto.response.UpdateProfileResponse;
 import com.devticket.member.presentation.dto.response.WithdrawResponse;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
 
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final UserTechStackRepository userTechStackRepository;
+    private final TechStackRepository techStackRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
     public SignUpProfileResponse createProfile(Long userId, SignUpProfileRequest request) {
-        // TODO: Phase 4에서 구현
-        return new SignUpProfileResponse(UUID.randomUUID());
+        User user = findUserByIdOrThrow(userId);
+        validateNicknameNotDuplicated(request.nickname());
+
+        UserProfile profile = new UserProfile(
+            user.getId(),
+            request.nickname(),
+            parsePosition(request.position()),
+            request.profileImageUrl(),
+            request.bio()
+        );
+        UserProfile savedProfile = userProfileRepository.save(profile);
+
+        saveTechStacks(user.getId(), request.techStackIds());
+
+        log.info("프로필 생성 완료: userId={}, nickname={}", userId, request.nickname());
+        return SignUpProfileResponse.from(savedProfile);
     }
 
     public GetProfileResponse getProfile(Long userId) {
-        // TODO: Phase 4에서 구현
-        return new GetProfileResponse(UUID.randomUUID(), "stub@example.com",
-            "stub", null, List.of(), null, null, "USER", "LOCAL");
+        User user = findUserByIdOrThrow(userId);
+        UserProfile profile = findProfileByUserIdOrThrow(userId);
+
+        List<UserTechStack> userTechStacks = userTechStackRepository.findByUserId(userId);
+        List<Long> techStackIds = userTechStacks.stream()
+            .map(UserTechStack::getTechStackId)
+            .toList();
+        List<TechStack> techStacks = techStackRepository.findByIdIn(techStackIds);
+
+        return GetProfileResponse.from(user, profile, techStacks);
     }
 
+    @Transactional
     public UpdateProfileResponse updateProfile(Long userId, UpdateProfileRequest request) {
-        // TODO: Phase 4에서 구현
-        return new UpdateProfileResponse(request.nickname(), request.position(),
-            request.profileImageUrl(), List.of());
+        findUserByIdOrThrow(userId);
+        UserProfile profile = findProfileByUserIdOrThrow(userId);
+
+        if (request.nickname() != null && !request.nickname().equals(profile.getNickname())) {
+            validateNicknameNotDuplicated(request.nickname());
+        }
+
+        profile.update(
+            request.nickname() != null ? request.nickname() : profile.getNickname(),
+            request.position() != null ? parsePosition(request.position()) : profile.getPosition(),
+            request.profileImageUrl() != null ? request.profileImageUrl() : profile.getProfileImgUrl(),
+            request.bio() != null ? request.bio() : profile.getBio()
+        );
+
+        userTechStackRepository.deleteByUserId(userId);
+        saveTechStacks(userId, request.techStackIds());
+
+        List<UserTechStack> updatedTechStacks = userTechStackRepository.findByUserId(userId);
+
+        log.info("프로필 수정 완료: userId={}", userId);
+        return UpdateProfileResponse.from(profile, updatedTechStacks);
     }
 
+    @Transactional
     public ChangePasswordResponse changePassword(Long userId, ChangePasswordRequest request) {
-        // TODO: Phase 4에서 구현
-        return new ChangePasswordResponse(false);
+        User user = findUserByIdOrThrow(userId);
+
+        validateLocalUser(user);
+        validateCurrentPassword(request.currentPassword(), user.getPassword());
+        validatePasswordConfirm(request.newPassword(), request.newPasswordConfirm());
+
+        String encodedPassword = passwordEncoder.encode(request.newPassword());
+        user.changePassword(encodedPassword);
+
+        log.info("비밀번호 변경 완료: userId={}", userId);
+        return new ChangePasswordResponse(true);
     }
 
+    @Transactional
     public WithdrawResponse withdraw(Long userId) {
-        // TODO: Phase 4에서 구현
-        return new WithdrawResponse(UUID.randomUUID(), "WITHDRAWN", LocalDateTime.now());
+        User user = findUserByIdOrThrow(userId);
+
+        user.withdraw();
+        refreshTokenRepository.deleteAllByUserId(userId);
+
+        log.info("회원 탈퇴 완료: userId={}", userId);
+        return WithdrawResponse.from(user);
+    }
+
+    // ========== 검증 ==========
+
+    private void validateNicknameNotDuplicated(String nickname) {
+        if (userProfileRepository.existsByNickname(nickname)) {
+            throw new BusinessException(MemberErrorCode.NICKNAME_DUPLICATED);
+        }
+    }
+
+    private void validateLocalUser(User user) {
+        if (user.getProviderType() != ProviderType.LOCAL) {
+            throw new BusinessException(MemberErrorCode.LOGIN_FAILED);
+        }
+    }
+
+    private void validateCurrentPassword(String rawPassword, String encodedPassword) {
+        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
+            throw new BusinessException(MemberErrorCode.PASSWORD_MISMATCH);
+        }
+    }
+
+    private void validatePasswordConfirm(String newPassword, String newPasswordConfirm) {
+        if (!newPassword.equals(newPasswordConfirm)) {
+            throw new BusinessException(MemberErrorCode.PASSWORD_LENGTH_INVALID);
+        }
+    }
+
+    // ========== 조회 ==========
+
+    private User findUserByIdOrThrow(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private UserProfile findProfileByUserIdOrThrow(Long userId) {
+        return userProfileRepository.findByUserId(userId)
+            .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    // ========== 유틸 ==========
+
+    private Position parsePosition(String position) {
+        try {
+            return Position.valueOf(position.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
+
+    private void saveTechStacks(Long userId, List<Long> techStackIds) {
+        if (techStackIds == null || techStackIds.isEmpty()) {
+            return;
+        }
+        techStackIds.forEach(techStackId ->
+            userTechStackRepository.save(new UserTechStack(userId, techStackId))
+        );
     }
 }

--- a/member/src/main/java/com/devticket/member/presentation/domain/model/TechStack.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/model/TechStack.java
@@ -30,4 +30,12 @@ public class TechStack {
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    public static TechStack of(Long id, String name) {
+        TechStack ts = new TechStack();
+        ts.id = id;
+        ts.name = name;
+        ts.createdAt = LocalDateTime.now();
+        return ts;
+    }
 }

--- a/member/src/test/java/com/devticket/member/application/UserServiceTest.java
+++ b/member/src/test/java/com/devticket/member/application/UserServiceTest.java
@@ -2,6 +2,7 @@ package com.devticket.member.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -14,6 +15,7 @@ import com.devticket.member.common.exception.BusinessException;
 import com.devticket.member.presentation.domain.MemberErrorCode;
 import com.devticket.member.presentation.domain.Position;
 import com.devticket.member.presentation.domain.ProviderType;
+import com.devticket.member.presentation.domain.model.TechStack;
 import com.devticket.member.presentation.domain.model.User;
 import com.devticket.member.presentation.domain.model.UserProfile;
 import com.devticket.member.presentation.domain.model.UserTechStack;
@@ -149,21 +151,25 @@ class UserServiceTest {
             // given
             User user = new User("test@test.com", "$2a$10$hashedPassword");
             UserProfile profile = new UserProfile(1L, "닉네임", Position.BACKEND, null, "자기소개");
-            List<UserTechStack> userTechStacks = List.of(new UserTechStack(1L, 10L));
+
+            List<UserTechStack> userTechStacks = List.of(new UserTechStack(1L, 10L), new UserTechStack(1L, 20L));
+            List<TechStack> techStacks = List.of(TechStack.of(10L, "Spring"), TechStack.of(20L, "MySQL"));
 
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
             given(userProfileRepository.findByUserId(anyLong())).willReturn(Optional.of(profile));
             given(userTechStackRepository.findByUserId(anyLong())).willReturn(userTechStacks);
-            given(techStackRepository.findAllById(anyList())).willReturn(List.of());
+            given(techStackRepository.findByIdIn(anyList())).willReturn(techStacks);
 
             // when
             GetProfileResponse response = userService.getProfile(1L);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.email()).isEqualTo("test@test.com");
-            assertThat(response.nickname()).isEqualTo("닉네임");
-            assertThat(response.position()).isEqualTo("BACKEND");
+            assertThat(response.techStacks())
+                .extracting(
+                    GetProfileResponse.TechStackInfo::techStackId,
+                    GetProfileResponse.TechStackInfo::name
+                )
+                .containsExactly(tuple(10L, "Spring"), tuple(20L, "MySQL"));
         }
     }
 


### PR DESCRIPTION
## 관련 이슈
- close #131 

## 작업 내용
- UserService 5개 public 메서드 실제 구현 (기존 stub 교체)
- private 메서드 역할별 분리:
  - 검증: `validateNicknameNotDuplicated()`, `validateLocalUser()`, `validateCurrentPassword()`, `validatePasswordConfirm()`
  - 조회: `findUserByIdOrThrow()`, `findProfileByUserIdOrThrow()`
  - 유틸: `parsePosition()`, `saveTechStacks()`

## 변경 사항
- `com.devticket.member.application.UserService` — stub → 실제 구현 교체

## 테스트
- [ ] Issue #131 단위 테스트 14건 전체 통과
- [ ] Swagger 동작 확인

## 참고 사항
- 프로필 수정 시 닉네임이 기존과 동일하면 중복 검증 스킵
- 기술 스택 수정은 전체 교체 방식 (deleteByUserId → 새로 삽입)
- 소셜 사용자(providerType != LOCAL)는 비밀번호 변경 차단
- 회원 탈퇴 시 User.withdraw() + RefreshToken 전체 삭제 (Soft Delete)
- `@Transactional(readOnly = true)` 기본, 쓰기 메서드만 `@Transactional` 오버라이드