### PR TITLE
[Gateway] feat: 프로필 미완성 사용자 API 접근 차단 필터 추가

### DIFF
--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/config/RoutePolicy.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/config/RoutePolicy.java
@@ -21,6 +21,15 @@ public final class RoutePolicy {
 
     private static final PathPatternParser PARSER = new PathPatternParser();
 
+    // 프로필 미완성 사용자도 접근 허용할 경로 (패턴)
+    public static final List<PathPattern> PROFILE_EXEMPT_PATTERNS = List.of(
+        new PathPatternParser().parse("/api/auth/**")
+    );
+
+    public static final List<PathPattern> PROFILE_EXEMPT_POST_PATTERNS = List.of(
+        new PathPatternParser().parse("/api/users/profile")
+    );
+
     // ──────────────────────────────────────────────
     // 인증 불필요 (비로그인 허용)
     // ──────────────────────────────────────────────

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/exception/GatewayErrorCode.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/exception/GatewayErrorCode.java
@@ -14,7 +14,8 @@ public enum GatewayErrorCode {
     INTERNAL_SERVER_ERROR(500, "COMMON_006", "서버 내부 오류가 발생했습니다."),
     SERVICE_CONNECT_FAILED(502, "COMMON_007", "외부 서비스 연동에 실패했습니다."),
     SERVICE_UNAVAILABLE(503, "COMMON_008", "서비스를 일시적으로 이용할 수 없습니다."),
-    RATE_LIMIT_EXCEEDED(429, "COMMON_009", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.");
+    RATE_LIMIT_EXCEEDED(429, "COMMON_009", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
+    PROFILE_INCOMPLETE(403, "COMMON_010", "프로필 설정을 완료해야 서비스를 이용할 수 있습니다.");
 
     private final int status;
     private final String code;

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/security/JwtAuthenticationFilter.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/security/JwtAuthenticationFilter.java
@@ -25,6 +25,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
     private static final String HEADER_USER_ID = "X-User-Id";
     private static final String HEADER_USER_EMAIL = "X-User-Email";
     private static final String HEADER_USER_ROLE = "X-User-Role";
+    private static final String HEADER_PROFILE_COMPLETED = "X-Profile-Completed";
 
     private final JwtTokenProvider jwtTokenProvider;
     private final GatewayAuthenticationEntryPoint entryPoint;
@@ -79,14 +80,23 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
                 exchange.getResponse(), GatewayErrorCode.INVALID_TOKEN);
         }
 
+        boolean profileCompleted = Boolean.TRUE.equals(claims.get("profileCompleted", Boolean.class));
+        if (!profileCompleted && !isProfileExemptPath(pathContainer, method)) {
+            log.debug("프로필 미완성 사용자 차단: path={}", pathContainer.value());
+            return entryPoint.writeErrorResponse(
+                exchange.getResponse(), GatewayErrorCode.PROFILE_INCOMPLETE);
+        }
+
         ServerHttpRequest mutatedRequest = request.mutate()
             .headers(headers -> {
                 headers.remove(HEADER_USER_ID);
                 headers.remove(HEADER_USER_EMAIL);
                 headers.remove(HEADER_USER_ROLE);
+                headers.remove(HEADER_PROFILE_COMPLETED);
                 headers.add(HEADER_USER_ID, userId);
                 headers.add(HEADER_USER_EMAIL, email);
                 headers.add(HEADER_USER_ROLE, role);
+                headers.add(HEADER_PROFILE_COMPLETED, String.valueOf(profileCompleted));
             })
             .build();
 
@@ -115,12 +125,21 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
         return RoutePolicy.matchesAny(RoutePolicy.HEALTH_PATTERNS, path);
     }
 
+    private boolean isProfileExemptPath(PathContainer path, HttpMethod method) {
+        if (RoutePolicy.matchesAny(RoutePolicy.PROFILE_EXEMPT_PATTERNS, path)) {
+            return true;
+        }
+        return HttpMethod.POST.equals(method)
+            && RoutePolicy.matchesAny(RoutePolicy.PROFILE_EXEMPT_POST_PATTERNS, path);
+    }
+
     private ServerHttpRequest removeUserHeaders(ServerHttpRequest request) {
         return request.mutate()
             .headers(headers -> {
                 headers.remove(HEADER_USER_ID);
                 headers.remove(HEADER_USER_EMAIL);
                 headers.remove(HEADER_USER_ROLE);
+                headers.remove(HEADER_PROFILE_COMPLETED);
             })
             .build();
     }

--- a/apigateway/src/test/java/com/devticket/apigateway/infrastructure/security/JwtAuthenticationFilterTest.java
+++ b/apigateway/src/test/java/com/devticket/apigateway/infrastructure/security/JwtAuthenticationFilterTest.java
@@ -53,6 +53,95 @@ class JwtAuthenticationFilterTest {
     }
 
     // ──────────────────────────────────────────────
+    // 프로필 미완성 사용자 차단 테스트
+    // ──────────────────────────────────────────────
+
+    @Test
+    void 프로필_미완성_사용자가_일반_API_요청시_403_COMMON_009() {
+        String token = JwtTestHelper.createValidTokenWithProfile("42", "user@test.com", "USER", false);
+
+        webTestClient.get()
+            .uri("/api/cart")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().isForbidden()
+            .expectBody()
+            .jsonPath("$.status").isEqualTo(403)
+            .jsonPath("$.code").isEqualTo("COMMON_010")
+            .jsonPath("$.message").isEqualTo("프로필 설정을 완료해야 서비스를 이용할 수 있습니다.")
+            .jsonPath("$.timestamp").exists();
+    }
+
+    @Test
+    void 프로필_미완성_사용자가_POST_api_users_profile_요청시_통과() {
+        String token = JwtTestHelper.createValidTokenWithProfile("42", "user@test.com", "USER", false);
+
+        webTestClient.post()
+            .uri("/api/users/profile")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void 프로필_미완성_사용자가_api_auth_요청시_통과() {
+        String token = JwtTestHelper.createValidTokenWithProfile("42", "user@test.com", "USER", false);
+
+        webTestClient.post()
+            .uri("/api/auth/logout")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void 프로필_완성_사용자는_모든_API_정상_통과() {
+        String token = JwtTestHelper.createValidTokenWithProfile("42", "user@test.com", "USER", true);
+
+        webTestClient.get()
+            .uri("/api/cart")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().value(status -> {
+                assertThat(status).isNotEqualTo(401);
+                assertThat(status).isNotEqualTo(403);
+            });
+    }
+
+    @Test
+    void 프로필_미완성_사용자가_orders_요청시_403_반환() {
+        String token = JwtTestHelper.createValidTokenWithProfile("42", "user@test.com", "USER", false);
+
+        webTestClient.get()
+            .uri("/api/orders")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().isForbidden()
+            .expectBody()
+            .jsonPath("$.code").isEqualTo("COMMON_010");
+    }
+
+    @Test
+    void 프로필_미완성_사용자가_GET_api_users_profile_은_차단() {
+        // POST만 허용, GET은 차단
+        String token = JwtTestHelper.createValidTokenWithProfile("42", "user@test.com", "USER", false);
+
+        webTestClient.get()
+            .uri("/api/users/profile")
+            .header("Authorization", "Bearer " + token)
+            .exchange()
+            .expectStatus().isForbidden()
+            .expectBody()
+            .jsonPath("$.code").isEqualTo("COMMON_010");
+    }
+
+    // ──────────────────────────────────────────────
     // 인증 실패 테스트
     // ──────────────────────────────────────────────
 

--- a/apigateway/src/test/java/com/devticket/apigateway/support/JwtTestHelper.java
+++ b/apigateway/src/test/java/com/devticket/apigateway/support/JwtTestHelper.java
@@ -15,15 +15,20 @@ public class JwtTestHelper {
     /**
      * 유효한 토큰 생성.
      */
-    public static String createValidToken(String userId, String email, String role) {
+    public static String createValidTokenWithProfile(String userId, String email, String role, boolean profileCompleted) {
         return Jwts.builder()
             .subject(userId)
             .claim("email", email)
             .claim("role", role)
+            .claim("profileCompleted", profileCompleted)
             .issuedAt(new Date())
-            .expiration(new Date(System.currentTimeMillis() + 1800000))
+            .expiration(new Date(System.currentTimeMillis() + 1000 * 60 * 30))
             .signWith(SECRET_KEY)
             .compact();
+    }
+
+    public static String createValidToken(String userId, String email, String role) {
+        return createValidTokenWithProfile(userId, email, role, true);
     }
 
     /**


### PR DESCRIPTION
## 관련 이슈
- close #144

## 작업 내용
- `JwtAuthenticationFilter`에 `profileCompleted` 클레임 파싱 및 차단 로직 추가
- `RoutePolicy`에 `PROFILE_EXEMPT_PATTERNS`, `PROFILE_EXEMPT_POST_PATTERNS` 상수 추가
- `GatewayErrorCode`에 `PROFILE_INCOMPLETE` (COMMON_010, 403) 추가
- `JwtTestHelper.createValidTokenWithProfile()` 추가 및 기존 `createValidToken()` 위임 처리
- 프로필 미완성 차단 관련 테스트 케이스 6개 추가

## 변경 사항
- `JwtAuthenticationFilter.java` — claims 파싱 후 profileCompleted 체크 블록 추가, X-Profile-Completed 헤더 하위 서비스 전달
- `RoutePolicy.java` — PROFILE_EXEMPT_PATTERNS, PROFILE_EXEMPT_POST_PATTERNS 추가
- `GatewayErrorCode.java` — PROFILE_INCOMPLETE(403, "COMMON_010") 추가
- `JwtTestHelper.java` — createValidTokenWithProfile() 추가
- `JwtAuthenticationFilterTest.java` — 프로필 차단/허용 테스트 케이스 추가

## 테스트
- [x] 단위 테스트 통과
- [x] 통합 테스트 통과

## 참고 사항
- COMMON_005("접근 권한이 없습니다.")는 역할 기반 차단용으로 유지, 프로필 미완성 차단은 COMMON_010으로 분리
- Member 서비스의 `JwtTokenProvider`에서 토큰 발급 시 `profileCompleted` 클레임을 포함해야 정상 동작함 (별도 작업 필요)
- `POST /api/users/profile`만 허용, `GET /api/users/profile`은 차단 대상