### PR TITLE
[Event] test: 판매자 등록 이벤트 목록 조회 및 권한 검증 테스트 구현

### DIFF
--- a/event/src/test/java/com/devticket/event/application/EventServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventServiceTest.java
@@ -219,4 +219,109 @@ class EventServiceTest {
         assertThat(response.totalElements()).isZero();
         assertThat(response.content()).isEmpty();
     }
+
+    // 판매자 등록 이벤트 목록 조회 테스트
+
+    @Test
+    void 일반_조회시_공개된_상태의_이벤트만_조회조건으로_전달된다() {
+        // given
+        EventListRequest request = new EventListRequest("스프링", EventCategory.MEETUP, List.of(1L, 2L), null, null);
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Event> mockPage = EventTestFixture.createEventPage();
+
+        // 서비스 내부에서 계산될 공개 허용 상태값들
+        List<EventStatus> publicStatuses = List.of(EventStatus.ON_SALE, EventStatus.SOLD_OUT, EventStatus.SALE_ENDED);
+
+        // 파라미터가 해체되어 전달됨을 검증
+        when(eventRepository.searchEvents("스프링", EventCategory.MEETUP, List.of(1L, 2L), null, publicStatuses, pageable))
+            .thenReturn(mockPage);
+
+        // when (currentUserId가 null)
+        EventListResponse response = eventService.getEventList(request, null, pageable);
+
+        // then
+        assertThat(response.totalElements()).isEqualTo(mockPage.getTotalElements());
+        verify(eventRepository).searchEvents("스프링", EventCategory.MEETUP, List.of(1L, 2L), null, publicStatuses, pageable);
+    }
+
+    @Test
+    void 판매자_본인_전체조회시_상태제한없이_전달된다() {
+        // given
+        UUID sellerId = UUID.randomUUID();
+        EventListRequest request = new EventListRequest(null, null, null, sellerId, null);
+        Pageable pageable = PageRequest.of(0, 20);
+
+        when(eventRepository.searchEvents(null, null, null, sellerId, null, pageable))
+            .thenReturn(EventTestFixture.createEventPage());
+
+        // when (currentUserId와 request의 sellerId가 일치함)
+        EventListResponse response = eventService.getEventList(request, sellerId, pageable);
+
+        // then
+        assertThat(response).isNotNull();
+        verify(eventRepository).searchEvents(null, null, null, sellerId, null, pageable);
+    }
+
+    @Test
+    void 판매자_본인_특정상태_조회시_해당상태가_전달된다() {
+        // given
+        UUID sellerId = UUID.randomUUID();
+        EventListRequest request = new EventListRequest(null, null, null, sellerId, EventStatus.DRAFT);
+        Pageable pageable = PageRequest.of(0, 20);
+
+        when(eventRepository.searchEvents(null, null, null, sellerId, List.of(EventStatus.DRAFT), pageable))
+            .thenReturn(EventTestFixture.createEventPage());
+
+        // when
+        EventListResponse response = eventService.getEventList(request, sellerId, pageable);
+
+        // then
+        assertThat(response).isNotNull();
+        verify(eventRepository).searchEvents(null, null, null, sellerId, List.of(EventStatus.DRAFT), pageable);
+    }
+
+    @Test
+    void 타인_비공개_이벤트_조회시_권한예외_발생() {
+        // given
+        UUID sellerId = UUID.randomUUID();
+        UUID otherUserId = UUID.randomUUID(); // 다른 사용자 (타인)
+        EventListRequest request = new EventListRequest(null, null, null, sellerId, EventStatus.DRAFT);
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when & then
+        assertThatThrownBy(() -> eventService.getEventList(request, otherUserId, pageable))
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(EventErrorCode.UNAUTHORIZED_SELLER.getMessage());
+    }
+
+    @Test
+    void 비로그인_사용자_비공개_이벤트_조회시_권한예외_발생() {
+        // given
+        EventListRequest request = new EventListRequest(null, null, null, null, EventStatus.DRAFT);
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when & then (currentUserId에 null 전달)
+        assertThatThrownBy(() -> eventService.getEventList(request, null, pageable))
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(EventErrorCode.UNAUTHORIZED_SELLER.getMessage());
+    }
+
+    @Test
+    void 검색결과가_없을경우_빈_리스트반환() {
+        // given
+        EventListRequest request = new EventListRequest("없는키워드", null, null, null, null);
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Event> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+        List<EventStatus> publicStatuses = List.of(EventStatus.ON_SALE, EventStatus.SOLD_OUT, EventStatus.SALE_ENDED);
+
+        when(eventRepository.searchEvents("없는키워드", null, null, null, publicStatuses, pageable))
+            .thenReturn(emptyPage);
+
+        // when
+        EventListResponse response = eventService.getEventList(request, null, pageable);
+
+        // then
+        assertThat(response.totalElements()).isZero();
+        assertThat(response.content()).isEmpty();
+    }
 }

--- a/event/src/test/java/com/devticket/event/presentation/controller/EventControllerTest.java
+++ b/event/src/test/java/com/devticket/event/presentation/controller/EventControllerTest.java
@@ -222,4 +222,79 @@ class EventControllerTest {
             .andDo(print())
             .andExpect(status().isBadRequest());
     }
+
+    // 판매자 등록 이벤트 목록 조회 테스트
+
+    @Test
+    void 헤더없이_일반목록_조회_파라미터_전달() throws Exception {
+        // given
+        EventListResponse mockResponse = EventTestFixture.createEventListResponse();
+
+        // currentUserId 자리에 isNull() 매칭
+        when(eventService.getEventList(any(EventListRequest.class), isNull(), any(Pageable.class)))
+            .thenReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/events")
+                .param("keyword", "스프링")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value(200));
+
+        // verify
+        ArgumentCaptor<EventListRequest> requestCaptor = ArgumentCaptor.forClass(EventListRequest.class);
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+
+        verify(eventService).getEventList(requestCaptor.capture(), isNull(), pageableCaptor.capture());
+
+        assertThat(requestCaptor.getValue().keyword()).isEqualTo("스프링");
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(20); // @PageableDefault 기본값
+    }
+
+    @Test
+    void 판매자_본인이벤트_조회_파라미터_바인딩() throws Exception {
+        // given
+        UUID sellerId = UUID.randomUUID();
+        EventListResponse mockResponse = EventTestFixture.createEventListResponse();
+
+        // 헤더 값(sellerId)이 서비스의 두 번째 파라미터로 전달되는지 eq()로 매칭
+        when(eventService.getEventList(any(EventListRequest.class), eq(sellerId), any(Pageable.class)))
+            .thenReturn(mockResponse);
+
+        // when & then (새로 추가된 sellerId, status 포함한 통합 테스트)
+        mockMvc.perform(get("/api/v1/events")
+                .header("X-User-Id", sellerId.toString())
+                .param("sellerId", sellerId.toString())
+                .param("status", "DRAFT")
+                .param("category", "MEETUP")
+                .param("techStacks", "1", "2")
+                .param("page", "1")
+                .param("size", "10")
+                .param("sort", "price,desc")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk());
+
+        // verify
+        ArgumentCaptor<EventListRequest> requestCaptor = ArgumentCaptor.forClass(EventListRequest.class);
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+
+        verify(eventService).getEventList(requestCaptor.capture(), eq(sellerId), pageableCaptor.capture());
+
+        // 1. DTO 필드 검증
+        EventListRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.sellerId()).isEqualTo(sellerId);
+        assertThat(capturedRequest.status()).isEqualTo(EventStatus.DRAFT);
+        assertThat(capturedRequest.category()).isEqualTo(EventCategory.MEETUP);
+        assertThat(capturedRequest.techStacks()).containsExactly(1L, 2L);
+
+        // 2. 페이징 및 정렬 검증
+        Pageable capturedPageable = pageableCaptor.getValue();
+        assertThat(capturedPageable.getPageNumber()).isEqualTo(1);
+        assertThat(capturedPageable.getPageSize()).isEqualTo(10);
+        assertThat(capturedPageable.getSort().getOrderFor("price").getDirection())
+            .isEqualTo(Sort.Direction.DESC);
+    }
+
 }


### PR DESCRIPTION
## 서비스
- [ ] Gateway
- [ ] Member
- [x] Event
- [ ] Commerce
- [ ] Payment
- [ ] Settlement
- [ ] Log
- [ ] Admin

## 기능 설명
판매자 전용 이벤트 목록 조회 기능의 통합에 따른 **비즈니스 로직의 무결성**과 **계층 간 의존성 규칙(DIP)** 준수 여부를 검증하기 위한 단위 테스트를 구현했습니다.

## 작업 내용
- [x] **계층 간 의존성 리팩토링 반영 (DIP 준수):**
    - `Infrastructure` 계층이 `Presentation` DTO(`EventListRequest`)를 직접 참조하던 역의존 문제를 해결했습니다.
    - 서비스 계층에서 파라미터를 해체하여 전달하도록 수정함에 따라, `Repository` 호출 시 개별 파라미터가 정확히 매핑되는지 테스트 코드로 검증했습니다.
- [x] **권한 기반 상태 필터링 로직 검증 (Service):**
    - **본인 조회:** 판매자 본인 요청 시 `allowedStatuses`가 제한 없이(또는 요청한 대로) 계산되어 전달되는지 확인했습니다.
    - **일반 조회:** 비로그인/타인 요청 시 공개 상태(`ON_SALE`, `SOLD_OUT`, `SALE_ENDED`)만 강제로 필터링되도록 서비스에서 조건이 생성되는지 검증했습니다.
    - **권한 방어:** 타인의 비공개 이벤트 접근 시 `UNAUTHORIZED_SELLER` 예외가 정상 발생함을 확인했습니다.
- [x] **컨트롤러 바인딩 및 엣지 케이스 테스트 (Controller):**
    - `X-User-Id` 헤더와 신규 쿼리 파라미터(`sellerId`, `status`)가 DTO에 누락 없이 바인딩되는지 검증했습니다.
    - 잘못된 Enum 값 요청 시 Spring의 `MethodArgumentTypeMismatchException`을 통해 `400 Bad Request`가 반환되는 엣지 케이스를 추가했습니다.

## API 엔드포인트
- `GET /api/v1/events`

## 참고 문서 및 관련 이슈
- **관련 Issue:** #201 

## 특이사항 (Review Note)
- `EventRepositoryImpl`은 이제 비즈니스 로직(권한 판단)을 전혀 모른 채, 서비스에서 결정해준 `statuses` 리스트를 기반으로 순수하게 DB 조회만 수행하도록 단일 책임 원칙을 강화했습니다.
- MockMvc 테스트 시 `@PageableDefault`에 의한 기본 페이징 동작(0페이지, 20사이즈)이 서비스 계층까지 잘 전달되는지 `ArgumentCaptor`를 통해 확인을 마쳤습니다.