### PR TITLE
[Event]refactor: 판매자 식별자(sellerId) 타입을 Long에서 UUID로 변경

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -24,7 +24,7 @@ public class EventService {
     private final EventRepository eventRepository;
 
     @Transactional
-    public SellerEventCreateResponse createEvent(Long sellerId, SellerEventCreateRequest request) {
+    public SellerEventCreateResponse createEvent(UUID sellerId, SellerEventCreateRequest request) {
 
         // 1. 비즈니스 정책 검증
         if (request.saleStartAt().isAfter(request.saleEndAt()) || request.saleStartAt().isEqual(request.saleEndAt())) {

--- a/event/src/main/java/com/devticket/event/domain/model/Event.java
+++ b/event/src/main/java/com/devticket/event/domain/model/Event.java
@@ -38,7 +38,7 @@ public class Event extends BaseEntity {
     private UUID eventId;
 
     @Column(nullable = false)
-    private Long sellerId;
+    private UUID sellerId;
 
     @Column(nullable = false, length = 255)
     private String title;
@@ -82,7 +82,7 @@ public class Event extends BaseEntity {
     private List<EventTechStack> eventTechStacks = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Event(UUID eventId, Long sellerId, String title, String description, String location,
+    private Event(UUID eventId, UUID sellerId, String title, String description, String location,
         LocalDateTime eventDateTime, LocalDateTime saleStartAt, LocalDateTime saleEndAt,
         Integer price, Integer totalQuantity, Integer maxQuantity, Integer remainingQuantity,
         EventStatus status, EventCategory category) {
@@ -103,7 +103,7 @@ public class Event extends BaseEntity {
     }
 
     public static Event create(
-        Long sellerId, String title, String description, String location,
+        UUID sellerId, String title, String description, String location,
         LocalDateTime eventDateTime, LocalDateTime saleStartAt, LocalDateTime saleEndAt,
         Integer price, Integer totalQuantity, Integer maxQuantity, EventCategory category
     ) {

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
@@ -26,7 +26,7 @@ public class EventController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public SuccessResponse<SellerEventCreateResponse> createEvent(
-        @RequestHeader("X-User-Id") Long sellerId, // 내부 식별자는 Long 유지
+        @RequestHeader("X-User-Id") UUID sellerId,
         @Valid @RequestBody SellerEventCreateRequest request) {
 
         SellerEventCreateResponse response = eventService.createEvent(sellerId, request);

--- a/event/src/test/java/com/devticket/event/application/EventServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventServiceTest.java
@@ -51,7 +51,7 @@ class EventServiceTest {
     @Test
     void 정상적인_조건일_경우_이벤트가_성공적으로_생성되고_UUID를_반환한다() {
         // given
-        Long sellerId = 1L;
+        UUID sellerId = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
         SellerEventCreateRequest request = EventTestFixture.createEventRequest(
             now.plusDays(4), now.plusDays(10), now.plusDays(15), 100, 4
@@ -76,7 +76,7 @@ class EventServiceTest {
     @Test
     void 판매시작일이_등록시점_기준_3일_이내면_예외가_발생한다() {
         // given
-        Long sellerId = 1L;
+        UUID sellerId = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
         SellerEventCreateRequest request = EventTestFixture.createEventRequest(
             now.plusDays(1), now.plusDays(10), now.plusDays(15), 100, 4
@@ -91,7 +91,7 @@ class EventServiceTest {
     @Test
     void 인당_최대구매수량이_총수량보다_크면_예외가_발생한다() {
         // given
-        Long sellerId = 1L;
+        UUID sellerId = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
         SellerEventCreateRequest request = EventTestFixture.createEventRequest(
             now.plusDays(4), now.plusDays(10), now.plusDays(15), 10, 20
@@ -106,7 +106,7 @@ class EventServiceTest {
     @Test
     void 행사일이_판매종료일보다_빠르면_예외가_발생한다() {
         // given
-        Long sellerId = 1L;
+        UUID sellerId = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
         // 행사일(plusDays(5))이 판매종료일(plusDays(10))보다 빠른 모순된 상황
         SellerEventCreateRequest request = EventTestFixture.createEventRequest(
@@ -124,7 +124,7 @@ class EventServiceTest {
     @Test
     void 존재하는_이벤트_조회시_상세정보를_반환한다() {
         // given
-        Long sellerId = 1L;
+        UUID sellerId = UUID.randomUUID();
 
         Event event = EventTestFixture.createEvent(sellerId);
         UUID eventId = event.getEventId();

--- a/event/src/test/java/com/devticket/event/fixture/EventTestFixture.java
+++ b/event/src/test/java/com/devticket/event/fixture/EventTestFixture.java
@@ -29,7 +29,7 @@ public class EventTestFixture {
         );
     }
 
-    public static Event createEvent(Long sellerId) {
+    public static Event createEvent(UUID sellerId) {
         return Event.create(
             sellerId, "상세 조회 테스트 밋업", "설명", "강남역",
             LocalDateTime.now().plusDays(15), LocalDateTime.now().plusDays(4), LocalDateTime.now().plusDays(10),
@@ -47,7 +47,7 @@ public class EventTestFixture {
 
     // Page<Event>를 반환하는 모의(Mock) 객체 생성 메서드
     public static Page<Event> createEventPage() {
-        Event event = createEvent(1L);
+        Event event = createEvent(UUID.randomUUID());
         ReflectionTestUtils.setField(event, "eventId", UUID.randomUUID());
         ReflectionTestUtils.setField(event, "createdAt", LocalDateTime.now());
 

--- a/event/src/test/java/com/devticket/event/presentation/controller/EventControllerTest.java
+++ b/event/src/test/java/com/devticket/event/presentation/controller/EventControllerTest.java
@@ -51,7 +51,7 @@ class EventControllerTest {
     @Test
     void 정상적인_요청시_201_응답과_UUID를_반환한다() throws Exception {
         // given
-        Long sellerId = 1L;
+        UUID sellerId = UUID.randomUUID();
         UUID expectedEventId = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
         SellerEventCreateRequest request = EventTestFixture.createEventRequest(
@@ -107,9 +107,11 @@ class EventControllerTest {
             100, 4, null, null, null
         );
 
+        UUID sellerId = UUID.randomUUID();
+
         // when & then
         mockMvc.perform(post("/api/v1/events")
-                .header("X-User-Id", "1")
+                .header("X-User-Id", sellerId.toString())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(badRequest)))
             .andDo(print())


### PR DESCRIPTION
## 서비스
- [ ] Gateway
- [ ] Member
- [x] Event
- [ ] Commerce
- [ ] Payment
- [ ] Settlement
- [ ] Log
- [ ] Admin

## 기능 설명
Event 도메인 내에서 판매자를 식별하는 `sellerId`의 타입을 기존 내부 식별자(`Long`)에서 외부 공개 식별자(`UUID`)로 전면 개편했습니다. 이를 통해 서비스 간 의존성을 낮추고 글로벌 식별자 표준을 준수합니다.

## 작업 내용
- [x] **Controller 계층:** 이벤트 생성 API 등에서 판매자를 식별하는 `@RequestHeader("X-User-Id")`의 파라미터 타입을 `Long`에서 `UUID`로 변경
- [x] **Service 계층:** `createEvent` 등 비즈니스 로직 메서드 시그니처의 `sellerId` 파라미터 타입 업데이트
- [x] **Domain/Entity 계층:** `Event` 엔티티의 `sellerId` 필드를 `UUID`로 변경 (DB 스키마 매핑 반영)
- [x] **테스트 코드 전면 수정 및 트러블슈팅:** - `EventTestFixture`의 팩토리 메서드 파라미터를 `UUID`로 일괄 변경
  - `EventServiceTest` 및 `EventControllerTest` 내의 더미 데이터(`1L`)를 `UUID.randomUUID()`로 교체
  - 컨트롤러 테스트 중 발생한 `TypeMismatchException` (500 에러) 원인 파악 후 정상적인 UUID 문자열 매핑으로 400 Validation 테스트 정상화 완료

## API 엔드포인트
- `POST /api/v1/events` (이벤트 생성)
- (기타 `X-User-Id` 헤더를 요구하는 모든 Event API)

## 참고 문서
- 관련 이슈: #177 
