### PR TITLE
[Commerce] feat: 장바구니 아이템 수량 변경, 특정 삭제, 전체 삭제 API 구현

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
@@ -1,5 +1,6 @@
 package com.devticket.commerce.cart.application.service;
 
+import com.devticket.commerce.cart.application.usecase.CartItemUseCase;
 import com.devticket.commerce.cart.application.usecase.CartUseCase;
 import com.devticket.commerce.cart.domain.exception.CartErrorCode;
 import com.devticket.commerce.cart.domain.exception.EventErrorCode;
@@ -9,8 +10,12 @@ import com.devticket.commerce.cart.domain.repository.CartItemRepository;
 import com.devticket.commerce.cart.domain.repository.CartRepository;
 import com.devticket.commerce.cart.infrastructure.external.client.EventClient;
 import com.devticket.commerce.cart.infrastructure.external.client.dto.InternalPurchaseValidationResponse;
+import com.devticket.commerce.cart.presentation.dto.req.CartItemQuantityRequest;
 import com.devticket.commerce.cart.presentation.dto.req.CartItemRequest;
+import com.devticket.commerce.cart.presentation.dto.res.CartClearResponse;
+import com.devticket.commerce.cart.presentation.dto.res.CartItemDeleteResponse;
 import com.devticket.commerce.cart.presentation.dto.res.CartItemDetail;
+import com.devticket.commerce.cart.presentation.dto.res.CartItemQuantityResponse;
 import com.devticket.commerce.cart.presentation.dto.res.CartItemResponse;
 import com.devticket.commerce.cart.presentation.dto.res.CartResponse;
 import com.devticket.commerce.common.exception.BusinessException;
@@ -25,7 +30,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class CartService implements CartUseCase {
+public class CartService implements CartUseCase, CartItemUseCase {
 
     private final CartRepository cartRepository;
     private final CartItemRepository cartItemRepository;
@@ -60,12 +65,11 @@ public class CartService implements CartUseCase {
         return CartItemResponse.of(cart, cartItem, event.title(), event.price());
     }
 
+    // 장바구니 전체 조회
     @Override
     public CartResponse getCart(UUID userId) {
         // 장바구니 비어 있음 예외
-        Cart cart = cartRepository.findByUserId(userId)
-            .orElseThrow(() -> new BusinessException(CartErrorCode.CART_EMPTY));
-
+        Cart cart = getCartByUserId(userId);
         // 장바구니 내 아이템 조회
         List<CartItem> cartItems = cartItemRepository.findAllByCartId(cart.getId());
 
@@ -78,6 +82,52 @@ public class CartService implements CartUseCase {
             }).toList();
 
         return CartResponse.of(cart, itemDetails);
+    }
+
+    // 장바구니 비우기
+    @Override
+    public CartClearResponse clearCart(UUID userId) {
+        Cart cart = getCartByUserId(userId);
+        List<CartItem> cartItems = cartItemRepository.findAllByCartId(cart.getId());
+        cartItemRepository.deleteAllInBatch(cartItems);
+        return CartClearResponse.of();
+    }
+
+    // 장바구니 아이템 갯수 증감
+    @Override
+    public CartItemQuantityResponse updateTicket(UUID userId, Long cartItemId, CartItemQuantityRequest request) {
+        // 장바구니 가져오기
+        Cart cart = getCartByUserId(userId);
+        // 장바구니 아이템 가져오기
+        CartItem cartItem = getCartItemById(cartItemId);
+
+        // 장바구니 아이템이 유저의 장바구니 아이템인가 확인 예외
+        if (!cartItem.getCartId().equals(cart.getId())) {
+            throw new BusinessException(CartErrorCode.ITEM_NOT_FOUND);
+        }
+
+        cartItem.addQuantity(request.quantity());
+
+        CartItem savedCartItem = cartItemRepository.save(cartItem);
+
+        return CartItemQuantityResponse.of(savedCartItem);
+    }
+
+    // 장바구니 아이템 삭제
+    @Override
+    public CartItemDeleteResponse deleteTicket(UUID userId, Long cartItemId) {
+        // 장바구니 가져오기
+        Cart cart = getCartByUserId(userId);
+        // 장바구니 아이템 가져오기
+        CartItem cartItem = getCartItemById(cartItemId);
+
+        // 장바구니 아이템이 유저의 장바구니 아이템인가 확인 예외
+        if (!cartItem.getCartId().equals(cart.getId())) {
+            throw new BusinessException(CartErrorCode.ITEM_NOT_FOUND);
+        }
+
+        cartItemRepository.deleteAllInBatch(List.of(cartItem));
+        return CartItemDeleteResponse.of();
     }
 
     // =========================================================================
@@ -135,6 +185,20 @@ public class CartService implements CartUseCase {
                 throw new BusinessException(EventErrorCode.INVALID_PURCHASE_REQUEST);
             }
         }
+
+    }
+
+
+    // 장바구니 존재 유무 확인
+    private Cart getCartByUserId(UUID userId) {
+        return cartRepository.findByUserId(userId)
+            .orElseThrow(() -> new BusinessException(CartErrorCode.CART_EMPTY));
+    }
+
+    // 장바구니 아이템 존재 유무 확인
+    private CartItem getCartItemById(Long cartItemId) {
+        return cartItemRepository.findById(cartItemId)
+            .orElseThrow(() -> new BusinessException(CartErrorCode.ITEM_NOT_FOUND));
     }
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/application/usecase/CartItemUseCase.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/usecase/CartItemUseCase.java
@@ -1,10 +1,15 @@
 package com.devticket.commerce.cart.application.usecase;
 
-import com.devticket.commerce.cart.presentation.dto.req.CartItemRequest;
-import com.devticket.commerce.cart.presentation.dto.res.CartItemResponse;
+import com.devticket.commerce.cart.presentation.dto.req.CartItemQuantityRequest;
+import com.devticket.commerce.cart.presentation.dto.res.CartItemDeleteResponse;
+import com.devticket.commerce.cart.presentation.dto.res.CartItemQuantityResponse;
+import java.util.UUID;
 
 public interface CartItemUseCase {
 
-    CartItemResponse save(Long userId, CartItemRequest request);
-    
+    // 장바구니 티켓 수량 변경
+    CartItemQuantityResponse updateTicket(UUID userId, Long cartItemId, CartItemQuantityRequest request);
+
+    CartItemDeleteResponse deleteTicket(UUID userId, Long cartItemId);
+
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/application/usecase/CartUseCase.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/usecase/CartUseCase.java
@@ -1,6 +1,7 @@
 package com.devticket.commerce.cart.application.usecase;
 
 import com.devticket.commerce.cart.presentation.dto.req.CartItemRequest;
+import com.devticket.commerce.cart.presentation.dto.res.CartClearResponse;
 import com.devticket.commerce.cart.presentation.dto.res.CartItemResponse;
 import com.devticket.commerce.cart.presentation.dto.res.CartResponse;
 import java.util.UUID;
@@ -15,4 +16,8 @@ public interface CartUseCase {
 
     // 장바구니 조회
     CartResponse getCart(UUID userId);
+
+    // 장바구니 전체 티켓 삭제
+    CartClearResponse clearCart(UUID userId);
+
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/domain/repository/CartItemRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/domain/repository/CartItemRepository.java
@@ -17,4 +17,7 @@ public interface CartItemRepository {
 
     // 장바구니 전체 조회
     List<CartItem> findAllByCartId(Long cartId);
+
+    // 장바구니 아이템 조회
+    Optional<CartItem> findById(Long cartItemId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/domain/repository/CartRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/domain/repository/CartRepository.java
@@ -9,4 +9,5 @@ public interface CartRepository {
     Optional<Cart> findByUserId(UUID userId);
 
     Cart save(Cart cart);
+
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemRepositoryAdapter.java
@@ -37,4 +37,9 @@ public class CartItemRepositoryAdapter implements CartItemRepository {
     public List<CartItem> findAllByCartId(Long cartId) {
         return cartItemJpaRepository.findAllByCartId(cartId);
     }
+
+    @Override
+    public Optional<CartItem> findById(Long cartItemId) {
+        return cartItemJpaRepository.findById(cartItemId);
+    }
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/controller/CartController.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/controller/CartController.java
@@ -1,7 +1,12 @@
 package com.devticket.commerce.cart.presentation.controller;
 
+import com.devticket.commerce.cart.application.usecase.CartItemUseCase;
 import com.devticket.commerce.cart.application.usecase.CartUseCase;
+import com.devticket.commerce.cart.presentation.dto.req.CartItemQuantityRequest;
 import com.devticket.commerce.cart.presentation.dto.req.CartItemRequest;
+import com.devticket.commerce.cart.presentation.dto.res.CartClearResponse;
+import com.devticket.commerce.cart.presentation.dto.res.CartItemDeleteResponse;
+import com.devticket.commerce.cart.presentation.dto.res.CartItemQuantityResponse;
 import com.devticket.commerce.cart.presentation.dto.res.CartItemResponse;
 import com.devticket.commerce.cart.presentation.dto.res.CartResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,7 +15,10 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -24,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CartController {
 
     private final CartUseCase cartUseCase;
+    private final CartItemUseCase cartItemUseCase;
 
     @PostMapping("/items")
     @Operation(description = "장바구니 담기")
@@ -43,6 +52,45 @@ public class CartController {
         @RequestHeader("X-User-Id") UUID userId
     ) {
         CartResponse response = cartUseCase.getCart(userId);
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(response);
+    }
+
+    @PatchMapping("/items/{cartItemId}")
+    @Operation(description = "장바구니 아이템 증감")
+    public ResponseEntity<CartItemQuantityResponse> updateCartItemQuantity(
+        @RequestHeader("X-User-Id") UUID userId,
+        @PathVariable Long cartItemId,
+        @RequestBody CartItemQuantityRequest request
+    ) {
+        CartItemQuantityResponse response = cartItemUseCase.updateTicket(userId, cartItemId, request);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(response);
+    }
+
+    @DeleteMapping("/items/{cartItemId}")
+    @Operation(description = "장바구니 아이템 삭제")
+    public ResponseEntity<CartItemDeleteResponse> deleteCartItem(
+        @PathVariable Long cartItemId,
+        @RequestHeader("X-User-Id") UUID userId
+    ) {
+        CartItemDeleteResponse response = cartItemUseCase.deleteTicket(userId, cartItemId);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(response);
+    }
+
+    @DeleteMapping
+    @Operation(description = "장바구니 아이템 전체 삭제")
+    public ResponseEntity<CartClearResponse> deleteCartItemAll(
+        @RequestHeader("X-User-Id") UUID userId
+    ) {
+        CartClearResponse response = cartUseCase.clearCart(userId);
+
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(response);

--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartClearResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartClearResponse.java
@@ -1,0 +1,17 @@
+package com.devticket.commerce.cart.presentation.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "장바구니 전체 삭제 응답")
+public record CartClearResponse(
+
+    @Schema(description = "응답 메시지")
+    String message
+
+) {
+
+    public static CartClearResponse of() {
+        return new CartClearResponse("삭제 완료");
+    }
+
+}

--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDeleteResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDeleteResponse.java
@@ -1,0 +1,16 @@
+package com.devticket.commerce.cart.presentation.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "장바구니 아이템 삭제 응답")
+public record CartItemDeleteResponse(
+
+    @Schema(description = "응답 메시지")
+    String message
+
+) {
+
+    public static CartItemDeleteResponse of() {
+        return new CartItemDeleteResponse("삭제되었습니다.");
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- PATCH /cart/items/{cartItemId} - 아이템 수량 증감 (양수: 증가, 음수: 감소)
- DELETE /cart/items/{cartItemId} - 특정 아이템 삭제
- DELETE /cart - 장바구니 전체 아이템 삭제

## 변경 사항
- `CartController` - PATCH, DELETE 엔드포인트 추가
- `CartUseCase` - updateTicket(), deleteTicket(), clearCart() 추가
- `CartService` - 위 메서드 로직 구현
- `CartItemQuantityRequest` - 신규 DTO 추가
- `CartItemQuantityResponse` - 신규 DTO 추가
- `CartItemDeleteResponse` - 신규 DTO 추가
- `CartClearResponse` - 신규 DTO 추가
- `CartItemRepository` - findById() 추가
- `CartItemJpaRepository` - findById() 쿼리 메서드 추가
- `CartItemRepositoryAdapter` - findById() 구현체 추가
- `CartService` - getCartByUserId(), getCartItemById() 헬퍼 메서드 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인

## 스크린샷
<!-- API 응답, Swagger 캡처 등 필요 시 첨부 -->

## 참고 사항
- 수량이 1 미만이 되면 INVALID_QUANTITY 예외 반환
- 다른 사용자의 아이템 접근 시 ITEM_NOT_FOUND 예외 반환
- 전체 삭제 시 장바구니 자체는 유지, 아이템만 삭제