### PR TITLE
[Event] test: 판매자 이벤트 상세/현황 조회 테스트 코드 구현

### DIFF
--- a/event/src/test/java/com/devticket/event/application/EventServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventServiceTest.java
@@ -22,6 +22,8 @@ import com.devticket.event.presentation.dto.EventListRequest;
 import com.devticket.event.presentation.dto.EventListResponse;
 import com.devticket.event.presentation.dto.SellerEventCreateRequest;
 import com.devticket.event.presentation.dto.SellerEventCreateResponse;
+import com.devticket.event.presentation.dto.SellerEventDetailResponse;
+import com.devticket.event.presentation.dto.SellerEventSummaryResponse;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -325,5 +327,108 @@ class EventServiceTest {
         // then
         assertThat(response.totalElements()).isZero();
         assertThat(response.content()).isEmpty();
+    }
+
+    // 판매자 이벤트 상세 조회 테스트
+
+    @Test
+    void 판매자_본인_이벤트_상세조회_성공시_SellerEventDetailResponse를_반환한다() {
+        // given
+        UUID sellerId = UUID.randomUUID();
+        Event event = EventTestFixture.createEvent(sellerId);
+        UUID eventId = event.getEventId();
+
+        when(eventRepository.findWithDetailsByEventId(eventId)).thenReturn(Optional.of(event));
+
+        // when
+        SellerEventDetailResponse response = eventService.getSellerEventDetail(sellerId, eventId);
+
+        // then
+        assertThat(response.eventId()).isEqualTo(eventId);
+        assertThat(response.title()).isEqualTo("상세 조회 테스트 밋업");
+        verify(eventRepository).findWithDetailsByEventId(eventId);
+    }
+
+    @Test
+    void 판매자_이벤트_상세조회시_이벤트가_없으면_예외가_발생한다() {
+        // given
+        UUID sellerId = UUID.randomUUID();
+        UUID invalidEventId = UUID.randomUUID();
+
+        when(eventRepository.findWithDetailsByEventId(invalidEventId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> eventService.getSellerEventDetail(sellerId, invalidEventId))
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 판매자_이벤트_상세조회시_본인_이벤트가_아니면_예외가_발생한다() {
+        // given
+        UUID sellerId = UUID.randomUUID();
+        UUID otherSellerId = UUID.randomUUID();
+        Event event = EventTestFixture.createEvent(otherSellerId);
+        UUID eventId = event.getEventId();
+
+        when(eventRepository.findWithDetailsByEventId(eventId)).thenReturn(Optional.of(event));
+
+        // when & then
+        assertThatThrownBy(() -> eventService.getSellerEventDetail(sellerId, eventId))
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(EventErrorCode.UNAUTHORIZED_SELLER.getMessage());
+    }
+
+    // 판매자 이벤트 현황 조회 테스트
+
+    @Test
+    void 판매자_본인_이벤트_현황조회_성공시_SellerEventSummaryResponse를_반환한다() {
+        // given
+        UUID sellerId = UUID.randomUUID();
+        Event event = EventTestFixture.createEvent(sellerId);
+        UUID eventId = event.getEventId();
+
+        when(eventRepository.findByEventId(eventId)).thenReturn(Optional.of(event));
+
+        // when
+        SellerEventSummaryResponse response = eventService.getEventSummary(sellerId, eventId);
+
+        // then
+        assertThat(response.eventId()).isEqualTo(eventId);
+        assertThat(response.title()).isEqualTo("상세 조회 테스트 밋업");
+        assertThat(response.totalQuantity()).isEqualTo(100);
+        assertThat(response.soldQuantity()).isZero();            // 새로 생성된 이벤트는 판매량 0
+        assertThat(response.remainingQuantity()).isEqualTo(100);
+        verify(eventRepository).findByEventId(eventId);
+    }
+
+    @Test
+    void 판매자_이벤트_현황조회시_이벤트가_없으면_예외가_발생한다() {
+        // given
+        UUID sellerId = UUID.randomUUID();
+        UUID invalidEventId = UUID.randomUUID();
+
+        when(eventRepository.findByEventId(invalidEventId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> eventService.getEventSummary(sellerId, invalidEventId))
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 판매자_이벤트_현황조회시_본인_이벤트가_아니면_예외가_발생한다() {
+        // given
+        UUID sellerId = UUID.randomUUID();
+        UUID otherSellerId = UUID.randomUUID();
+        Event event = EventTestFixture.createEvent(otherSellerId);
+        UUID eventId = event.getEventId();
+
+        when(eventRepository.findByEventId(eventId)).thenReturn(Optional.of(event));
+
+        // when & then
+        assertThatThrownBy(() -> eventService.getEventSummary(sellerId, eventId))
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(EventErrorCode.UNAUTHORIZED_SELLER.getMessage());
     }
 }

--- a/event/src/test/java/com/devticket/event/fixture/EventTestFixture.java
+++ b/event/src/test/java/com/devticket/event/fixture/EventTestFixture.java
@@ -1,10 +1,13 @@
 package com.devticket.event.fixture;
 
 import com.devticket.event.domain.enums.EventCategory;
+import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.domain.model.Event;
 import com.devticket.event.presentation.dto.EventDetailResponse;
 import com.devticket.event.presentation.dto.EventListResponse;
 import com.devticket.event.presentation.dto.SellerEventCreateRequest;
+import com.devticket.event.presentation.dto.SellerEventDetailResponse;
+import com.devticket.event.presentation.dto.SellerEventSummaryResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -58,5 +61,42 @@ public class EventTestFixture {
     // Controller 테스트용 EventListResponse 생성 메서드
     public static EventListResponse createEventListResponse() {
         return EventListResponse.of(createEventPage());
+    }
+
+    // 판매자 이벤트 상세 조회 응답 생성
+    public static SellerEventDetailResponse createSellerEventDetailResponse(UUID eventId) {
+        return new SellerEventDetailResponse(
+            eventId,
+            "상세 조회 테스트 밋업",
+            "설명",
+            "강남역",
+            LocalDateTime.now().plusDays(15),
+            LocalDateTime.now().plusDays(4),
+            LocalDateTime.now().plusDays(10),
+            50000,
+            100,
+            80,
+            4,
+            EventStatus.DRAFT,
+            EventCategory.MEETUP,
+            List.of(new SellerEventDetailResponse.TechStackInfo(1L, "Spring")),
+            List.of("url1"),
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
+    }
+
+    // 판매자 이벤트 현황 조회 응답 생성
+    public static SellerEventSummaryResponse createSellerEventSummaryResponse(UUID eventId) {
+        return new SellerEventSummaryResponse(
+            eventId,
+            "상세 조회 테스트 밋업",
+            EventStatus.ON_SALE,
+            100,
+            20,
+            80,
+            LocalDateTime.now().plusDays(10),
+            LocalDateTime.now().plusDays(15)
+        );
     }
 }

--- a/event/src/test/java/com/devticket/event/presentation/controller/EventControllerTest.java
+++ b/event/src/test/java/com/devticket/event/presentation/controller/EventControllerTest.java
@@ -22,6 +22,8 @@ import com.devticket.event.presentation.dto.EventListRequest;
 import com.devticket.event.presentation.dto.EventListResponse;
 import com.devticket.event.presentation.dto.SellerEventCreateRequest;
 import com.devticket.event.presentation.dto.SellerEventCreateResponse;
+import com.devticket.event.presentation.dto.SellerEventDetailResponse;
+import com.devticket.event.presentation.dto.SellerEventSummaryResponse;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -295,6 +297,76 @@ class EventControllerTest {
         assertThat(capturedPageable.getPageSize()).isEqualTo(10);
         assertThat(capturedPageable.getSort().getOrderFor("price").getDirection())
             .isEqualTo(Sort.Direction.DESC);
+    }
+
+    // 판매자 이벤트 상세 조회 테스트
+
+    @Test
+    void 판매자_이벤트_상세조회_성공시_200_응답과_상세정보를_반환한다() throws Exception {
+        // given
+        UUID sellerId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        SellerEventDetailResponse mockResponse = EventTestFixture.createSellerEventDetailResponse(eventId);
+
+        when(eventService.getSellerEventDetail(eq(sellerId), eq(eventId))).thenReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/events/seller/{eventId}", eventId)
+                .header("X-User-Id", sellerId.toString())
+                .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.eventId").value(eventId.toString()))
+            .andExpect(jsonPath("$.data.title").value("상세 조회 테스트 밋업"))
+            .andExpect(jsonPath("$.data.techStacks").isArray())
+            .andExpect(jsonPath("$.data.imageUrls").isArray());
+    }
+
+    @Test
+    void 판매자_이벤트_상세조회시_X_User_Id_헤더가_없으면_400_응답을_반환한다() throws Exception {
+        // given
+        UUID eventId = UUID.randomUUID();
+
+        // when & then (헤더 미포함)
+        mockMvc.perform(get("/api/v1/events/seller/{eventId}", eventId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isBadRequest());
+    }
+
+    // 판매자 이벤트 현황 조회 테스트
+
+    @Test
+    void 판매자_이벤트_현황조회_성공시_200_응답과_현황정보를_반환한다() throws Exception {
+        // given
+        UUID sellerId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        SellerEventSummaryResponse mockResponse = EventTestFixture.createSellerEventSummaryResponse(eventId);
+
+        when(eventService.getEventSummary(eq(sellerId), eq(eventId))).thenReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/events/{eventId}/statistics", eventId)
+                .header("X-User-Id", sellerId.toString())
+                .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.eventId").value(eventId.toString()))
+            .andExpect(jsonPath("$.data.totalQuantity").value(100))
+            .andExpect(jsonPath("$.data.soldQuantity").value(20))
+            .andExpect(jsonPath("$.data.remainingQuantity").value(80));
+    }
+
+    @Test
+    void 판매자_이벤트_현황조회시_X_User_Id_헤더가_없으면_400_응답을_반환한다() throws Exception {
+        // given
+        UUID eventId = UUID.randomUUID();
+
+        // when & then (헤더 미포함)
+        mockMvc.perform(get("/api/v1/events/{eventId}/statistics", eventId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isBadRequest());
     }
 
 }


### PR DESCRIPTION
## 서비스
- [ ] Gateway
- [ ] Member
- [x] Event
- [ ] Commerce
- [ ] Payment
- [ ] Settlement
- [ ] Log
- [ ] Admin

## 기능 설명
판매자 전용 이벤트 상세 조회 및 판매 현황 조회 기능의 비즈니스 로직 무결성과 계층 간 의존성 규칙(DIP) 준수 여부를 검증하기 위한 단위 테스트를 구현했습니다.

## 작업 내용
- [x] **판매자 이벤트 상세조회 테스트 (Service Layer)**:
    - `getSellerEventDetail()` 메서드의 정상 동작 검증
    - 존재하지 않는 이벤트 조회 시 `EVENT_NOT_FOUND` 예외 처리 검증
    - 타인 이벤트 접근 시 `UNAUTHORIZED_SELLER` 권한 예외 발생 검증

- [x] **판매자 이벤트 현황조회 테스트 (Service Layer)**:
    - `getEventSummary()` 메서드의 정상 동작 검증
    - 총수량, 판매수량, 남은수량(`totalQuantity`, `soldQuantity`, `remainingQuantity`) 응답값 검증
    - 존재하지 않는 이벤트 및 타인 이벤트 조회 시 권한 예외 처리 검증

- [x] **판매자 이벤트 상세조회 API 테스트 (Controller Layer)**:
    - `GET /api/v1/events/seller/{eventId}` 엔드포인트의 200 OK 응답 검증
    - `X-User-Id` 헤더 바인딩 및 필수값 검증
    - 응답 JSON 구조(`eventId`, `title`, `techStacks` array, `imageUrls` array) 검증
    - `X-User-Id` 헤더 누락 시 400 Bad Request 반환 검증

- [x] **판매자 이벤트 현황조회 API 테스트 (Controller Layer)**:
    - `GET /api/v1/events/{eventId}/statistics` 엔드포인트의 200 OK 응답 검증
    - 응답 데이터(`eventId`, `totalQuantity`, `soldQuantity`, `remainingQuantity`) 검증
    - `X-User-Id` 헤더 누락 시 400 Bad Request 반환 검증

- [x] **테스트 데이터 팩토리 추가 (Test Fixture)**:
    - `createSellerEventDetailResponse()`: 판매자 이벤트 상세정보 응답 DTO 생성 (기술스택 정보 및 이미지 URL 배열 포함)
    - `createSellerEventSummaryResponse()`: 판매자 이벤트 현황 응답 DTO 생성 (판매 수량 통계 정보 포함)

## API 엔드포인트
- `GET /api/v1/events/seller/{eventId}` - 판매자 이벤트 상세조회
- `GET /api/v1/events/{eventId}/statistics` - 판매자 이벤트 판매 현황조회

## 참고 문서 및 관련 이슈
- **관련 Issue**: #209 

## 특이사항 (Review Note)
- 서비스 계층에서 판매자 인증(`sellerId != event.getSellerId()`)을 명시적으로 검증하여, 보안 로직이 컨트롤러나 레포지토리 계층으로 누출되지 않도록 설계했습니다.
- MockMvc 테스트에서 `X-User-Id` 헤더 바인딩과 필수값 검증을 통해 컨트롤러의 파라미터 매핑이 정확함을 확인했습니다.
- `ArgumentCaptor`를 활용한 메서드 호출 검증으로 요청 DTO의 모든 필드(`keyword`, `category`, `techStacks`, `sellerId`, `status`)가 누락 없이 바인딩되는지 확인했습니다.
- 각 테스트는 **성공 케이스**, **리소스 미존재 케이스**, **권한 예외 케이스**를 모두 커버하여 엣지 케이스 처리를 검증했습니다.
