### PR TITLE
[Commerce] Feat : 티켓 발급 기능

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/order/domain/exception/OrderItemErrorCode.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/exception/OrderItemErrorCode.java
@@ -8,8 +8,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum OrderItemErrorCode implements ErrorCode {
 
-    EXCEED_MAX_QUANTITY(400, "ORDER_ITEM_001", "주문 가능한 수량 범위를 벗어났습니다.");
-    
+    EXCEED_MAX_QUANTITY(400, "ORDER_ITEM_001", "주문 가능한 수량 범위를 벗어났습니다."),
+    ORDER_ITEM_NOT_FOUND(404, "ORDER_ITEM_002", "존재하지 않는 주문아이템입니다.");
+
     private final int status;
     private final String code;
     private final String message;

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderItemRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderItemRepository.java
@@ -2,11 +2,14 @@ package com.devticket.commerce.order.domain.repository;
 
 import com.devticket.commerce.order.domain.model.OrderItem;
 import java.util.List;
+import java.util.UUID;
 
 public interface OrderItemRepository {
 
     OrderItem save(OrderItem OrderItem);
 
+    List<OrderItem> findAllByOrderId(UUID orderId);
+
     List<OrderItem> saveAll(List<OrderItem> orderItems);
-    
+
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderRepository.java
@@ -1,8 +1,12 @@
 package com.devticket.commerce.order.domain.repository;
 
 import com.devticket.commerce.order.domain.model.Order;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface OrderRepository {
 
     Order save(Order order);
+
+    Optional<Order> findByOrderId(UUID orderId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderItemJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderItemJpaRepository.java
@@ -1,9 +1,12 @@
 package com.devticket.commerce.order.infrastructure.persistence;
 
 import com.devticket.commerce.order.domain.model.OrderItem;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderItemJpaRepository extends JpaRepository<OrderItem, Long> {
 
 
+    List<OrderItem> findAllByOrderId(UUID orderId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderItemRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderItemRepositoryAdapter.java
@@ -3,6 +3,8 @@ package com.devticket.commerce.order.infrastructure.persistence;
 import com.devticket.commerce.order.domain.model.OrderItem;
 import com.devticket.commerce.order.domain.repository.OrderItemRepository;
 import java.util.List;
+import java.util.UUID;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -10,7 +12,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class OrderItemRepositoryAdapter implements OrderItemRepository {
 
-    public final OrderItemJpaRepository orderItemJpaRepository;
+    private final OrderItemJpaRepository orderItemJpaRepository;
 
     @Override
     public OrderItem save(OrderItem orderItem) {
@@ -20,5 +22,10 @@ public class OrderItemRepositoryAdapter implements OrderItemRepository {
     @Override
     public List<OrderItem> saveAll(List<OrderItem> orderItems) {
         return orderItemJpaRepository.saveAll(orderItems);
+    }
+
+    @Override
+    public List<OrderItem> findAllByOrderId(UUID orderId) {
+        return orderItemJpaRepository.findAllByOrderId(orderId);
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderJpaRepository.java
@@ -1,9 +1,11 @@
 package com.devticket.commerce.order.infrastructure.persistence;
 
 import com.devticket.commerce.order.domain.model.Order;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
 
-
+    Optional<Order> findByOrderId(UUID orderId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderRepositoryAdapter.java
@@ -2,6 +2,8 @@ package com.devticket.commerce.order.infrastructure.persistence;
 
 import com.devticket.commerce.order.domain.model.Order;
 import com.devticket.commerce.order.domain.repository.OrderRepository;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +16,10 @@ public class OrderRepositoryAdapter implements OrderRepository {
     @Override
     public Order save(Order order) {
         return orderJpaRepository.save(order);
+    }
+
+    @Override
+    public Optional<Order> findByOrderId(UUID orderId) {
+        return orderJpaRepository.findByOrderId(orderId);
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
@@ -1,0 +1,64 @@
+package com.devticket.commerce.ticket.application.service;
+
+import com.devticket.commerce.common.exception.BusinessException;
+import com.devticket.commerce.order.domain.exception.OrderErrorCode;
+import com.devticket.commerce.order.domain.exception.OrderItemErrorCode;
+import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.model.OrderItem;
+import com.devticket.commerce.order.domain.repository.OrderItemRepository;
+import com.devticket.commerce.order.domain.repository.OrderRepository;
+import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
+import com.devticket.commerce.ticket.domain.model.Ticket;
+import com.devticket.commerce.ticket.domain.repository.TicketRepository;
+import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
+import com.devticket.commerce.ticket.presentation.dto.res.TicketResponse;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TicketService implements TicketUsecase {
+
+    private final TicketRepository ticketRepository;
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    @Override
+    @Transactional
+    public TicketResponse createTicket(UUID userId, TicketRequest request) {
+        // Order 주문 조회
+        Order order = orderRepository.findByOrderId(request.orderId())
+            .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        // order 상태값 PAID로 변경
+        order.completePayment();
+
+        //order.id -> orderItem목록 조회
+        List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(order.getOrderId());
+        if (orderItems.isEmpty()) {
+            throw new BusinessException(OrderItemErrorCode.ORDER_ITEM_NOT_FOUND);
+        }
+
+        // OrderItem 수량별로 Ticket 생성
+        List<Ticket> tickets = orderItems.stream()
+            .flatMap(orderItem ->
+                IntStream.range(0, orderItem.getQuantity())
+                    .mapToObj(i -> Ticket.create(orderItem.getOrderItemId(), orderItem.getUserId(),
+                        orderItem.getEventId()))
+            )
+            .collect(Collectors.toList());
+
+        // 티켓 일괄 저장
+        List<Ticket> savedTickets = ticketRepository.saveAll(tickets);
+
+        //응답데이터 구성
+        return TicketResponse.of(order.getOrderId(), savedTickets);
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/application/usecase/TicketUsecase.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/application/usecase/TicketUsecase.java
@@ -1,0 +1,10 @@
+package com.devticket.commerce.ticket.application.usecase;
+
+import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
+import com.devticket.commerce.ticket.presentation.dto.res.TicketResponse;
+import java.util.UUID;
+
+public interface TicketUsecase {
+
+    TicketResponse createTicket(UUID userId, TicketRequest request);
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/domain/enums/TicketStatus.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/domain/enums/TicketStatus.java
@@ -1,0 +1,6 @@
+package com.devticket.commerce.ticket.domain.enums;
+
+public enum TicketStatus {
+    ISSUED, CANCELLED, REFUNDED
+}
+

--- a/commerce/src/main/java/com/devticket/commerce/ticket/domain/model/Ticket.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/domain/model/Ticket.java
@@ -1,0 +1,95 @@
+package com.devticket.commerce.ticket.domain.model;
+
+import com.devticket.commerce.common.entity.BaseEntity;
+import com.devticket.commerce.ticket.domain.enums.TicketStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@SuperBuilder
+@Getter
+@Table(name = "ticket", schema = "commerce")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Ticket extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    @Column(name = "ticket_id", nullable = false, unique = true)
+    UUID ticketId;
+
+    @Column(name = "order_item_id", nullable = false)
+    Long orderItemId;
+
+    @Column(name = "user_id", nullable = false)
+    UUID userId;
+
+    @Column(name = "event_id", nullable = false)
+    Long eventId;
+
+    @Column(name = "ticket_number", unique = true, length = 100, nullable = false)
+    String ticketNumber;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    TicketStatus status;
+
+    @Column(name = "issued_at", nullable = false)
+    LocalDateTime issuedAt;
+
+    @Column(name = "deleted_at")
+    LocalDateTime deletedAt;
+
+    //---- 정적 팩토리 메서드 ------------------------------
+
+    public static Ticket create(
+        Long orderItemId,
+        UUID userId,
+        Long eventId
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+        //티켓번호 생성 20250327-*******
+        String datePrefix = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String uniqueSuffix = UUID.randomUUID().toString().substring(0, 8);
+        String generatedTicketNumber = String.format("%s-%s", datePrefix, uniqueSuffix);
+
+        return Ticket.builder()
+            .ticketId(UUID.randomUUID())
+            .orderItemId(orderItemId)
+            .userId(userId)
+            .eventId(eventId)
+            .ticketNumber(generatedTicketNumber)
+            .status(TicketStatus.ISSUED)
+            .issuedAt(now)
+            .deletedAt(null)
+            .build();
+    }
+
+    //---- 비즈니스 도메인 메서드 ----------------------------
+
+    //status변경 : REFUNDED
+    public void refundTicket() {
+        this.status = TicketStatus.REFUNDED;
+    }
+
+    //status변경 : CANCELLED
+    public void cancelledTicket() {
+        this.status = TicketStatus.CANCELLED;
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/domain/model/Ticket.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/domain/model/Ticket.java
@@ -35,7 +35,7 @@ public class Ticket extends BaseEntity {
     UUID ticketId;
 
     @Column(name = "order_item_id", nullable = false)
-    Long orderItemId;
+    UUID orderItemId;
 
     @Column(name = "user_id", nullable = false)
     UUID userId;
@@ -59,7 +59,7 @@ public class Ticket extends BaseEntity {
     //---- 정적 팩토리 메서드 ------------------------------
 
     public static Ticket create(
-        Long orderItemId,
+        UUID orderItemId,
         UUID userId,
         Long eventId
     ) {

--- a/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
@@ -1,0 +1,8 @@
+package com.devticket.commerce.ticket.domain.repository;
+
+import com.devticket.commerce.ticket.domain.model.Ticket;
+
+public interface TicketRepository {
+
+    Ticket save(Ticket ticket);
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
@@ -1,8 +1,11 @@
 package com.devticket.commerce.ticket.domain.repository;
 
 import com.devticket.commerce.ticket.domain.model.Ticket;
+import java.util.List;
 
 public interface TicketRepository {
 
     Ticket save(Ticket ticket);
+
+    List<Ticket> saveAll(List<Ticket> ticketList);
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketJpaRepository.java
@@ -1,0 +1,8 @@
+package com.devticket.commerce.ticket.infrastructure.persistence;
+
+import com.devticket.commerce.ticket.domain.model.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketJpaRepository extends JpaRepository<Ticket, Long> {
+
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.devticket.commerce.ticket.infrastructure.persistence;
 
 import com.devticket.commerce.ticket.domain.model.Ticket;
 import com.devticket.commerce.ticket.domain.repository.TicketRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +15,10 @@ public class TicketRepositoryAdapter implements TicketRepository {
     @Override
     public Ticket save(Ticket ticket) {
         return ticketJpaRepository.save(ticket);
+    }
+
+    @Override
+    public List<Ticket> saveAll(List<Ticket> ticketList) {
+        return ticketJpaRepository.saveAll(ticketList);
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
@@ -1,0 +1,18 @@
+package com.devticket.commerce.ticket.infrastructure.persistence;
+
+import com.devticket.commerce.ticket.domain.model.Ticket;
+import com.devticket.commerce.ticket.domain.repository.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TicketRepositoryAdapter implements TicketRepository {
+
+    public final TicketJpaRepository ticketJpaRepository;
+
+    @Override
+    public Ticket save(Ticket ticket) {
+        return ticketJpaRepository.save(ticket);
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/TicketController.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/TicketController.java
@@ -1,0 +1,38 @@
+package com.devticket.commerce.ticket.presentation.controller;
+
+import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
+import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
+import com.devticket.commerce.ticket.presentation.dto.res.TicketResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/ticket")
+@RequiredArgsConstructor
+@Tag(name = "Ticket API")
+public class TicketController {
+
+    private final TicketUsecase ticketUsecase;
+
+    @PostMapping("/items")
+    @Operation(description = "장바구니 담기")
+    public ResponseEntity<TicketResponse> addToCart(
+        @RequestHeader("X-User-Id") UUID userId,
+        @RequestBody TicketRequest request
+    ) {
+        TicketResponse response = ticketUsecase.createTicket(userId, request);
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(response);
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/TicketController.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/TicketController.java
@@ -24,9 +24,9 @@ public class TicketController {
 
     private final TicketUsecase ticketUsecase;
 
-    @PostMapping("/items")
-    @Operation(description = "장바구니 담기")
-    public ResponseEntity<TicketResponse> addToCart(
+    @PostMapping
+    @Operation(description = "티켓 발급")
+    public ResponseEntity<TicketResponse> createTickets(
         @RequestHeader("X-User-Id") UUID userId,
         @RequestBody TicketRequest request
     ) {

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/TicketRequest.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/TicketRequest.java
@@ -1,0 +1,10 @@
+package com.devticket.commerce.ticket.presentation.dto.req;
+
+import java.util.UUID;
+
+public record TicketRequest(
+    UUID orderId
+) {
+
+
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketResponse.java
@@ -1,0 +1,43 @@
+package com.devticket.commerce.ticket.presentation.dto.res;
+
+import com.devticket.commerce.ticket.domain.model.Ticket;
+import java.util.List;
+import java.util.UUID;
+
+public record TicketResponse(
+    UUID orderId,
+    Integer totalCount,
+    List<TicketInfo> tickets
+) {
+
+    public static TicketResponse of(UUID orderId, List<Ticket> savedTickets) {
+        List<TicketInfo> ticketInfos = savedTickets.stream()
+            .map(TicketInfo::from)
+            .toList();
+
+        return new TicketResponse(
+            orderId,
+            ticketInfos.size(),
+            ticketInfos
+        );
+    }
+
+    //inner record
+    public record TicketInfo(
+        Long ticketId,
+        String ticketNumber,
+        Long eventId,
+        String status
+    ) {
+
+        public static TicketInfo from(Ticket ticket) {
+            return new TicketInfo(
+                ticket.getId(),
+                ticket.getTicketNumber(),
+                ticket.getEventId(),
+                ticket.getStatus().name()
+            );
+
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #171

## 작업 내용
Ticket발급요청 -> Ticket생성, Order상태변경

## 변경 사항
- Ticket
  -  Ticket : 엔티티
  -  TicketStatus : 티켓 상태값관리 Enums
  -  TicketErrorCode 
  -  TicketRepository,TicketJpaRepository, TicketRepositoryAdapter
  - TicketController - createTicket
  - DTO - TicketRequest,TicketResponse

- Order
  - OrderRepository - findByOrderId추가 
 
## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항