### PR TITLE
[Commerce] feat: 장바구니 아이템 수량 변경 API 구현

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/req/CartItemQuantityRequest.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/req/CartItemQuantityRequest.java
@@ -1,0 +1,9 @@
+package com.devticket.commerce.cart.presentation.dto.req;
+
+public record CartItemQuantityRequest(
+
+    int quantity
+
+) {
+
+}

--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemQuantityResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemQuantityResponse.java
@@ -1,0 +1,21 @@
+package com.devticket.commerce.cart.presentation.dto.res;
+
+import com.devticket.commerce.cart.domain.model.CartItem;
+import lombok.Builder;
+
+@Builder
+public record CartItemQuantityResponse(
+
+    String cartItemId,
+    int quantity
+
+) {
+
+    public static CartItemQuantityResponse of(CartItem cartItem) {
+        return CartItemQuantityResponse.builder()
+            .cartItemId(String.valueOf(cartItem.getId()))
+            .quantity(cartItem.getQuantity())
+            .build();
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- PATCH /cart/items/{cartItemId} 엔드포인트 추가
- X-User-Id 헤더로 사용자 식별
- delta 값으로 수량 증감 (양수: 증가, 음수: 감소)
- 최소 수량 1개 검증 (도메인 레이어)
- 내 장바구니 아이템인지 검증

## 변경 사항
- `CartController` - PATCH /cart/items/{cartItemId} 엔드포인트 추가
- `CartUseCase` - updateTicket() 메서드 추가
- `CartService` - updateTicket() 로직 구현
- `CartItemQuantityRequest` - 신규 DTO 추가 (delta 필드)
- `CartItemQuantityResponse` - 신규 DTO 추가 (cartItemId, quantity 필드)
- `CartItemRepository` - findById() 추가
- `CartItemRepositoryAdapter` - findById() 구현체 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷
<!-- API 응답, Swagger 캡처 등 필요 시 첨부 -->

## 참고 사항
- 수량이 1 미만이 되면 INVALID_QUANTITY 예외 반환
- 다른 사용자의 아이템 수정 시 ITEM_NOT_FOUND 예외 반환