### PR TITLE
[Event] refactor: 이벤트 생성시 즉시 판매중 상태로 수정

### DIFF
--- a/event/src/main/java/com/devticket/event/domain/model/Event.java
+++ b/event/src/main/java/com/devticket/event/domain/model/Event.java
@@ -123,8 +123,8 @@ public class Event extends BaseEntity {
             .totalQuantity(totalQuantity)
             .maxQuantity(maxQuantity)
             .remainingQuantity(totalQuantity)
-            .status(EventStatus.DRAFT)
-//            .status(EventStatus.ON_SALE)
+//            .status(EventStatus.DRAFT)
+            .status(EventStatus.ON_SALE)
             .category(category)
             .build();
     }

--- a/event/src/test/java/com/devticket/event/application/EventServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventServiceTest.java
@@ -75,7 +75,7 @@ class EventServiceTest {
 
         // then
         assertThat(response.eventId()).isEqualTo(expectedUuid);
-        assertThat(response.status()).isEqualTo(EventStatus.DRAFT);
+        assertThat(response.status()).isEqualTo(EventStatus.ON_SALE);
 
         verify(eventRepository, times(2)).save(argThat(event -> event != null));
     }

--- a/event/src/test/java/com/devticket/event/presentation/controller/EventControllerTest.java
+++ b/event/src/test/java/com/devticket/event/presentation/controller/EventControllerTest.java
@@ -66,7 +66,7 @@ class EventControllerTest {
 
         SellerEventCreateResponse expectedResponse = new SellerEventCreateResponse(
             expectedEventId,
-            EventStatus.DRAFT,
+            EventStatus.ON_SALE,
             now
         );
 
@@ -81,7 +81,7 @@ class EventControllerTest {
             .andDo(print())
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.data.eventId").value(expectedEventId.toString()))
-            .andExpect(jsonPath("$.data.status").value("DRAFT"))
+            .andExpect(jsonPath("$.data.status").value("ON_SALE"))
             .andExpect(jsonPath("$.data.createdAt").exists());
     }
 


### PR DESCRIPTION
### 변경 사항
이벤트 생성 시 기본 상태를 `EventStatus.DRAFT`(임시 저장)에서 `EventStatus.ON_SALE`(판매 중)로 변경합니다.

기존에는 이벤트를 생성할 때 DRAFT 상태로 저장한 후, 별도의 업데이트 작업을 통해 ON_SALE 상태로 전환했습니다. 이번 변경으로 이벤트 생성 즉시 외부에 공개되도록 개선되었습니다.

### 수정 파일
   - `Event.create()` 팩토리 메서드에서 생성 시 상태를 ON_SALE로 설정

   - `정상적인_조건일_경우_이벤트가_성공적으로_생성되고_UUID를_반환한다()` 테스트에서 반환값 상태 검증 변경

   - `정상적인_요청시_201_응답과_UUID를_반환한다()` 테스트에서 Mock 응답 및 API 응답 상태 검증 변경

### 영향 분석
- ✅ `canBeUpdated()`: DRAFT, ON_SALE 모두 수정 가능하므로 기존 로직 유지
- ✅ `canBeCancelled()`: DRAFT, ON_SALE 모두 취소 가능하므로 기존 로직 유지  
- ✅ `isPublicStatus()`: ON_SALE은 이미 공개 상태로 분류되므로 접근 제어 정상 작동
- ℹ️ 이벤트 생성 후 즉시 공개됨 (기존: DRAFT → 별도 업데이트 필요)