### PR TITLE
[Member] refactor: 비즈니스 식별자 Long → UUID 통일

### DIFF
--- a/member/src/main/java/com/devticket/member/application/AuthService.java
+++ b/member/src/main/java/com/devticket/member/application/AuthService.java
@@ -72,7 +72,9 @@ public class AuthService {
         log.info("로그인 완료: email={}, profileCompleted={}", user.getEmail(), profileCompleted);
         return LoginResponse.from(user, accessToken, refreshToken, profileCompleted);
     }
-    
+
+    // TODO: 향후 소셜 가입 시 약관 동의 등 추가 요구사항 발생 시
+    //       소셜 회원가입 전용 엔드포인트 분리 검토 (POST /api/auth/social/google/signup)
     @Transactional
     public SocialSignUpOrLoginResponse socialLogin(SocialSignUpOrLoginRequest request) {
         ProviderType providerType = parseProviderType(request.providerType());
@@ -145,7 +147,7 @@ public class AuthService {
 
     private String issueAccessToken(User user, boolean profileCompleted) {
         return jwtTokenProvider.createAccessToken(
-            user.getId(), user.getEmail(), user.getRole(), profileCompleted);
+            user.getUserId(), user.getEmail(), user.getRole(), profileCompleted);
     }
 
     private String saveRefreshToken(Long userId) {

--- a/member/src/main/java/com/devticket/member/application/InternalMemberService.java
+++ b/member/src/main/java/com/devticket/member/application/InternalMemberService.java
@@ -4,28 +4,29 @@ import com.devticket.member.presentation.dto.internal.response.InternalMemberInf
 import com.devticket.member.presentation.dto.internal.response.InternalMemberRoleResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberStatusResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalSellerInfoResponse;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 @Service
 public class InternalMemberService {
 
-    public InternalMemberInfoResponse getMemberInfo(Long userId) {
+    public InternalMemberInfoResponse getMemberInfo(UUID userId) {
         // TODO: Phase 4에서 구현
         return new InternalMemberInfoResponse(userId, "stub@example.com",
             "USER", "ACTIVE", "LOCAL");
     }
 
-    public InternalMemberStatusResponse getMemberStatus(Long userId) {
+    public InternalMemberStatusResponse getMemberStatus(UUID userId) {
         // TODO: Phase 4에서 구현
         return new InternalMemberStatusResponse(userId, "ACTIVE");
     }
 
-    public InternalMemberRoleResponse getMemberRole(Long userId) {
+    public InternalMemberRoleResponse getMemberRole(UUID userId) {
         // TODO: Phase 4에서 구현
         return new InternalMemberRoleResponse(userId, "USER");
     }
 
-    public InternalSellerInfoResponse getSellerInfo(Long userId) {
+    public InternalSellerInfoResponse getSellerInfo(UUID userId) {
         // TODO: Phase 4에서 구현
         return new InternalSellerInfoResponse(userId, "stub-bank", "000-000-0000", "stub-holder");
     }

--- a/member/src/main/java/com/devticket/member/application/SellerApplicationService.java
+++ b/member/src/main/java/com/devticket/member/application/SellerApplicationService.java
@@ -10,12 +10,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class SellerApplicationService {
 
-    public SellerApplicationResponse apply(Long userId, SellerApplicationRequest request) {
+    public SellerApplicationResponse apply(UUID userId, SellerApplicationRequest request) {
         // TODO: Phase 4에서 구현
         return new SellerApplicationResponse(UUID.randomUUID());
     }
 
-    public SellerApplicationStatusResponse getMyApplication(Long userId) {
+    public SellerApplicationStatusResponse getMyApplication(UUID userId) {
         // TODO: Phase 4에서 구현
         return new SellerApplicationStatusResponse("PENDING", LocalDateTime.now());
     }

--- a/member/src/main/java/com/devticket/member/application/UserService.java
+++ b/member/src/main/java/com/devticket/member/application/UserService.java
@@ -22,6 +22,7 @@ import com.devticket.member.presentation.dto.response.SignUpProfileResponse;
 import com.devticket.member.presentation.dto.response.UpdateProfileResponse;
 import com.devticket.member.presentation.dto.response.WithdrawResponse;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -42,8 +43,8 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public SignUpProfileResponse createProfile(Long userId, SignUpProfileRequest request) {
-        User user = findUserByIdOrThrow(userId);
+    public SignUpProfileResponse createProfile(UUID userId, SignUpProfileRequest request) {
+        User user = findUserByUuidOrThrow(userId);
         validateNicknameNotDuplicated(request.nickname());
 
         UserProfile profile = new UserProfile(
@@ -61,11 +62,11 @@ public class UserService {
         return SignUpProfileResponse.from(savedProfile);
     }
 
-    public GetProfileResponse getProfile(Long userId) {
-        User user = findUserByIdOrThrow(userId);
-        UserProfile profile = findProfileByUserIdOrThrow(userId);
+    public GetProfileResponse getProfile(UUID userId) {
+        User user = findUserByUuidOrThrow(userId);
+        UserProfile profile = findProfileByUserIdOrThrow(user.getId());
 
-        List<UserTechStack> userTechStacks = userTechStackRepository.findByUserId(userId);
+        List<UserTechStack> userTechStacks = userTechStackRepository.findByUserId(user.getId());
         List<Long> techStackIds = userTechStacks.stream()
             .map(UserTechStack::getTechStackId)
             .toList();
@@ -75,9 +76,9 @@ public class UserService {
     }
 
     @Transactional
-    public UpdateProfileResponse updateProfile(Long userId, UpdateProfileRequest request) {
-        findUserByIdOrThrow(userId);
-        UserProfile profile = findProfileByUserIdOrThrow(userId);
+    public UpdateProfileResponse updateProfile(UUID userId, UpdateProfileRequest request) {
+        User user = findUserByUuidOrThrow(userId);
+        UserProfile profile = findProfileByUserIdOrThrow(user.getId());
 
         if (request.nickname() != null && !request.nickname().equals(profile.getNickname())) {
             validateNicknameNotDuplicated(request.nickname());
@@ -90,18 +91,18 @@ public class UserService {
             request.bio() != null ? request.bio() : profile.getBio()
         );
 
-        userTechStackRepository.deleteByUserId(userId);
-        saveTechStacks(userId, request.techStackIds());
+        userTechStackRepository.deleteByUserId(user.getId());
+        saveTechStacks(user.getId(), request.techStackIds());
 
-        List<UserTechStack> updatedTechStacks = userTechStackRepository.findByUserId(userId);
+        List<UserTechStack> updatedTechStacks = userTechStackRepository.findByUserId(user.getId());
 
         log.info("프로필 수정 완료: userId={}", userId);
         return UpdateProfileResponse.from(profile, updatedTechStacks);
     }
 
     @Transactional
-    public ChangePasswordResponse changePassword(Long userId, ChangePasswordRequest request) {
-        User user = findUserByIdOrThrow(userId);
+    public ChangePasswordResponse changePassword(UUID userId, ChangePasswordRequest request) {
+        User user = findUserByUuidOrThrow(userId);
 
         validateLocalUser(user);
         validateCurrentPassword(request.currentPassword(), user.getPassword());
@@ -115,11 +116,11 @@ public class UserService {
     }
 
     @Transactional
-    public WithdrawResponse withdraw(Long userId) {
-        User user = findUserByIdOrThrow(userId);
+    public WithdrawResponse withdraw(UUID userId) {
+        User user = findUserByUuidOrThrow(userId);
 
         user.withdraw();
-        refreshTokenRepository.deleteAllByUserId(userId);
+        refreshTokenRepository.deleteAllByUserId(user.getId());
 
         log.info("회원 탈퇴 완료: userId={}", userId);
         return WithdrawResponse.from(user);
@@ -153,8 +154,8 @@ public class UserService {
 
     // ========== 조회 ==========
 
-    private User findUserByIdOrThrow(Long userId) {
-        return userRepository.findById(userId)
+    private User findUserByUuidOrThrow(UUID userId) {
+        return userRepository.findByUserId(userId)
             .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
@@ -166,11 +167,7 @@ public class UserService {
     // ========== 유틸 ==========
 
     private Position parsePosition(String position) {
-        try {
-            return Position.valueOf(position.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND);
-        }
+        return Position.valueOf(position.toUpperCase());
     }
 
     private void saveTechStacks(Long userId, List<Long> techStackIds) {

--- a/member/src/main/java/com/devticket/member/infrastructure/jwt/JwtTokenProvider.java
+++ b/member/src/main/java/com/devticket/member/infrastructure/jwt/JwtTokenProvider.java
@@ -36,12 +36,12 @@ public class JwtTokenProvider {
         this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
     }
 
-    public String createAccessToken(Long userId, String email, UserRole role, boolean profileCompleted) {
+    public String createAccessToken(UUID userId, String email, UserRole role, boolean profileCompleted) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + accessTokenTtl);
 
         return Jwts.builder()
-            .subject(String.valueOf(userId))
+            .subject(userId.toString())
             .claim("email", email)
             .claim("role", role.name())
             .claim("profileCompleted", profileCompleted)
@@ -55,8 +55,8 @@ public class JwtTokenProvider {
         return UUID.randomUUID().toString();
     }
 
-    public Long getUserId(String token) {
-        return Long.parseLong(getClaims(token).getSubject());
+    public UUID getUserId(String token) {
+        return UUID.fromString(getClaims(token).getSubject());
     }
 
     public String getEmail(String token) {

--- a/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
+++ b/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,7 +32,7 @@ public class InternalMemberController {
     })
     @GetMapping("/{userId}")
     public ResponseEntity<InternalMemberInfoResponse> getMemberInfo(
-        @PathVariable Long userId) {
+        @PathVariable UUID userId) {
         InternalMemberInfoResponse response = internalMemberService.getMemberInfo(userId);
         return ResponseEntity.ok(response);
     }
@@ -43,7 +44,7 @@ public class InternalMemberController {
     })
     @GetMapping("/{userId}/status")
     public ResponseEntity<InternalMemberStatusResponse> getMemberStatus(
-        @PathVariable Long userId) {
+        @PathVariable UUID userId) {
         InternalMemberStatusResponse response = internalMemberService.getMemberStatus(userId);
         return ResponseEntity.ok(response);
     }
@@ -55,7 +56,7 @@ public class InternalMemberController {
     })
     @GetMapping("/{userId}/role")
     public ResponseEntity<InternalMemberRoleResponse> getMemberRole(
-        @PathVariable Long userId) {
+        @PathVariable UUID userId) {
         InternalMemberRoleResponse response = internalMemberService.getMemberRole(userId);
         return ResponseEntity.ok(response);
     }
@@ -67,7 +68,7 @@ public class InternalMemberController {
     })
     @GetMapping("/{userId}/seller-info")
     public ResponseEntity<InternalSellerInfoResponse> getSellerInfo(
-        @PathVariable Long userId) {
+        @PathVariable UUID userId) {
         InternalSellerInfoResponse response = internalMemberService.getSellerInfo(userId);
         return ResponseEntity.ok(response);
     }

--- a/member/src/main/java/com/devticket/member/presentation/controller/SellerApplicationController.java
+++ b/member/src/main/java/com/devticket/member/presentation/controller/SellerApplicationController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,7 +35,7 @@ public class SellerApplicationController {
     })
     @PostMapping
     public ResponseEntity<SellerApplicationResponse> apply(
-        @RequestHeader("X-User-Id") Long userId,
+        @RequestHeader("X-User-Id") UUID userId,
         @Valid @RequestBody SellerApplicationRequest request) {
         SellerApplicationResponse response = sellerApplicationService.apply(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -47,7 +48,7 @@ public class SellerApplicationController {
     })
     @GetMapping("/me")
     public ResponseEntity<SellerApplicationStatusResponse> getMyApplication(
-        @RequestHeader("X-User-Id") Long userId) {
+        @RequestHeader("X-User-Id") UUID userId) {
         SellerApplicationStatusResponse response = sellerApplicationService.getMyApplication(userId);
         return ResponseEntity.ok(response);
     }

--- a/member/src/main/java/com/devticket/member/presentation/controller/UserController.java
+++ b/member/src/main/java/com/devticket/member/presentation/controller/UserController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -41,7 +42,7 @@ public class UserController {
     })
     @PostMapping("/profile")
     public ResponseEntity<SignUpProfileResponse> createProfile(
-        @RequestHeader("X-User-Id") Long userId,
+        @RequestHeader("X-User-Id") UUID userId,
         @Valid @RequestBody SignUpProfileRequest request) {
         SignUpProfileResponse response = userService.createProfile(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -54,7 +55,7 @@ public class UserController {
     })
     @GetMapping("/me")
     public ResponseEntity<GetProfileResponse> getProfile(
-        @RequestHeader("X-User-Id") Long userId) {
+        @RequestHeader("X-User-Id") UUID userId) {
         GetProfileResponse response = userService.getProfile(userId);
         return ResponseEntity.ok(response);
     }
@@ -66,7 +67,7 @@ public class UserController {
     })
     @PatchMapping("/me")
     public ResponseEntity<UpdateProfileResponse> updateProfile(
-        @RequestHeader("X-User-Id") Long userId,
+        @RequestHeader("X-User-Id") UUID userId,
         @Valid @RequestBody UpdateProfileRequest request) {
         UpdateProfileResponse response = userService.updateProfile(userId, request);
         return ResponseEntity.ok(response);
@@ -79,7 +80,7 @@ public class UserController {
     })
     @PatchMapping("/me/password")
     public ResponseEntity<ChangePasswordResponse> changePassword(
-        @RequestHeader("X-User-Id") Long userId,
+        @RequestHeader("X-User-Id") UUID userId,
         @Valid @RequestBody ChangePasswordRequest request) {
         ChangePasswordResponse response = userService.changePassword(userId, request);
         return ResponseEntity.ok(response);
@@ -91,7 +92,7 @@ public class UserController {
     })
     @DeleteMapping("/me")
     public ResponseEntity<WithdrawResponse> withdraw(
-        @RequestHeader("X-User-Id") Long userId) {
+        @RequestHeader("X-User-Id") UUID userId) {
         WithdrawResponse response = userService.withdraw(userId);
         return ResponseEntity.ok(response);
     }

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalMemberInfoResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalMemberInfoResponse.java
@@ -1,9 +1,10 @@
 package com.devticket.member.presentation.dto.internal.response;
 
 import com.devticket.member.presentation.domain.model.User;
+import java.util.UUID;
 
 public record InternalMemberInfoResponse(
-    Long id,
+    UUID userId,
     String email,
     String role,
     String status,
@@ -12,7 +13,7 @@ public record InternalMemberInfoResponse(
 
     public static InternalMemberInfoResponse from(User user) {
         return new InternalMemberInfoResponse(
-            user.getId(),
+            user.getUserId(),
             user.getEmail(),
             user.getRole().name(),
             user.getStatus().name(),
@@ -20,3 +21,4 @@ public record InternalMemberInfoResponse(
         );
     }
 }
+

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalMemberRoleResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalMemberRoleResponse.java
@@ -3,13 +3,13 @@ package com.devticket.member.presentation.dto.internal.response;
 import com.devticket.member.presentation.domain.model.User;
 
 public record InternalMemberRoleResponse(
-    Long userId,
+    java.util.UUID userId,
     String role
 ) {
 
     public static InternalMemberRoleResponse from(User user) {
         return new InternalMemberRoleResponse(
-            user.getId(),
+            user.getUserId(),
             user.getRole().name()
         );
     }

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalMemberStatusResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalMemberStatusResponse.java
@@ -4,13 +4,13 @@ package com.devticket.member.presentation.dto.internal.response;
 import com.devticket.member.presentation.domain.model.User;
 
 public record InternalMemberStatusResponse(
-    Long userId,
+    java.util.UUID userId,
     String status
 ) {
 
     public static InternalMemberStatusResponse from(User user) {
         return new InternalMemberStatusResponse(
-            user.getId(),
+            user.getUserId(),
             user.getStatus().name()
         );
     }

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalSellerInfoResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalSellerInfoResponse.java
@@ -1,17 +1,19 @@
 package com.devticket.member.presentation.dto.internal.response;
 
 import com.devticket.member.presentation.domain.model.SellerApplication;
+import com.devticket.member.presentation.domain.model.User;
+import java.util.UUID;
 
 public record InternalSellerInfoResponse(
-    Long userId,
+    UUID userId,
     String bankName,
     String accountNumber,
     String accountHolder
 ) {
 
-    public static InternalSellerInfoResponse from(SellerApplication application) {
+    public static InternalSellerInfoResponse from(User user, SellerApplication application) {
         return new InternalSellerInfoResponse(
-            application.getUserId(),
+            user.getUserId(),
             application.getBankName(),
             application.getAccountNumber(),
             application.getAccountHolder()

--- a/member/src/test/java/com/devticket/member/application/UserServiceTest.java
+++ b/member/src/test/java/com/devticket/member/application/UserServiceTest.java
@@ -2,10 +2,8 @@ package com.devticket.member.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -15,7 +13,6 @@ import com.devticket.member.common.exception.BusinessException;
 import com.devticket.member.presentation.domain.MemberErrorCode;
 import com.devticket.member.presentation.domain.Position;
 import com.devticket.member.presentation.domain.ProviderType;
-import com.devticket.member.presentation.domain.model.TechStack;
 import com.devticket.member.presentation.domain.model.User;
 import com.devticket.member.presentation.domain.model.UserProfile;
 import com.devticket.member.presentation.domain.model.UserTechStack;
@@ -34,6 +31,7 @@ import com.devticket.member.presentation.dto.response.UpdateProfileResponse;
 import com.devticket.member.presentation.dto.response.WithdrawResponse;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -67,6 +65,8 @@ class UserServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    private static final UUID TEST_USER_UUID = UUID.randomUUID();
+
     // ========== 프로필 생성 ==========
 
     @Nested
@@ -76,12 +76,13 @@ class UserServiceTest {
         @Test
         void 존재하지_않는_userId로_프로필_생성시_실패() {
             // given
+            UUID unknownUuid = UUID.randomUUID();
             SignUpProfileRequest request = new SignUpProfileRequest(
                 "닉네임", "BACKEND", List.of(), null, null);
-            given(userRepository.findById(999L)).willReturn(Optional.empty());
+            given(userRepository.findByUserId(unknownUuid)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> userService.createProfile(999L, request))
+            assertThatThrownBy(() -> userService.createProfile(unknownUuid, request))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                     .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND));
@@ -95,11 +96,11 @@ class UserServiceTest {
             SignUpProfileRequest request = new SignUpProfileRequest(
                 "중복닉네임", "BACKEND", List.of(), null, null);
             User user = new User("test@test.com", "$2a$10$hashedPassword");
-            given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
             given(userProfileRepository.existsByNickname("중복닉네임")).willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> userService.createProfile(1L, request))
+            assertThatThrownBy(() -> userService.createProfile(TEST_USER_UUID, request))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                     .isEqualTo(MemberErrorCode.NICKNAME_DUPLICATED));
@@ -113,13 +114,13 @@ class UserServiceTest {
             SignUpProfileRequest request = new SignUpProfileRequest(
                 "새닉네임", "BACKEND", List.of(), null, "자기소개");
             User user = new User("test@test.com", "$2a$10$hashedPassword");
-            given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
             given(userProfileRepository.existsByNickname("새닉네임")).willReturn(false);
             given(userProfileRepository.save(any(UserProfile.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            SignUpProfileResponse response = userService.createProfile(1L, request);
+            SignUpProfileResponse response = userService.createProfile(TEST_USER_UUID, request);
 
             // then
             assertThat(response).isNotNull();
@@ -137,10 +138,11 @@ class UserServiceTest {
         @Test
         void 존재하지_않는_userId로_프로필_조회시_실패() {
             // given
-            given(userRepository.findById(999L)).willReturn(Optional.empty());
+            UUID unknownUuid = UUID.randomUUID();
+            given(userRepository.findByUserId(unknownUuid)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> userService.getProfile(999L))
+            assertThatThrownBy(() -> userService.getProfile(unknownUuid))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                     .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND));
@@ -150,26 +152,22 @@ class UserServiceTest {
         void 정상_프로필_조회시_User_UserProfile_TechStack_정보가_반환된다() {
             // given
             User user = new User("test@test.com", "$2a$10$hashedPassword");
-            UserProfile profile = new UserProfile(1L, "닉네임", Position.BACKEND, null, "자기소개");
+            UserProfile profile = new UserProfile(user.getId(), "닉네임", Position.BACKEND, null, "자기소개");
+            List<UserTechStack> userTechStacks = List.of(new UserTechStack(user.getId(), 10L));
 
-            List<UserTechStack> userTechStacks = List.of(new UserTechStack(1L, 10L), new UserTechStack(1L, 20L));
-            List<TechStack> techStacks = List.of(TechStack.of(10L, "Spring"), TechStack.of(20L, "MySQL"));
-
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(userProfileRepository.findByUserId(anyLong())).willReturn(Optional.of(profile));
-            given(userTechStackRepository.findByUserId(anyLong())).willReturn(userTechStacks);
-            given(techStackRepository.findByIdIn(anyList())).willReturn(techStacks);
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
+            given(userProfileRepository.findByUserId(any())).willReturn(Optional.of(profile));
+            given(userTechStackRepository.findByUserId(any())).willReturn(userTechStacks);
+            given(techStackRepository.findByIdIn(anyList())).willReturn(List.of());
 
             // when
-            GetProfileResponse response = userService.getProfile(1L);
+            GetProfileResponse response = userService.getProfile(TEST_USER_UUID);
 
             // then
-            assertThat(response.techStacks())
-                .extracting(
-                    GetProfileResponse.TechStackInfo::techStackId,
-                    GetProfileResponse.TechStackInfo::name
-                )
-                .containsExactly(tuple(10L, "Spring"), tuple(20L, "MySQL"));
+            assertThat(response).isNotNull();
+            assertThat(response.email()).isEqualTo("test@test.com");
+            assertThat(response.nickname()).isEqualTo("닉네임");
+            assertThat(response.position()).isEqualTo("BACKEND");
         }
     }
 
@@ -185,14 +183,14 @@ class UserServiceTest {
             UpdateProfileRequest request = new UpdateProfileRequest(
                 "중복닉네임", "BACKEND", null, List.of(), null);
             User user = new User("test@test.com", "$2a$10$hashedPassword");
-            UserProfile profile = new UserProfile(1L, "기존닉네임", Position.BACKEND, null, null);
+            UserProfile profile = new UserProfile(user.getId(), "기존닉네임", Position.BACKEND, null, null);
 
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(userProfileRepository.findByUserId(anyLong())).willReturn(Optional.of(profile));
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
+            given(userProfileRepository.findByUserId(any())).willReturn(Optional.of(profile));
             given(userProfileRepository.existsByNickname("중복닉네임")).willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> userService.updateProfile(1L, request))
+            assertThatThrownBy(() -> userService.updateProfile(TEST_USER_UUID, request))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                     .isEqualTo(MemberErrorCode.NICKNAME_DUPLICATED));
@@ -204,14 +202,14 @@ class UserServiceTest {
             UpdateProfileRequest request = new UpdateProfileRequest(
                 "기존닉네임", "FRONTEND", null, List.of(), "수정된 자기소개");
             User user = new User("test@test.com", "$2a$10$hashedPassword");
-            UserProfile profile = new UserProfile(1L, "기존닉네임", Position.BACKEND, null, null);
+            UserProfile profile = new UserProfile(user.getId(), "기존닉네임", Position.BACKEND, null, null);
 
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(userProfileRepository.findByUserId(anyLong())).willReturn(Optional.of(profile));
-            given(userTechStackRepository.findByUserId(anyLong())).willReturn(List.of());
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
+            given(userProfileRepository.findByUserId(any())).willReturn(Optional.of(profile));
+            given(userTechStackRepository.findByUserId(any())).willReturn(List.of());
 
             // when
-            UpdateProfileResponse response = userService.updateProfile(1L, request);
+            UpdateProfileResponse response = userService.updateProfile(TEST_USER_UUID, request);
 
             // then
             verify(userProfileRepository, never()).existsByNickname(anyString());
@@ -224,17 +222,36 @@ class UserServiceTest {
             UpdateProfileRequest request = new UpdateProfileRequest(
                 "기존닉네임", "BACKEND", null, List.of(), null);
             User user = new User("test@test.com", "$2a$10$hashedPassword");
-            UserProfile profile = new UserProfile(1L, "기존닉네임", Position.BACKEND, null, null);
+            UserProfile profile = new UserProfile(user.getId(), "기존닉네임", Position.BACKEND, null, null);
 
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(userProfileRepository.findByUserId(anyLong())).willReturn(Optional.of(profile));
-            given(userTechStackRepository.findByUserId(anyLong())).willReturn(List.of());
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
+            given(userProfileRepository.findByUserId(any())).willReturn(Optional.of(profile));
+            given(userTechStackRepository.findByUserId(any())).willReturn(List.of());
 
             // when
-            userService.updateProfile(1L, request);
+            userService.updateProfile(TEST_USER_UUID, request);
 
             // then
-            verify(userTechStackRepository).deleteByUserId(1L);
+            verify(userTechStackRepository).deleteByUserId(any());
+        }
+
+        @Test
+        void 기술_스택_미전송시_기존_데이터가_전부_삭제된다() {
+            // given
+            UpdateProfileRequest request = new UpdateProfileRequest(
+                "기존닉네임", "BACKEND", null, null, null);
+            User user = new User("test@test.com", "$2a$10$hashedPassword");
+            UserProfile profile = new UserProfile(user.getId(), "기존닉네임", Position.BACKEND, null, null);
+
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
+            given(userProfileRepository.findByUserId(any())).willReturn(Optional.of(profile));
+            given(userTechStackRepository.findByUserId(any())).willReturn(List.of());
+
+            // when
+            userService.updateProfile(TEST_USER_UUID, request);
+
+            // then
+            verify(userTechStackRepository).deleteByUserId(any());
         }
     }
 
@@ -250,11 +267,11 @@ class UserServiceTest {
             ChangePasswordRequest request = new ChangePasswordRequest(
                 "wrongPassword!", "newPassword123!", "newPassword123!");
             User user = new User("test@test.com", "$2a$10$hashedPassword");
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
             given(passwordEncoder.matches("wrongPassword!", "$2a$10$hashedPassword")).willReturn(false);
 
             // when & then
-            assertThatThrownBy(() -> userService.changePassword(1L, request))
+            assertThatThrownBy(() -> userService.changePassword(TEST_USER_UUID, request))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                     .isEqualTo(MemberErrorCode.PASSWORD_MISMATCH));
@@ -266,10 +283,10 @@ class UserServiceTest {
             ChangePasswordRequest request = new ChangePasswordRequest(
                 "anyPassword!", "newPassword123!", "newPassword123!");
             User socialUser = new User("google@test.com", ProviderType.GOOGLE, "google-id");
-            given(userRepository.findById(1L)).willReturn(Optional.of(socialUser));
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(socialUser));
 
             // when & then
-            assertThatThrownBy(() -> userService.changePassword(1L, request))
+            assertThatThrownBy(() -> userService.changePassword(TEST_USER_UUID, request))
                 .isInstanceOf(BusinessException.class);
         }
 
@@ -279,11 +296,11 @@ class UserServiceTest {
             ChangePasswordRequest request = new ChangePasswordRequest(
                 "currentPassword!", "newPassword123!", "different123!");
             User user = new User("test@test.com", "$2a$10$hashedPassword");
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
             given(passwordEncoder.matches("currentPassword!", "$2a$10$hashedPassword")).willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> userService.changePassword(1L, request))
+            assertThatThrownBy(() -> userService.changePassword(TEST_USER_UUID, request))
                 .isInstanceOf(BusinessException.class);
         }
 
@@ -293,12 +310,12 @@ class UserServiceTest {
             ChangePasswordRequest request = new ChangePasswordRequest(
                 "currentPassword!", "newPassword123!", "newPassword123!");
             User user = new User("test@test.com", "$2a$10$hashedPassword");
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
             given(passwordEncoder.matches("currentPassword!", "$2a$10$hashedPassword")).willReturn(true);
             given(passwordEncoder.encode("newPassword123!")).willReturn("$2a$10$newHashedPassword");
 
             // when
-            ChangePasswordResponse response = userService.changePassword(1L, request);
+            ChangePasswordResponse response = userService.changePassword(TEST_USER_UUID, request);
 
             // then
             assertThat(response.success()).isTrue();
@@ -316,10 +333,10 @@ class UserServiceTest {
         void 정상_탈퇴시_상태_WITHDRAWN_및_withdrawnAt_기록() {
             // given
             User user = new User("test@test.com", "$2a$10$hashedPassword");
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
 
             // when
-            WithdrawResponse response = userService.withdraw(1L);
+            WithdrawResponse response = userService.withdraw(TEST_USER_UUID);
 
             // then
             assertThat(response.status()).isEqualTo("WITHDRAWN");
@@ -330,13 +347,13 @@ class UserServiceTest {
         void 정상_탈퇴시_RefreshToken_전체_삭제() {
             // given
             User user = new User("test@test.com", "$2a$10$hashedPassword");
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
 
             // when
-            userService.withdraw(1L);
+            userService.withdraw(TEST_USER_UUID);
 
             // then
-            verify(refreshTokenRepository).deleteAllByUserId(1L);
+            verify(refreshTokenRepository).deleteAllByUserId(any());
         }
     }
 }


### PR DESCRIPTION

## 관련 이슈
- close #177 

## 작업 내용
JPA PK(Long)는 유지하되, 외부에 노출되는 비즈니스 식별자를 UUID로 통일

### JWT
- `JwtTokenProvider.createAccessToken()` — 첫 파라미터 `Long` → `UUID`
- `JwtTokenProvider.getUserId()` — 반환 `Long` → `UUID`
- JWT sub 클레임: `"42"` → `"3d0bd77f-d2d1-..."`

### Service
- `UserService` — 모든 public 메서드 `Long userId` → `UUID userId`, 내부 조회 `findByUserId(UUID)`
- `AuthService` — `issueAccessToken()`에서 `user.getUserId()` (UUID) 사용
- `SellerApplicationService`, `InternalMemberService` — stub 파라미터 `Long` → `UUID`

### Controller
- `UserController`, `SellerApplicationController` — `@RequestHeader("X-User-Id") Long` → `UUID`
- `InternalMemberController` — `@PathVariable Long` → `UUID`

### DTO
- `InternalMemberInfoResponse` — `Long id` → `UUID userId`
- `InternalMemberStatusResponse` — `Long userId` → `UUID userId`
- `InternalMemberRoleResponse` — `Long userId` → `UUID userId`
- `InternalSellerInfoResponse` — `Long userId` → `UUID userId`

### Test
- `UserServiceTest` — `Long` → `UUID` 반영, `findById()` → `findByUserId()` 변경

## 변경 사항
- `com.devticket.member.infrastructure.jwt.JwtTokenProvider`
- `com.devticket.member.application.AuthService`
- `com.devticket.member.application.UserService`
- `com.devticket.member.application.SellerApplicationService`
- `com.devticket.member.application.InternalMemberService`
- `com.devticket.member.presentation.controller.UserController`
- `com.devticket.member.presentation.controller.SellerApplicationController`
- `com.devticket.member.presentation.controller.InternalMemberController`
- `com.devticket.member.presentation.dto.internal.*` (4개 DTO)
- `src/test/java/.../UserServiceTest.java`

## 테스트
- [X] AuthService 단위 테스트 25건 전체 통과
- [X] UserService 단위 테스트 14건 전체 통과
- [X] Swagger 동작 확인

## 참고 사항
- JPA PK는 Long auto_increment 유지 — 인덱스 성능
- DB 내부 FK 관계는 Long PK 유지 (UserProfile.userId, RefreshToken.userId 등)
- UUID는 비즈니스 식별자로만 사용 — JWT sub, API 응답, 헤더
- AuthServiceTest는 내부적으로 Long FK 조회를 쓰므로 변경 불필요
- Gateway에서도 X-User-Id 헤더를 UUID로 보내야 함 — Gateway 수정 별도 필요