### PR TITLE
test(member): SellerApplicationService 단위 테스트 6건 작성

### DIFF
--- a/member/src/main/java/com/devticket/member/application/SellerApplicationService.java
+++ b/member/src/main/java/com/devticket/member/application/SellerApplicationService.java
@@ -10,12 +10,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class SellerApplicationService {
 
-    public SellerApplicationResponse apply(Long userId, SellerApplicationRequest request) {
+    public SellerApplicationResponse apply(UUID userId, SellerApplicationRequest request) {
         // TODO: Phase 4에서 구현
         return new SellerApplicationResponse(UUID.randomUUID());
     }
 
-    public SellerApplicationStatusResponse getMyApplication(Long userId) {
+    public SellerApplicationStatusResponse getMyApplication(UUID userId) {
         // TODO: Phase 4에서 구현
         return new SellerApplicationStatusResponse("PENDING", LocalDateTime.now());
     }

--- a/member/src/test/java/com/devticket/member/application/SellerApplicationServiceTest.java
+++ b/member/src/test/java/com/devticket/member/application/SellerApplicationServiceTest.java
@@ -1,0 +1,161 @@
+package com.devticket.member.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.devticket.member.common.exception.BusinessException;
+import com.devticket.member.presentation.domain.MemberErrorCode;
+import com.devticket.member.presentation.domain.SellerApplicationStatus;
+import com.devticket.member.presentation.domain.UserRole;
+import com.devticket.member.presentation.domain.model.SellerApplication;
+import com.devticket.member.presentation.domain.model.User;
+import com.devticket.member.presentation.domain.repository.SellerApplicationRepository;
+import com.devticket.member.presentation.domain.repository.UserRepository;
+import com.devticket.member.presentation.dto.request.SellerApplicationRequest;
+import com.devticket.member.presentation.dto.response.SellerApplicationResponse;
+import com.devticket.member.presentation.dto.response.SellerApplicationStatusResponse;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SellerApplicationServiceTest {
+
+    @InjectMocks
+    private SellerApplicationService sellerApplicationService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SellerApplicationRepository sellerApplicationRepository;
+
+    private static final UUID TEST_USER_UUID = UUID.randomUUID();
+
+    // ========== 판매자 전환 신청 ==========
+
+    @Nested
+    @DisplayName("판매자 전환 신청")
+    class Apply {
+
+        @Test
+        void 이미_SELLER인_사용자_신청시_실패() {
+            // given
+            SellerApplicationRequest request = new SellerApplicationRequest(
+                "국민은행", "123-456-789", "홍길동");
+            User sellerUser = new User("seller@test.com", "$2a$10$hashedPassword");
+            sellerUser.changeRole(UserRole.SELLER);
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(sellerUser));
+
+            // when & then
+            assertThatThrownBy(() -> sellerApplicationService.apply(TEST_USER_UUID, request))
+                .isInstanceOf(BusinessException.class);
+
+            verify(sellerApplicationRepository, never()).save(any(SellerApplication.class));
+        }
+
+        @Test
+        void PENDING_상태_중복_신청시_실패() {
+            // given
+            SellerApplicationRequest request = new SellerApplicationRequest(
+                "국민은행", "123-456-789", "홍길동");
+            User user = new User("test@test.com", "$2a$10$hashedPassword");
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
+            given(sellerApplicationRepository.existsByUserIdAndStatus(any(), any(SellerApplicationStatus.class)))
+                .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> sellerApplicationService.apply(TEST_USER_UUID, request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                    .isEqualTo(MemberErrorCode.SELLER_APPLICATION_DUPLICATED));
+
+            verify(sellerApplicationRepository, never()).save(any(SellerApplication.class));
+        }
+
+        @Test
+        void 정상_신청시_SellerApplication_생성_확인() {
+            // given
+            SellerApplicationRequest request = new SellerApplicationRequest(
+                "국민은행", "123-456-789", "홍길동");
+            User user = new User("test@test.com", "$2a$10$hashedPassword");
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
+            given(sellerApplicationRepository.existsByUserIdAndStatus(any(), any(SellerApplicationStatus.class)))
+                .willReturn(false);
+            given(sellerApplicationRepository.save(any(SellerApplication.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            SellerApplicationResponse response = sellerApplicationService.apply(TEST_USER_UUID, request);
+
+            // then
+            verify(sellerApplicationRepository).save(any(SellerApplication.class));
+        }
+
+        @Test
+        void 정상_신청시_응답에_applicationId가_포함된다() {
+            // given
+            SellerApplicationRequest request = new SellerApplicationRequest(
+                "국민은행", "123-456-789", "홍길동");
+            User user = new User("test@test.com", "$2a$10$hashedPassword");
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
+            given(sellerApplicationRepository.existsByUserIdAndStatus(any(), any(SellerApplicationStatus.class)))
+                .willReturn(false);
+            given(sellerApplicationRepository.save(any(SellerApplication.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            SellerApplicationResponse response = sellerApplicationService.apply(TEST_USER_UUID, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.applicationId()).isNotNull();
+        }
+    }
+
+    // ========== 신청 상태 조회 ==========
+
+    @Nested
+    @DisplayName("신청 상태 조회")
+    class GetMyApplication {
+
+        @Test
+        void 신청_내역_없는_사용자_조회시_실패() {
+            // given
+            User user = new User("test@test.com", "$2a$10$hashedPassword");
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
+            given(sellerApplicationRepository.findByUserId(any())).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sellerApplicationService.getMyApplication(TEST_USER_UUID))
+                .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        void 정상_조회시_status와_createdAt_반환() {
+            // given
+            User user = new User("test@test.com", "$2a$10$hashedPassword");
+            SellerApplication application = new SellerApplication(
+                user.getId(), "국민은행", "123-456-789", "홍길동");
+            given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
+            given(sellerApplicationRepository.findByUserId(any())).willReturn(Optional.of(application));
+
+            // when
+            SellerApplicationStatusResponse response = sellerApplicationService.getMyApplication(TEST_USER_UUID);
+
+            // then
+            assertThat(response.status()).isEqualTo("PENDING");
+            assertThat(response.createdAt()).isNotNull();
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #128 

## 작업 내용
- SellerApplicationService 2개 메서드에 대한 단위 테스트 총 6건 작성
- UUID 비즈니스 식별자 반영
- `any()` matcher 사용 (테스트에서 JPA id가 null이므로 anyLong() 불가)

## 변경 사항
- `src/test/java/com/devticket/member/application/SellerApplicationServiceTest.java` — 신규 생성

## 테스트
- [ ] 단위 테스트 통과
- [ ] Swagger 동작 확인

## 참고 사항
- **CI 실패 허용 머지** — SellerApplicationService가 현재 stub 상태이므로 테스트는 전부 실패합니다