### PR TITLE
[Payment] test: 결제 ready, confirm, fail 유닛 테스트 작성

### DIFF
--- a/payment/src/main/java/com/devticket/payment/mock/MockCommerceController.java
+++ b/payment/src/main/java/com/devticket/payment/mock/MockCommerceController.java
@@ -17,7 +17,7 @@ public class MockCommerceController {
     @GetMapping("/internal/orders/{orderId}")
     public InternalOrderInfoResponse getOrderInfo(@PathVariable String orderId) {
         return new InternalOrderInfoResponse(
-            4L,
+            1L,
             UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
             "test",
             50000,

--- a/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
@@ -271,7 +271,7 @@ public class PaymentServiceImpl implements PaymentService {
                 e
             );
 
-            payment.fail("주문 완료 처리 실패로 승인 후 자동 취소됨");
+            payment.fail("주문 완료 처리 실패 및 PG 자동 취소 실패");
             paymentRepository.save(payment);
 
             throw new PaymentException(PaymentErrorCode.PG_REFUND_FAILED);

--- a/payment/src/main/resources/application-local.yml
+++ b/payment/src/main/resources/application-local.yml
@@ -34,11 +34,9 @@ logging:
 
 internal:
   commerce:
-    #base-url: http://commerce-service:8083
-    base-url: http://localhost:8084/mock/commerce
+    base-url: http://commerce-service:8083
 
 pg:
   toss:
-    #base-url: https://api.tosspayments.com
-    base-url: http://localhost:8084/mock/pg
+    base-url: https://api.tosspayments.com
     secret-key: ${PG_SECRET_KEY}


### PR DESCRIPTION
## 관련 이슈
close #147 

## 작업 내용
- PaymentServiceImpl의 readyPayment, confirmPgPayment, failPgPayment에 대한 유닛 테스트를 작성했습니다. 테스트 작성 과정에서 발견된 트랜잭션 관련 버그도 함께 수정했습니다.

## 변경 사항
 버그 수정 — PaymentServiceImpl
  - 클래스 레벨 @Transactional(readOnly = true) 제거
    - 기존에 read-only 트랜잭션을 상속받아 confirmPgPayment의 paymentRepository.save()가 DB에 반영되지 않는 문제 수정

  테스트 — PaymentServiceImplTest (신규, 총 20개)
  - 기존 PaymentServiceTest 대체 (@Nested + @DisplayName 구조로 재작성)


## 테스트
- [x] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인