### PR TITLE
[Commerce] feat :  장바구니에서 주문하기 기능

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
@@ -47,17 +47,14 @@ public class CartService implements CartUseCase {
 
         //DB 작업 : 장바구니 확보와 장바구니에 아이템 담기 로직을 한개 트랜잭션 단위로 묶음.
         //Cart와 CartItem -> 객체참조x, 연관관계 매핑 없이 식별자참조.
-        record SaveResult(Cart cart, CartItem cartItem) {
+        Cart cart = findOrCreateCart(userId);
 
-        }
-        SaveResult result = transactionTemplate.execute(status -> {
-            Cart cart = findOrCreateCart(userId);
-            CartItem item = addOrUpdateCartItem(cart.getId(), request);
-            return new SaveResult(cart, item);
-        });
+        CartItem cartItem = transactionTemplate.execute(status ->
+            addOrUpdateCartItem(cart.getId(), request)
+        );
 
         //응답데이터 구성
-        return CartItemResponse.of(result.cart(), result.cartItem(), event.title(), event.price());
+        return CartItemResponse.of(cart, cartItem, event.title(), event.price());
     }
 
     // =========================================================================
@@ -82,10 +79,12 @@ public class CartService implements CartUseCase {
     private CartItem addOrUpdateCartItem(Long cartId, CartItemRequest request) {
         return cartItemRepository.findByCartIdAndEventId(cartId, request.eventId())
             .map(existingItem -> {
+                log.info("[CartService] 기존 아이템 수량 추가: cartId={}, eventId={}", cartId, request.eventId());
                 existingItem.addQuantity(request.quantity());
-                return existingItem;
+                return cartItemRepository.save(existingItem);
             })
             .orElseGet(() -> {
+                log.info("[CartService] 신규 아이템 생성: cartId={}, eventId={}", cartId, request.eventId());
                 CartItem newItem = CartItem.create(cartId, request.eventId(), request.quantity());
                 return cartItemRepository.save(newItem);
             });

--- a/commerce/src/main/java/com/devticket/commerce/cart/application/usecase/CartItemUseCase.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/usecase/CartItemUseCase.java
@@ -6,4 +6,5 @@ import com.devticket.commerce.cart.presentation.dto.res.CartItemResponse;
 public interface CartItemUseCase {
 
     CartItemResponse save(Long userId, CartItemRequest request);
+    
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/domain/model/CartItem.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/domain/model/CartItem.java
@@ -6,6 +6,8 @@ import com.devticket.commerce.common.exception.BusinessException;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -26,6 +28,9 @@ import lombok.experimental.SuperBuilder;
 public class CartItem extends BaseEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     @Column(name = "cart_id")
     @Schema(description = "장바구니 항목")
     private Long cartId;

--- a/commerce/src/main/java/com/devticket/commerce/cart/domain/repository/CartItemRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/domain/repository/CartItemRepository.java
@@ -1,11 +1,17 @@
 package com.devticket.commerce.cart.domain.repository;
 
 import com.devticket.commerce.cart.domain.model.CartItem;
+import java.util.List;
 import java.util.Optional;
 
 public interface CartItemRepository {
 
     CartItem save(CartItem cartItem);
 
+    List<CartItem> findAllById(List<Long> cartItemIds);
+
     Optional<CartItem> findByCartIdAndEventId(Long cartId, Long eventId);
+
+    //장바구니 아이템 삭제
+    void deleteAllInBatch(List<CartItem> cartItems);
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.devticket.commerce.cart.infrastructure.persistence;
 
 import com.devticket.commerce.cart.domain.model.CartItem;
 import com.devticket.commerce.cart.domain.repository.CartItemRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class CartItemRepositoryAdapter implements CartItemRepository {
 
-    public final CartItemJpaRepository cartItemJpaRepository;
+    private final CartItemJpaRepository cartItemJpaRepository;
 
     @Override
     public CartItem save(CartItem cartItem) {
@@ -18,7 +19,17 @@ public class CartItemRepositoryAdapter implements CartItemRepository {
     }
 
     @Override
+    public List<CartItem> findAllById(List<Long> cartItemIds) {
+        return cartItemJpaRepository.findAllById(cartItemIds);
+    }
+
+    @Override
     public Optional<CartItem> findByCartIdAndEventId(Long cartId, Long eventId) {
         return cartItemJpaRepository.findByCartIdAndEventId(cartId, eventId);
+    }
+
+    @Override
+    public void deleteAllInBatch(List<CartItem> cartItems) {
+        cartItemJpaRepository.deleteAllInBatch(cartItems);
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartRepositoryAdapter.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class CartRepositoryAdapter implements CartRepository {
 
-    public final CartJpaRepository cartJpaRepository;
+    private final CartJpaRepository cartJpaRepository;
 
     @Override
     public Optional<Cart> findByUserId(UUID userId) {

--- a/commerce/src/main/java/com/devticket/commerce/mock/controller/MockEventController.java
+++ b/commerce/src/main/java/com/devticket/commerce/mock/controller/MockEventController.java
@@ -1,8 +1,10 @@
 package com.devticket.commerce.mock.controller;
 
 import com.devticket.commerce.cart.infrastructure.external.client.dto.InternalPurchaseValidationResponse;
+import com.devticket.commerce.order.infrastructure.external.client.dto.InternalBulkStockAdjustmentRequest;
 import com.devticket.commerce.order.infrastructure.external.client.dto.InternalStockAdjustmentRequest;
 import com.devticket.commerce.order.infrastructure.external.client.dto.InternalStockAdjustmentResponse;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -45,7 +47,25 @@ public class MockEventController {
             eventId,
             true,
             100,
-            "이벤트 제목"
+            "이벤트 제목",
+            30000,
+            10
         );
+    }
+
+    @PatchMapping("/{eventId}/stock-adjustments")
+    public List<InternalStockAdjustmentResponse> mockBulkAdjustStock(
+        @RequestBody InternalBulkStockAdjustmentRequest request
+    ) {
+        return request.eventItems().stream()
+            .map(item -> new InternalStockAdjustmentResponse(
+                item.eventId(),
+                true,
+                100,
+                "이벤트 제목",
+                30000,
+                10
+            ))
+            .toList();
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -1,0 +1,128 @@
+package com.devticket.commerce.order.application.service;
+
+import com.devticket.commerce.cart.domain.exception.EventErrorCode;
+import com.devticket.commerce.cart.domain.model.CartItem;
+import com.devticket.commerce.cart.domain.repository.CartItemRepository;
+import com.devticket.commerce.common.exception.BusinessException;
+import com.devticket.commerce.order.application.usecase.OrderUsecase;
+import com.devticket.commerce.order.domain.exception.OrderErrorCode;
+import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.model.OrderItem;
+import com.devticket.commerce.order.domain.repository.OrderItemRepository;
+import com.devticket.commerce.order.domain.repository.OrderRepository;
+import com.devticket.commerce.order.infrastructure.external.client.OrderToEventClient;
+import com.devticket.commerce.order.infrastructure.external.client.dto.InternalBulkStockAdjustmentRequest;
+import com.devticket.commerce.order.infrastructure.external.client.dto.InternalStockAdjustmentResponse;
+import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
+import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class OrderService implements OrderUsecase {
+
+    private final OrderToEventClient orderToEventClient;
+    private final CartItemRepository cartItemRepository;
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    // ==== Public Methods (Main Flow) ====================================
+
+    // 장바구니에서 상품선택 후 주문하기 진행
+    @Transactional
+    @Override
+    public OrderResponse createOrderByCart(UUID userId, CartOrderRequest request) {
+        //장바구니 아이템 조회
+        List<CartItem> cartItems = cartItemRepository.findAllById(request.cartItemIds());
+        //재고 선차감 : Event API호출
+        List<InternalStockAdjustmentResponse> eventResults = orderToEventClient.adjustStocks(
+            InternalBulkStockAdjustmentRequest.createForOrder(cartItems));
+
+        try {
+            //총 주문 금액 계산
+            int totalAmount = calculateTotalAmount(cartItems, eventResults);
+            //재고 선차감 성공시 Order생성
+            Order order = Order.create(userId, totalAmount);
+            orderRepository.save(order);
+            //OrderItem생성
+            List<OrderItem> savedOrderItems = createOrderItem(order.getId(), userId, cartItems, eventResults);
+            //주문완료건 장바구니에서 삭제처리
+            if (!cartItems.isEmpty()) {
+                cartItemRepository.deleteAllInBatch(cartItems);
+            }
+            //응답데이터 변환
+            Map<Long, String> eventTitles = eventResults.stream()
+                .collect(Collectors.toMap(
+                    InternalStockAdjustmentResponse::eventId,
+                    InternalStockAdjustmentResponse::eventTitle
+                ));
+            return OrderResponse.of(order, savedOrderItems, eventTitles);
+
+        } catch (Exception e) {
+            //주문 생성 실패시 선차감한 재고를 원복하는 api호출
+            List<InternalStockAdjustmentResponse> rollbackEventResults = orderToEventClient.adjustStocks(
+                InternalBulkStockAdjustmentRequest.createForCancel(cartItems));
+            throw new BusinessException(OrderErrorCode.ORDER_CREATION_FAILED);
+        }
+    }
+
+    // ==== Private Helpers (Logic & Validation) ==========================
+
+    private int calculateTotalAmount(List<CartItem> cartItems, List<InternalStockAdjustmentResponse> eventItems) {
+        int totalAmount = 0;
+        Map<Long, Integer> priceMap = eventItems.stream()
+            .collect(
+                Collectors.toMap(InternalStockAdjustmentResponse::eventId, InternalStockAdjustmentResponse::price));
+
+        return cartItems.stream()
+            .mapToInt(cartItem -> {
+                Integer currentPrice = priceMap.get(cartItem.getEventId());
+
+                if (currentPrice == null) {
+                    throw new BusinessException(EventErrorCode.EVENT_NOT_FOUND);
+                }
+
+                return currentPrice * cartItem.getQuantity();
+            })
+            .sum();
+    }
+
+    private List<OrderItem> createOrderItem(Long orderId, UUID userId, List<CartItem> cartItems,
+        List<InternalStockAdjustmentResponse> eventItems) {
+
+        Map<Long, InternalStockAdjustmentResponse> eventMap = eventItems.stream()
+            .collect(Collectors.toMap(InternalStockAdjustmentResponse::eventId, r -> r));
+
+        List<OrderItem> orderItems = cartItems.stream()
+            .map(cartItem -> {
+                InternalStockAdjustmentResponse detail = eventMap.get(cartItem.getEventId());
+
+                if (detail == null) {
+                    throw new BusinessException(EventErrorCode.EVENT_NOT_FOUND);
+                }
+
+                return OrderItem.create(
+                    orderId,         // 발급된 부모 ID 주입
+                    userId,                // 유저 식별값
+                    cartItem.getEventId(), // 이벤트 ID
+                    detail.price(),        // 최신 가격 스냅샷
+                    cartItem.getQuantity(),// 주문 수량
+                    detail.maxQuantity()   // 인당 제한 수량 검증용
+                );
+            })
+            .toList();
+
+        return orderItemRepository.saveAll(orderItems);
+    }
+
+
+}
+
+

--- a/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
@@ -1,0 +1,13 @@
+package com.devticket.commerce.order.application.usecase;
+
+import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
+import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
+import java.util.UUID;
+
+public interface OrderUsecase {
+
+    //주문하기_장바구니에서 단건,다건 주문
+    OrderResponse createOrderByCart(UUID userId, CartOrderRequest request);
+
+
+}

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/exception/OrderErrorCode.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/exception/OrderErrorCode.java
@@ -21,7 +21,8 @@ public enum OrderErrorCode implements ErrorCode {
     CANNOT_CHANGE_AMOUNT_AFTER_PAID(400, "ORDER_010", "결제가 완료된 주문은 수량을 변경할 수 없습니다."),
     INVALID_QUANTITY(400, "ORDER_011", "유효하지 않은 주문 수량입니다."),
     EMPTY_ORDER_ITEMS(400, "ORDER_012", "주문한 상품이 존재하지 않습니다."),
-    INVALID_TOTAL_AMOUNT(400, "ORDER_013", "총 주문 금액이 유효하지 않습니다.");
+    INVALID_TOTAL_AMOUNT(400, "ORDER_013", "총 주문 금액이 유효하지 않습니다."),
+    ORDER_CREATION_FAILED(500, "ORDER_014", "주문 생성 중 내부 오류가 발생했습니다.");
 
 
     private final int status;

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/model/Order.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/model/Order.java
@@ -15,7 +15,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -65,7 +64,9 @@ public class Order extends BaseEntity {
 
     public static Order create(
         UUID userId,
-        List<OrderItem> items
+        int totalAmount
+        //List<OrderItem> items
+
     ) {
         LocalDateTime now = LocalDateTime.now();
 
@@ -74,24 +75,24 @@ public class Order extends BaseEntity {
         String uniqueSuffix = UUID.randomUUID().toString().substring(0, 8);
         String generatedOrderNumber = String.format("%s-%s", datePrefix, uniqueSuffix);
 
-        // 최소 주문 상품 존재 여부 확인
-        if (items == null || items.isEmpty()) {
-            throw new BusinessException(OrderErrorCode.EMPTY_ORDER_ITEMS);
-        }
+//        // 최소 주문 상품 존재 여부 확인
+//        if (items == null || items.isEmpty()) {
+//            throw new BusinessException(OrderErrorCode.EMPTY_ORDER_ITEMS);
+//        }
+//
+//        // OrderItem들의 subtotalAmount 합계
+//        int calculatedTotal = items.stream()
+//            .mapToInt(OrderItem::getSubtotalAmount)
+//            .sum();
 
-        // OrderItem들의 subtotalAmount 합계
-        int calculatedTotal = items.stream()
-            .mapToInt(OrderItem::getSubtotalAmount)
-            .sum();
-
-        validateTotalAmount(calculatedTotal);
+        validateTotalAmount(totalAmount);
 
         return Order.builder()
             .orderId(UUID.randomUUID())
             .userId(userId)
             .orderNumber(generatedOrderNumber)
             .paymentMethod(null)
-            .totalAmount(calculatedTotal)
+            .totalAmount(totalAmount)
             .status(OrderStatus.CREATED)
             .orderedAt(now)
             .deletedAt(null)

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderItemRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderItemRepository.java
@@ -1,8 +1,12 @@
 package com.devticket.commerce.order.domain.repository;
 
 import com.devticket.commerce.order.domain.model.OrderItem;
+import java.util.List;
 
 public interface OrderItemRepository {
 
     OrderItem save(OrderItem OrderItem);
+
+    List<OrderItem> saveAll(List<OrderItem> orderItems);
+    
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/OrderToEventClient.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/OrderToEventClient.java
@@ -2,10 +2,12 @@ package com.devticket.commerce.order.infrastructure.external.client;
 
 import com.devticket.commerce.common.exception.BusinessException;
 import com.devticket.commerce.common.exception.CommonErrorCode;
-import com.devticket.commerce.order.infrastructure.external.client.dto.InternalStockAdjustmentRequest;
+import com.devticket.commerce.order.infrastructure.external.client.dto.InternalBulkStockAdjustmentRequest;
 import com.devticket.commerce.order.infrastructure.external.client.dto.InternalStockAdjustmentResponse;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -21,29 +23,31 @@ public class OrderToEventClient {
         this.restClient = restClient;
     }
 
-    //주문 생성,취소시 -> Event의 재고 차감,증감
-    public InternalStockAdjustmentResponse adjustStock(Long eventId, InternalStockAdjustmentRequest request) {
+    // 주문 생성,취소시 -> 여러건의 Event의 재고 차감,증감
+    public List<InternalStockAdjustmentResponse> adjustStocks(InternalBulkStockAdjustmentRequest request) {
         try {
-            log.info("[EventClient] Adjusting stock : eventId={}, delta={}", eventId, request.quantityDelta());
+            // [추가] 보낼 데이터의 내용을 구체적으로 로깅 (JSON 구조 확인용)
+            log.info("[OrderToEventClient] Bulk Request Payload: {}", request);
 
             return restClient.patch()
-                .uri("/internal/events/{eventId}/stock", eventId)
+                .uri("/internal/events/stock-adjustments")
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(request)
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    log.error("[EventClient] API Error: {} {}", res.getStatusCode(), res.getStatusText());
+                    String errorBody = res.toString();
+                    log.error("[OrderToEventClient] API Error Status: {} {}", res.getStatusCode(), res.getStatusText());
+                    log.error("[OrderToEventClient] API Error Body: {}", errorBody); // 이게 500 에러의 핵심 단서입니다.
+
                     throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
                 })
-                .body(InternalStockAdjustmentResponse.class);
-
+                .body(new ParameterizedTypeReference<List<InternalStockAdjustmentResponse>>() {
+                });
 
         } catch (BusinessException e) {
-            // 이미 정의된 비즈니스 예외는 그대로 던짐
             throw e;
         } catch (Exception e) {
-            // 연결 실패, 타임아웃 등 시스템적 장애 처리
-            log.error("[EventClient] Critical Error: ", e);
+            log.error("[OrderToEventClient] Critical Error (Network/Mapping): ", e);
             throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
     }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/dto/InternalBulkStockAdjustmentRequest.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/dto/InternalBulkStockAdjustmentRequest.java
@@ -1,0 +1,42 @@
+package com.devticket.commerce.order.infrastructure.external.client.dto;
+
+import com.devticket.commerce.cart.domain.model.CartItem;
+import java.util.List;
+
+public record InternalBulkStockAdjustmentRequest(
+    List<EventItem> eventItems
+) {
+
+    //inner record
+    public record EventItem(
+        Long eventId,
+        int quantityDelta
+    ) {
+
+    }
+
+    //정적팩토리 메서드
+    public static InternalBulkStockAdjustmentRequest createForOrder(List<CartItem> cartItems) {
+        List<EventItem> items = cartItems.stream()
+            .map(item -> new EventItem(
+                item.getEventId(),
+                -item.getQuantity()
+            ))
+            .toList();
+
+        return new InternalBulkStockAdjustmentRequest(items);
+    }
+
+
+    // 취소 시: 주문 아이템들을 재고 복구(양수) 요청으로 변환
+    public static InternalBulkStockAdjustmentRequest createForCancel(List<CartItem> cartItems) {
+        return new InternalBulkStockAdjustmentRequest(
+            cartItems.stream()
+                .map(item -> new EventItem(item.getEventId(), item.getQuantity()))
+                .toList()
+        );
+    }
+
+}
+
+

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/dto/InternalStockAdjustmentResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/dto/InternalStockAdjustmentResponse.java
@@ -4,7 +4,9 @@ public record InternalStockAdjustmentResponse(
     Long eventId,
     Boolean success,
     Integer remainingQuantity,
-    String eventTitle
+    String eventTitle,
+    Integer price,
+    Integer maxQuantity
 ) {
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderItemRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderItemRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.devticket.commerce.order.infrastructure.persistence;
 
 import com.devticket.commerce.order.domain.model.OrderItem;
 import com.devticket.commerce.order.domain.repository.OrderItemRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +15,10 @@ public class OrderItemRepositoryAdapter implements OrderItemRepository {
     @Override
     public OrderItem save(OrderItem orderItem) {
         return orderItemJpaRepository.save(orderItem);
+    }
+
+    @Override
+    public List<OrderItem> saveAll(List<OrderItem> orderItems) {
+        return orderItemJpaRepository.saveAll(orderItems);
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java
@@ -1,0 +1,39 @@
+package com.devticket.commerce.order.presentation.controller;
+
+import com.devticket.commerce.order.application.usecase.OrderUsecase;
+import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
+import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+@Tag(name = "Order API", description = "주문서 생성,수정,조회,삭제")
+public class OrderController {
+
+    private final OrderUsecase orderUsecase;
+
+    @PostMapping
+    @Operation(description = "주문하기 : 장바구니에 저장된 상품 단건,다건 주문하기")
+    public ResponseEntity<OrderResponse> createOrderByCart(
+        @RequestHeader("X-User-Id") UUID userId,
+        @RequestBody CartOrderRequest request
+    ) {
+        OrderResponse response = orderUsecase.createOrderByCart(userId, request);
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(response);
+
+    }
+
+}

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/CartOrderRequest.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/CartOrderRequest.java
@@ -1,0 +1,11 @@
+package com.devticket.commerce.order.presentation.dto.req;
+
+
+import java.util.List;
+
+//장바구니에서 주문요청
+public record CartOrderRequest(
+    List<Long> cartItemIds
+) {
+
+}

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderResponse.java
@@ -6,6 +6,7 @@ import com.devticket.commerce.order.domain.model.OrderItem;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.Builder;
 
@@ -19,10 +20,13 @@ public record OrderResponse(
     LocalDateTime createdAt
 ) {
 
-    public static OrderResponse of(Order order, List<OrderItem> orderItems, String eventTitle) {
+    public static OrderResponse of(Order order, List<OrderItem> orderItems, Map<Long, String> eventTitles) {
 
         List<OrderItemsResponse> itemResponses = orderItems.stream()
-            .map(item -> OrderItemsResponse.of(item, eventTitle))
+            .map(item -> {
+                String title = eventTitles.getOrDefault(item.getEventId(), "알 수 없는 이벤트");
+                return OrderItemsResponse.of(item, title);
+            })
             .toList();
 
         return OrderResponse.builder()


### PR DESCRIPTION
## 관련 이슈
- close #206

## 작업 내용
- 장바구니에서 주문하기 기능 service,controller,repository 작성
- 주문하기완료후 장바구니에 등록된 아이템삭제  

## 변경 사항
장바구니에서 주문하기->Event재고선차감 -> Order,OrderItem생성 -> 장바구니 CartItem 삭제

- Cart도메인
  - CartItem엔티티 - 복합키x, id필드 추가(PK) 
  - CartItemRepository-  deleteAllInBatch 주문하기 완료 후 장바구니 아이템 삭제 

- Order,OrderItem
  - OrderController, OrderRepository, OrderService

- Mock
  - MockEventController : mockBulkAdjustStock추

- Event 재고차감 api 
  - OrderToEventClient - 재고 차감요청 api호출
  - InternalStockAdjustmentResponse : Event재고차감요청 응답DTO에 필드추가 
  - InternalBulkStockAdjustmentRequest : 여러건의 Event의 재고차감 요청DTO

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항
