### PR TITLE
[Payment] feat: 예치금 충전 승인 서비스 구현 + 테스트

### DIFF
--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -1,10 +1,14 @@
 package com.devticket.payment.wallet.application.service;
 
+import com.devticket.payment.payment.application.dto.PgPaymentConfirmCommand;
+import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
+import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.wallet.domain.WalletPolicyConstants;
 import com.devticket.payment.wallet.domain.exception.WalletErrorCode;
 import com.devticket.payment.wallet.domain.exception.WalletException;
 import com.devticket.payment.wallet.domain.model.Wallet;
 import com.devticket.payment.wallet.domain.model.WalletCharge;
+import com.devticket.payment.wallet.domain.model.WalletTransaction;
 import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
 import com.devticket.payment.wallet.domain.repository.WalletRepository;
 import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
@@ -35,6 +39,7 @@ public class WalletServiceImpl implements WalletService {
     private final WalletRepository walletRepository;
     private final WalletTransactionRepository walletTransactionRepository;
     private final WalletChargeRepository walletChargeRepository;
+    private final PgPaymentClient pgPaymentClient;
 
     @Override
     @Transactional
@@ -74,8 +79,75 @@ public class WalletServiceImpl implements WalletService {
     }
 
     @Override
-    public WalletChargeConfirmResponse confirmCharge(UUID userId, WalletChargeConfirmRequest request) {
-        return null;
+    @Transactional
+    public WalletChargeConfirmResponse confirmCharge(UUID userId,
+        WalletChargeConfirmRequest request) {
+        // 1. WalletCharge 조회
+        UUID chargeId = UUID.fromString(request.chargeId());
+        WalletCharge walletCharge = walletChargeRepository.findByChargeId(chargeId)
+            .orElseThrow(() -> new WalletException(WalletErrorCode.CHARGE_NOT_FOUND));
+
+        // 2. PENDING 상태 확인
+        if (!walletCharge.isPending()) {
+            throw new WalletException(WalletErrorCode.CHARGE_NOT_PENDING);
+        }
+
+        // 3. 금액 일치 검증
+        if (!walletCharge.getAmount().equals(request.amount())) {
+            throw new WalletException(WalletErrorCode.CHARGE_AMOUNT_MISMATCH);
+        }
+
+        // 4. PG 승인 호출
+        PgPaymentConfirmResult pgResult;
+        try {
+            pgResult = pgPaymentClient.confirm(new PgPaymentConfirmCommand(
+                request.paymentKey(),
+                walletCharge.getChargeId().toString(),
+                request.amount()
+            ));
+        } catch (Exception e) {
+            log.error("[WalletCharge] PG 승인 실패 — chargeId={}, error={}",
+                chargeId, e.getMessage());
+            walletCharge.fail();
+            return WalletChargeConfirmResponse.from(
+                walletCharge.getChargeId().toString(),
+                walletCharge.getAmount(),
+                null,
+                "FAILED",
+                null
+            );
+        }
+
+        // 5. Wallet 잔액 증가 (비관적 락)
+        Wallet wallet = walletRepository.findByUserIdForUpdate(userId)
+            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
+
+        wallet.charge(walletCharge.getAmount());
+
+        // 6. WalletCharge 완료 처리
+        walletCharge.complete(pgResult.paymentKey());
+
+        // 7. WalletTransaction 생성
+        String transactionKey = "CHARGE:" + pgResult.paymentKey();
+        WalletTransaction walletTransaction = WalletTransaction.createCharge(
+            wallet.getId(),
+            userId,
+            transactionKey,
+            walletCharge.getAmount(),
+            wallet.getBalance()
+        );
+        walletTransactionRepository.save(walletTransaction);
+
+        log.info("[WalletCharge] 충전 승인 완료 — chargeId={}, amount={}, balance={}",
+            chargeId, walletCharge.getAmount(), wallet.getBalance());
+
+        return WalletChargeConfirmResponse.from(
+            walletCharge.getChargeId().toString(),
+            walletCharge.getAmount(),
+            wallet.getBalance(),
+            walletCharge.getStatus().name(),
+            walletTransaction.getCreatedAt()
+        );
     }
 
     @Override

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -83,9 +83,14 @@ public class WalletServiceImpl implements WalletService {
     public WalletChargeConfirmResponse confirmCharge(UUID userId,
         WalletChargeConfirmRequest request) {
         // 1. WalletCharge 조회
-        UUID chargeId = UUID.fromString(request.chargeId());
+        UUID chargeId = parseUUID(request.chargeId());
         WalletCharge walletCharge = walletChargeRepository.findByChargeId(chargeId)
             .orElseThrow(() -> new WalletException(WalletErrorCode.CHARGE_NOT_FOUND));
+
+        // 소유자 검증 추가
+        if (!walletCharge.getUserId().equals(userId)) {
+            throw new WalletException(WalletErrorCode.CHARGE_NOT_FOUND);
+        }
 
         // 2. PENDING 상태 확인
         if (!walletCharge.isPending()) {
@@ -163,5 +168,13 @@ public class WalletServiceImpl implements WalletService {
     @Override
     public WalletWithdrawResponse withdraw(UUID userId, WalletWithdrawRequest request) {
         return null;
+    }
+
+    private UUID parseUUID(String value) {
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            throw new WalletException(WalletErrorCode.INVALID_CHARGE_REQUEST);
+        }
     }
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/exception/WalletErrorCode.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/exception/WalletErrorCode.java
@@ -12,7 +12,10 @@ public enum WalletErrorCode implements ErrorCode {
     INVALID_CHARGE_AMOUNT(400, "WALLET_002", "충전 금액은 1,000원 이상 50,000원 이하여야 합니다."),
     DAILY_CHARGE_LIMIT_EXCEEDED(400, "WALLET_003", "일일 충전 한도(1,000,000원)를 초과했습니다."),
     REFUNDABLE_BALANCE_NOT_FOUND(400, "WALLET_004", "환불 가능한 예치금이 없습니다."),
-    WALLET_NOT_FOUND(404, "WALLET_005", "예치금 지갑을 찾을 수 없습니다.");
+    WALLET_NOT_FOUND(404, "WALLET_005", "예치금 지갑을 찾을 수 없습니다."),
+    CHARGE_AMOUNT_MISMATCH(400, "WALLET_006", "충전 금액이 일치하지 않습니다."),
+    CHARGE_NOT_FOUND(404, "WALLET_007", "충전 요청을 찾을 수 없습니다."),
+    CHARGE_NOT_PENDING(409, "WALLET_008", "대기 상태가 아닌 충전 건입니다.");
 
     private final int status;
     private final String code;

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/exception/WalletErrorCode.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/exception/WalletErrorCode.java
@@ -15,7 +15,8 @@ public enum WalletErrorCode implements ErrorCode {
     WALLET_NOT_FOUND(404, "WALLET_005", "예치금 지갑을 찾을 수 없습니다."),
     CHARGE_AMOUNT_MISMATCH(400, "WALLET_006", "충전 금액이 일치하지 않습니다."),
     CHARGE_NOT_FOUND(404, "WALLET_007", "충전 요청을 찾을 수 없습니다."),
-    CHARGE_NOT_PENDING(409, "WALLET_008", "대기 상태가 아닌 충전 건입니다.");
+    CHARGE_NOT_PENDING(409, "WALLET_008", "대기 상태가 아닌 충전 건입니다."),
+    INVALID_CHARGE_REQUEST(400, "WALLET_009", "유효하지 않은 충전 요청입니다.");
 
     private final int status;
     private final String code;

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/repository/WalletChargeRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/repository/WalletChargeRepository.java
@@ -11,7 +11,7 @@ public interface WalletChargeRepository {
 
     Optional<WalletCharge> findByUserIdAndIdempotencyKey(UUID userId, String idempotencyKey);
 
-    Optional<WalletCharge> findByIdempotencyKey(String idempotencyKey);
+    Optional<WalletCharge> findByChargeId(UUID chargeId);
 
     int sumTodayChargeAmount(UUID userId, LocalDateTime startOfDay);
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletChargeJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletChargeJpaRepository.java
@@ -9,10 +9,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface WalletChargeJpaRepository extends JpaRepository<WalletCharge, Long> {
-
-    Optional<WalletCharge> findByIdempotencyKey(String idempotencyKey);
-
+    
     Optional<WalletCharge> findByUserIdAndIdempotencyKey(UUID userId, String idempotencyKey);
+
+    Optional<WalletCharge> findByChargeId(UUID chargeId);
 
     @Query("SELECT COALESCE(SUM(wc.amount), 0) FROM WalletCharge wc "
         + "WHERE wc.userId = :userId "

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletChargeRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletChargeRepositoryImpl.java
@@ -25,8 +25,8 @@ public class WalletChargeRepositoryImpl implements WalletChargeRepository {
     }
 
     @Override
-    public Optional<WalletCharge> findByIdempotencyKey(String idempotencyKey) {
-        return walletChargeJpaRepository.findByIdempotencyKey(idempotencyKey);
+    public Optional<WalletCharge> findByChargeId(UUID chargeId) {
+        return walletChargeJpaRepository.findByChargeId(chargeId);
     }
 
     @Override

--- a/payment/src/main/java/com/devticket/payment/wallet/presentation/dto/WalletChargeConfirmRequest.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/presentation/dto/WalletChargeConfirmRequest.java
@@ -5,14 +5,15 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record WalletChargeConfirmRequest(
-    @NotBlank(message = "transactionKey는 필수입니다.")
-    String transactionKey,
+    @NotBlank(message = "paymentKey는 필수입니다.")
+    String paymentKey,
 
-    @NotBlank(message = "transactionId는 필수입니다.")
-    String transactionId,
+    @NotBlank(message = "chargeId는 필수입니다.")
+    String chargeId,
 
     @NotNull(message = "amount는 필수입니다.")
     @Min(value = 1, message = "amount는 1 이상이어야 합니다.")
     Integer amount
 ) {
+
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/presentation/dto/WalletChargeConfirmResponse.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/presentation/dto/WalletChargeConfirmResponse.java
@@ -9,6 +9,7 @@ public record WalletChargeConfirmResponse(
     String status,
     LocalDateTime approvedAt
 ) {
+
     public static WalletChargeConfirmResponse from(
         String transactionId,
         Integer amount,

--- a/payment/src/test/java/com/devticket/payment/application/service/WalletServiceImplTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/WalletServiceImplTest.java
@@ -9,15 +9,21 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.devticket.payment.payment.application.dto.PgPaymentConfirmCommand;
+import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
+import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.wallet.application.service.WalletServiceImpl;
 import com.devticket.payment.wallet.domain.WalletPolicyConstants;
 import com.devticket.payment.wallet.domain.enums.WalletChargeStatus;
 import com.devticket.payment.wallet.domain.exception.WalletException;
 import com.devticket.payment.wallet.domain.model.Wallet;
 import com.devticket.payment.wallet.domain.model.WalletCharge;
+import com.devticket.payment.wallet.domain.model.WalletTransaction;
 import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
 import com.devticket.payment.wallet.domain.repository.WalletRepository;
 import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
+import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmRequest;
+import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeResponse;
 import java.time.LocalDateTime;
@@ -30,7 +36,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class WalletServiceImplTest {
@@ -46,6 +51,9 @@ class WalletServiceImplTest {
 
     @Mock
     private WalletChargeRepository walletChargeRepository;
+
+    @Mock
+    private PgPaymentClient pgPaymentClient;
 
     private static final UUID USER_ID = UUID.randomUUID();
     private static final String IDEMPOTENCY_KEY = UUID.randomUUID().toString();
@@ -86,7 +94,6 @@ class WalletServiceImplTest {
         void 멱등성_키_중복() {
             // given
             WalletChargeRequest request = new WalletChargeRequest(10_000);
-            Wallet wallet = Wallet.create(USER_ID);
             WalletCharge existingCharge = WalletCharge.create(
                 1L, USER_ID, 10_000, IDEMPOTENCY_KEY);
 
@@ -101,7 +108,7 @@ class WalletServiceImplTest {
             assertThat(response.amount()).isEqualTo(10_000);
             assertThat(response.status()).isEqualTo(WalletChargeStatus.PENDING.name());
             verify(walletChargeRepository, never()).save(any(WalletCharge.class));
-            verify(walletRepository, never()).findByUserId(any());
+            verify(walletRepository, never()).findByUserIdForUpdate(any());
         }
 
         @Test
@@ -109,12 +116,11 @@ class WalletServiceImplTest {
         void 일일_충전_한도_초과() {
             // given
             WalletChargeRequest request = new WalletChargeRequest(50_000);
-            Wallet wallet = Wallet.create(USER_ID);
 
             given(walletChargeRepository.findByUserIdAndIdempotencyKey(USER_ID, IDEMPOTENCY_KEY))
                 .willReturn(Optional.empty());
             given(walletRepository.findByUserIdForUpdate(USER_ID))
-                .willReturn(Optional.of(wallet));
+                .willReturn(Optional.of(Wallet.create(USER_ID)));
             given(walletChargeRepository.sumTodayChargeAmount(eq(USER_ID), any(LocalDateTime.class)))
                 .willReturn(WalletPolicyConstants.DAILY_CHARGE_LIMIT);
 
@@ -158,14 +164,15 @@ class WalletServiceImplTest {
         @DisplayName("일일 한도 경계값 — 한도 내 최대 금액 정상 처리")
         void 일일_한도_경계값_성공() {
             // given
-            int todayTotal = WalletPolicyConstants.DAILY_CHARGE_LIMIT - WalletPolicyConstants.MAX_CHARGE_AMOUNT;
-            WalletChargeRequest request = new WalletChargeRequest(WalletPolicyConstants.MAX_CHARGE_AMOUNT);
-            Wallet wallet = Wallet.create(USER_ID);
+            int todayTotal = WalletPolicyConstants.DAILY_CHARGE_LIMIT
+                - WalletPolicyConstants.MAX_CHARGE_AMOUNT;
+            WalletChargeRequest request =
+                new WalletChargeRequest(WalletPolicyConstants.MAX_CHARGE_AMOUNT);
 
             given(walletChargeRepository.findByUserIdAndIdempotencyKey(USER_ID, IDEMPOTENCY_KEY))
                 .willReturn(Optional.empty());
             given(walletRepository.findByUserIdForUpdate(USER_ID))
-                .willReturn(Optional.of(wallet));
+                .willReturn(Optional.of(Wallet.create(USER_ID)));
             given(walletChargeRepository.sumTodayChargeAmount(eq(USER_ID), any(LocalDateTime.class)))
                 .willReturn(todayTotal);
             given(walletChargeRepository.save(any(WalletCharge.class)))
@@ -183,14 +190,15 @@ class WalletServiceImplTest {
         @DisplayName("일일 한도 경계값 — 1원 초과 시 예외")
         void 일일_한도_경계값_초과() {
             // given
-            int todayTotal = WalletPolicyConstants.DAILY_CHARGE_LIMIT - WalletPolicyConstants.MIN_CHARGE_AMOUNT + 1;
-            WalletChargeRequest request = new WalletChargeRequest(WalletPolicyConstants.MIN_CHARGE_AMOUNT);
-            Wallet wallet = Wallet.create(USER_ID);
+            int todayTotal = WalletPolicyConstants.DAILY_CHARGE_LIMIT
+                - WalletPolicyConstants.MIN_CHARGE_AMOUNT + 1;
+            WalletChargeRequest request =
+                new WalletChargeRequest(WalletPolicyConstants.MIN_CHARGE_AMOUNT);
 
             given(walletChargeRepository.findByUserIdAndIdempotencyKey(USER_ID, IDEMPOTENCY_KEY))
                 .willReturn(Optional.empty());
             given(walletRepository.findByUserIdForUpdate(USER_ID))
-                .willReturn(Optional.of(wallet));
+                .willReturn(Optional.of(Wallet.create(USER_ID)));
             given(walletChargeRepository.sumTodayChargeAmount(eq(USER_ID), any(LocalDateTime.class)))
                 .willReturn(todayTotal);
 
@@ -200,34 +208,167 @@ class WalletServiceImplTest {
 
             verify(walletChargeRepository, never()).save(any(WalletCharge.class));
         }
+    }
+
+    @Nested
+    @DisplayName("예치금 충전 승인")
+    class ConfirmChargeTest {
+
+        private static final String PAYMENT_KEY = "toss_pg_key_123";
+
+        private WalletCharge createPendingCharge() {
+            return WalletCharge.create(1L, USER_ID, 10_000, UUID.randomUUID().toString());
+        }
+
+        private PgPaymentConfirmResult createPgResult(WalletCharge charge) {
+            return new PgPaymentConfirmResult(
+                PAYMENT_KEY,
+                charge.getChargeId().toString(),
+                "CARD",
+                "DONE",
+                charge.getAmount(),
+                LocalDateTime.now().toString()
+            );
+        }
 
         @Test
-        @DisplayName("유니크 충돌 — 동시 요청 시 기존 레코드로 멱등 응답")
-        void 유니크_충돌_멱등_응답() {
+        @DisplayName("정상 충전 승인 — balance 증가, WalletTransaction 생성, COMPLETED")
+        void 정상_충전_승인() {
             // given
-            WalletChargeRequest request = new WalletChargeRequest(10_000);
+            WalletCharge charge = createPendingCharge();
             Wallet wallet = Wallet.create(USER_ID);
-            WalletCharge existingCharge = WalletCharge.create(
-                1L, USER_ID, 10_000, IDEMPOTENCY_KEY);
+            WalletChargeConfirmRequest request = new WalletChargeConfirmRequest(
+                PAYMENT_KEY, charge.getChargeId().toString(), 10_000);
 
-            given(walletChargeRepository.findByUserIdAndIdempotencyKey(USER_ID, IDEMPOTENCY_KEY))
-                .willReturn(Optional.empty());
+            given(walletChargeRepository.findByChargeId(charge.getChargeId()))
+                .willReturn(Optional.of(charge));
+            given(pgPaymentClient.confirm(any(PgPaymentConfirmCommand.class)))
+                .willReturn(createPgResult(charge));
             given(walletRepository.findByUserIdForUpdate(USER_ID))
                 .willReturn(Optional.of(wallet));
-            given(walletChargeRepository.sumTodayChargeAmount(eq(USER_ID), any(LocalDateTime.class)))
-                .willReturn(0);
-            given(walletChargeRepository.save(any(WalletCharge.class)))
-                .willThrow(new DataIntegrityViolationException("unique constraint"));
-            given(walletChargeRepository.findByUserIdAndIdempotencyKey(USER_ID, IDEMPOTENCY_KEY))
-                .willReturn(Optional.empty())
-                .willReturn(Optional.of(existingCharge));
+            given(walletTransactionRepository.save(any(WalletTransaction.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            WalletChargeResponse response = walletService.charge(USER_ID, request, IDEMPOTENCY_KEY);
+            WalletChargeConfirmResponse response = walletService.confirmCharge(USER_ID, request);
 
             // then
             assertThat(response).isNotNull();
             assertThat(response.amount()).isEqualTo(10_000);
+            assertThat(response.balance()).isEqualTo(10_000);
+            assertThat(response.status()).isEqualTo(WalletChargeStatus.COMPLETED.name());
+            assertThat(wallet.getBalance()).isEqualTo(10_000);
+            verify(walletTransactionRepository, times(1)).save(any(WalletTransaction.class));
+        }
+
+        @Test
+        @DisplayName("PENDING이 아닌 WalletCharge 승인 시도 — 예외")
+        void 이미_처리된_충전건() {
+            // given
+            WalletCharge charge = createPendingCharge();
+            charge.complete("already_completed_key");
+            WalletChargeConfirmRequest request = new WalletChargeConfirmRequest(
+                PAYMENT_KEY, charge.getChargeId().toString(), 10_000);
+
+            given(walletChargeRepository.findByChargeId(charge.getChargeId()))
+                .willReturn(Optional.of(charge));
+
+            // when & then
+            assertThatThrownBy(() -> walletService.confirmCharge(USER_ID, request))
+                .isInstanceOf(WalletException.class)
+                .hasMessageContaining("대기 상태가 아닌");
+
+            verify(pgPaymentClient, never()).confirm(any());
+            verify(walletRepository, never()).findByUserIdForUpdate(any());
+        }
+
+        @Test
+        @DisplayName("금액 불일치 — 예외")
+        void 금액_불일치() {
+            // given
+            WalletCharge charge = createPendingCharge();
+            WalletChargeConfirmRequest request = new WalletChargeConfirmRequest(
+                PAYMENT_KEY, charge.getChargeId().toString(), 99_999);
+
+            given(walletChargeRepository.findByChargeId(charge.getChargeId()))
+                .willReturn(Optional.of(charge));
+
+            // when & then
+            assertThatThrownBy(() -> walletService.confirmCharge(USER_ID, request))
+                .isInstanceOf(WalletException.class)
+                .hasMessageContaining("금액이 일치하지");
+
+            verify(pgPaymentClient, never()).confirm(any());
+        }
+
+        @Test
+        @DisplayName("PG 승인 실패 — WalletCharge FAILED, balance 변동 없음")
+        void PG_승인_실패() {
+            // given
+            WalletCharge charge = createPendingCharge();
+            WalletChargeConfirmRequest request = new WalletChargeConfirmRequest(
+                PAYMENT_KEY, charge.getChargeId().toString(), 10_000);
+
+            given(walletChargeRepository.findByChargeId(charge.getChargeId()))
+                .willReturn(Optional.of(charge));
+            given(pgPaymentClient.confirm(any(PgPaymentConfirmCommand.class)))
+                .willThrow(new RuntimeException("PG 오류"));
+
+            // when
+            WalletChargeConfirmResponse response = walletService.confirmCharge(USER_ID, request);
+
+            // then
+            assertThat(response.status()).isEqualTo("FAILED");
+            assertThat(response.balance()).isNull();
+            assertThat(charge.getStatus()).isEqualTo(WalletChargeStatus.FAILED);
+            verify(walletRepository, never()).findByUserIdForUpdate(any());
+            verify(walletTransactionRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("WalletCharge 미존재 — 예외")
+        void 충전건_미존재() {
+            // given
+            UUID unknownChargeId = UUID.randomUUID();
+            WalletChargeConfirmRequest request = new WalletChargeConfirmRequest(
+                PAYMENT_KEY, unknownChargeId.toString(), 10_000);
+
+            given(walletChargeRepository.findByChargeId(unknownChargeId))
+                .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> walletService.confirmCharge(USER_ID, request))
+                .isInstanceOf(WalletException.class)
+                .hasMessageContaining("충전 요청을 찾을 수 없습니다");
+        }
+
+        @Test
+        @DisplayName("transactionKey 멱등성 — 동일 paymentKey로 WalletTransaction 중복 생성 방지")
+        void 트랜잭션키_멱등성() {
+            // given
+            WalletCharge charge = createPendingCharge();
+            Wallet wallet = Wallet.create(USER_ID);
+            WalletChargeConfirmRequest request = new WalletChargeConfirmRequest(
+                PAYMENT_KEY, charge.getChargeId().toString(), 10_000);
+
+            given(walletChargeRepository.findByChargeId(charge.getChargeId()))
+                .willReturn(Optional.of(charge));
+            given(pgPaymentClient.confirm(any(PgPaymentConfirmCommand.class)))
+                .willReturn(createPgResult(charge));
+            given(walletRepository.findByUserIdForUpdate(USER_ID))
+                .willReturn(Optional.of(wallet));
+            given(walletTransactionRepository.save(any(WalletTransaction.class)))
+                .willAnswer(invocation -> {
+                    WalletTransaction tx = invocation.getArgument(0);
+                    assertThat(tx.getTransactionKey()).isEqualTo("CHARGE:" + PAYMENT_KEY);
+                    return tx;
+                });
+
+            // when
+            walletService.confirmCharge(USER_ID, request);
+
+            // then
+            verify(walletTransactionRepository, times(1)).save(any(WalletTransaction.class));
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈
- close #151

## 작업 내용
- 예치금 충전 승인(`POST /wallet/charge/confirm`) 서비스를 구현합니다.
- PG 결제 완료 후 클라이언트가 paymentKey, chargeId, amount를 전달하면 PG 승인 검증 → Wallet 잔액 증가 → WalletTransaction 기록까지 하나의 트랜잭션으로 처리합니다.

### 충전 승인 플로우
1. `chargeId`로 WalletCharge 조회 → 미존재 시 예외
2. PENDING 상태 확인 → 이미 처리된 건이면 예외
3. 요청 금액과 WalletCharge 금액 일치 검증
4. PgPaymentClient.confirm() 호출
5. PG 승인 성공 시 하나의 트랜잭션으로:
   - WalletCharge status → COMPLETED, paymentKey 저장
   - Wallet balance 증가 (`findByUserIdForUpdate` 비관적 락)
   - WalletTransaction 생성 (type: CHARGE, transactionKey: `CHARGE:{paymentKey}`)
6. PG 승인 실패 시:
   - WalletCharge status → FAILED
   - balance 변동 없음, FAILED 응답 반환

### WalletCharge → WalletTransaction 연결
- 충전 시작(Issue 2)에서 WalletCharge(PENDING) 생성 — balance 변동 없음
- 충전 승인(이 PR)에서 WalletTransaction(CHARGE) 생성 — balance 변동 있음
- `transactionKey = "CHARGE:{paymentKey}"`로 WalletTransaction UNIQUE 제약 → 동일 PG 승인의 중복 처리 방지

## 변경 사항

### 수정 파일
| 파일 | 변경 내용 |
|---|---|
| `WalletServiceImpl.java` | confirmCharge() 구현 |
| `WalletChargeConfirmRequest.java` | 필드명 변경 (transactionKey → paymentKey, transactionId → chargeId) |
| `WalletChargeConfirmResponse.java` | approvedAt null 방어 |
| `WalletChargeRepository.java` | findByChargeId() 추가 |
| `WalletChargeJpaRepository.java` | findByChargeId() 추가 |
| `WalletChargeRepositoryImpl.java` | findByChargeId() 위임 |
| `WalletErrorCode.java` | CHARGE_NOT_FOUND, CHARGE_NOT_PENDING, CHARGE_AMOUNT_MISMATCH 추가 |
| `WalletServiceImplTest.java` | 충전 승인 테스트 6건 추가 |

## 테스트
- [x] 정상 충전 승인 — balance 증가, WalletTransaction 생성, COMPLETED
- [x] PENDING이 아닌 WalletCharge 승인 시도 — 예외
- [x] 금액 불일치 — 예외
- [x] PG 승인 실패 — WalletCharge FAILED, balance 변동 없음
- [x] WalletCharge 미존재 — 예외
- [x] transactionKey 멱등성 — 동일 paymentKey로 WalletTransaction 중복 생성 방지

## 참고 사항
- PG 승인 실패 시 예외를 throw하지 않고 FAILED 응답을 반환합니다. 클라이언트가 실패를 인지하고 재시도(새 Idempotency-Key로 충전 시작부터)할 수 있도록 하기 위함입니다.
- `paymentKey` UNIQUE 제약(WalletCharge)으로 동일 PG 콜백 중복 수신을 DB 레벨에서 차단합니다.
- `transactionKey` UNIQUE 제약(WalletTransaction)으로 동일 승인의 중복 원장 기록을 방지합니다.