### PR TITLE
[Commerce] feat: 장바구니 조회 API 구현

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
@@ -10,8 +10,11 @@ import com.devticket.commerce.cart.domain.repository.CartRepository;
 import com.devticket.commerce.cart.infrastructure.external.client.EventClient;
 import com.devticket.commerce.cart.infrastructure.external.client.dto.InternalPurchaseValidationResponse;
 import com.devticket.commerce.cart.presentation.dto.req.CartItemRequest;
+import com.devticket.commerce.cart.presentation.dto.res.CartItemDetail;
 import com.devticket.commerce.cart.presentation.dto.res.CartItemResponse;
+import com.devticket.commerce.cart.presentation.dto.res.CartResponse;
 import com.devticket.commerce.common.exception.BusinessException;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -55,6 +58,26 @@ public class CartService implements CartUseCase {
 
         //응답데이터 구성
         return CartItemResponse.of(cart, cartItem, event.title(), event.price());
+    }
+
+    @Override
+    public CartResponse getCart(UUID userId) {
+        // 장바구니 비어 있음 예외
+        Cart cart = cartRepository.findByUserId(userId)
+            .orElseThrow(() -> new BusinessException(CartErrorCode.CART_EMPTY));
+
+        // 장바구니 내 아이템 조회
+        List<CartItem> cartItems = cartItemRepository.findAllByCartId(cart.getId());
+
+        // 아이템 -> 아이템 상세
+        List<CartItemDetail> itemDetails = cartItems.stream()
+            .map(cartItem -> {
+                InternalPurchaseValidationResponse event =
+                    eventClient.getValidateEventStatus(cartItem.getEventId(), userId, cartItem.getQuantity());
+                return CartItemDetail.of(cartItem, event.title(), event.price());
+            }).toList();
+
+        return CartResponse.of(cart, itemDetails);
     }
 
     // =========================================================================

--- a/commerce/src/main/java/com/devticket/commerce/cart/application/usecase/CartUseCase.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/usecase/CartUseCase.java
@@ -2,6 +2,7 @@ package com.devticket.commerce.cart.application.usecase;
 
 import com.devticket.commerce.cart.presentation.dto.req.CartItemRequest;
 import com.devticket.commerce.cart.presentation.dto.res.CartItemResponse;
+import com.devticket.commerce.cart.presentation.dto.res.CartResponse;
 import java.util.UUID;
 
 public interface CartUseCase {
@@ -12,5 +13,6 @@ public interface CartUseCase {
     //장바구니 생성
     CartItemResponse save(UUID userId, CartItemRequest request);
 
-
+    // 장바구니 조회
+    CartResponse getCart(UUID userId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/domain/repository/CartItemRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/domain/repository/CartItemRepository.java
@@ -14,4 +14,7 @@ public interface CartItemRepository {
 
     //장바구니 아이템 삭제
     void deleteAllInBatch(List<CartItem> cartItems);
+
+    // 장바구니 전체 조회
+    List<CartItem> findAllByCartId(Long cartId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemJpaRepository.java
@@ -1,10 +1,13 @@
 package com.devticket.commerce.cart.infrastructure.persistence;
 
 import com.devticket.commerce.cart.domain.model.CartItem;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CartItemJpaRepository extends JpaRepository<CartItem, Long> {
 
     Optional<CartItem> findByCartIdAndEventId(Long cartId, Long eventId);
+
+    List<CartItem> findAllByCartId(Long cartId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemRepositoryAdapter.java
@@ -32,4 +32,9 @@ public class CartItemRepositoryAdapter implements CartItemRepository {
     public void deleteAllInBatch(List<CartItem> cartItems) {
         cartItemJpaRepository.deleteAllInBatch(cartItems);
     }
+
+    @Override
+    public List<CartItem> findAllByCartId(Long cartId) {
+        return cartItemJpaRepository.findAllByCartId(cartId);
+    }
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/controller/CartController.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/controller/CartController.java
@@ -3,12 +3,14 @@ package com.devticket.commerce.cart.presentation.controller;
 import com.devticket.commerce.cart.application.usecase.CartUseCase;
 import com.devticket.commerce.cart.presentation.dto.req.CartItemRequest;
 import com.devticket.commerce.cart.presentation.dto.res.CartItemResponse;
+import com.devticket.commerce.cart.presentation.dto.res.CartResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -34,4 +36,16 @@ public class CartController {
             .status(HttpStatus.CREATED)
             .body(response);
     }
+
+    @GetMapping
+    @Operation(description = "장바구니 조회")
+    public ResponseEntity<CartResponse> getCart(
+        @RequestHeader("X-User-Id") UUID userId
+    ) {
+        CartResponse response = cartUseCase.getCart(userId);
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(response);
+    }
+
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDetail.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDetail.java
@@ -1,0 +1,24 @@
+package com.devticket.commerce.cart.presentation.dto.res;
+
+import com.devticket.commerce.cart.domain.model.CartItem;
+import lombok.Builder;
+
+@Builder
+public record CartItemDetail(
+    Long eventId,
+    String eventTitle,
+    int price,
+    int quantity
+) {
+
+    //엔티티와 외부 정보를 조합하여 DTO로 변환하는 정적 팩토리 메서드
+    public static CartItemDetail of(CartItem cartItem, String title, int price) {
+        return CartItemDetail.builder()
+            .eventId(cartItem.getEventId())
+            .eventTitle(title)
+            .price(price)
+            .quantity(cartItem.getQuantity())
+            .build();
+    }
+
+}

--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemResponse.java
@@ -28,23 +28,3 @@ public record CartItemResponse(
     }
 }
 
-//CartItemResponse의 Inner Record
-@Builder
-record CartItemDetail(
-    Long eventId,
-    String eventTitle,
-    int price,
-    int quantity
-) {
-
-    //엔티티와 외부 정보를 조합하여 DTO로 변환하는 정적 팩토리 메서드
-    static CartItemDetail of(CartItem cartItem, String title, int price) {
-        return CartItemDetail.builder()
-            .eventId(cartItem.getEventId())
-            .eventTitle(title)
-            .price(price)
-            .quantity(cartItem.getQuantity())
-            .build();
-    }
-
-}

--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartResponse.java
@@ -1,0 +1,36 @@
+package com.devticket.commerce.cart.presentation.dto.res;
+
+import com.devticket.commerce.cart.domain.model.Cart;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "장바구니 조회 응답 데이터")
+public record CartResponse(
+
+    @Schema(description = "장바구니 ID")
+    String cartId,
+
+    @Schema(description = "장바구니 아이템 목록")
+    List<CartItemDetail> items,
+
+    @Schema(description = "총 금액")
+    int totalAmount
+
+) {
+
+    // (카트 + 카트 아이템 상세) -> cartResponse 정적 팩토리 메서드
+    public static CartResponse of(Cart cart, List<CartItemDetail> items) {
+        int totalAmount = items.stream()
+            .mapToInt(item -> item.price() * item.quantity())
+            .sum();
+
+        return CartResponse.builder()
+            .cartId(String.valueOf(cart.getId()))
+            .items(items)
+            .totalAmount(totalAmount)
+            .build();
+    }
+
+}

--- a/commerce/src/main/resources/application-local.yml
+++ b/commerce/src/main/resources/application-local.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/devticket
+    url: jdbc:postgresql://localhost:5433/devticket
     username: devticket
     password: devticket
     driver-class-name: org.postgresql.Driver
@@ -13,7 +13,7 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: localhost:9093
     consumer:
       group-id: devticket-commerce
       auto-offset-reset: earliest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_PASSWORD: devticket
       POSTGRES_DB: devticket
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
 
@@ -17,7 +17,7 @@ services:
     image: confluentinc/cp-kafka:7.5.0
     container_name: devticket-kafka
     ports:
-      - "9092:9092"
+      - "9093:9092"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller


### PR DESCRIPTION
PR 제목:
[Commerce] feat: 장바구니 조회 API 구현
PR 본문:
markdown## 관련 이슈
- close #

## 작업 내용
- GET /cart 엔드포인트 추가 (X-User-Id 헤더로 사용자 식별)
- 장바구니 없을 시 CART_EMPTY 예외 반환
- 장바구니 내 아이템별 Event 서비스 호출하여 title, price 조합 후 응답

## 변경 사항
- `CartController` - GET /cart 엔드포인트 추가
- `CartUseCase` - getCart() 메서드 추가
- `CartService` - getCart() 로직 구현
- `CartResponse` - 신규 DTO 추가
- `CartItemDetail` - CartItemResponse에서 별도 파일로 분리
- `CartItemRepository` - findAllByCartId() 추가
- `CartItemJpaRepository` - findAllByCartId() 쿼리 메서드 추가
- `CartItemRepositoryAdapter` - findAllByCartId() 구현체 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인

## 스크린샷
<!-- API 응답, Swagger 캡처 등 필요 시 첨부 -->

## 참고 사항
- base 브랜치: `feat/commerce-cart`