### PR TITLE
[Commerce] feat: 판매자 이벤트 참여자 목록 조회 API 구현

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderItemRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderItemRepository.java
@@ -3,6 +3,7 @@ package com.devticket.commerce.order.domain.repository;
 import com.devticket.commerce.order.domain.model.OrderItem;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface OrderItemRepository {
@@ -16,4 +17,6 @@ public interface OrderItemRepository {
     List<OrderItem> findSettlementItems(UUID sellerId, LocalDateTime periodStart, LocalDateTime periodEnd);
 
     List<OrderItem> findAllByEventId(Long eventId);
+
+    Optional<OrderItem> findByOrderItemId(UUID orderItemId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderItemJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderItemJpaRepository.java
@@ -3,6 +3,7 @@ package com.devticket.commerce.order.infrastructure.persistence;
 import com.devticket.commerce.order.domain.model.OrderItem;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -25,4 +26,6 @@ public interface OrderItemJpaRepository extends JpaRepository<OrderItem, Long> {
     );
 
     List<OrderItem> findAllByEventId(Long eventId);
+
+    Optional<OrderItem> findByOrderItemId(UUID orderItemId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderItemRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderItemRepositoryAdapter.java
@@ -4,6 +4,7 @@ import com.devticket.commerce.order.domain.model.OrderItem;
 import com.devticket.commerce.order.domain.repository.OrderItemRepository;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -37,5 +38,10 @@ public class OrderItemRepositoryAdapter implements OrderItemRepository {
     @Override
     public List<OrderItem> findAllByEventId(Long eventId) {
         return orderItemJpaRepository.findAllByEventId(eventId);
+    }
+
+    @Override
+    public Optional<OrderItem> findByOrderItemId(UUID orderItemId) {
+        return orderItemJpaRepository.findByOrderItemId(orderItemId);
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
@@ -1,7 +1,9 @@
 package com.devticket.commerce.ticket.application.service;
 
 import com.devticket.commerce.common.exception.BusinessException;
+import com.devticket.commerce.order.domain.exception.OrderErrorCode;
 import com.devticket.commerce.order.domain.exception.OrderItemErrorCode;
+import com.devticket.commerce.order.domain.model.Order;
 import com.devticket.commerce.order.domain.model.OrderItem;
 import com.devticket.commerce.order.domain.repository.OrderItemRepository;
 import com.devticket.commerce.order.domain.repository.OrderRepository;
@@ -9,10 +11,15 @@ import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
 import com.devticket.commerce.ticket.domain.model.Ticket;
 import com.devticket.commerce.ticket.domain.repository.TicketRepository;
 import com.devticket.commerce.ticket.infrastructure.external.client.TicketToEventClient;
+import com.devticket.commerce.ticket.infrastructure.external.client.TicketToMemberClient;
 import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalBulkEventInfoRequest;
 import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalEventInfoResponse;
+import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalMemberInfoResponse;
+import com.devticket.commerce.ticket.presentation.dto.req.SellerEventParticipantListRequest;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketListRequest;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
+import com.devticket.commerce.ticket.presentation.dto.res.SellerEventParticipantListResponse;
+import com.devticket.commerce.ticket.presentation.dto.res.SellerEventParticipantResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketDetailResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketListResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketResponse;
@@ -36,6 +43,7 @@ public class TicketService implements TicketUsecase {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final TicketToEventClient ticketToEventClient;
+    private final TicketToMemberClient ticketToMemberClient;
 
     @Override
     public TicketListResponse getTicketList(UUID userId, TicketListRequest request) {
@@ -96,5 +104,42 @@ public class TicketService implements TicketUsecase {
 
         //응답데이터 구성
         return TicketResponse.of(request.orderId(), savedTickets);
+    }
+
+    public SellerEventParticipantListResponse getParticipantList(UUID userId, Long eventId,
+        SellerEventParticipantListRequest request) {
+
+        // 1단계: eventId로 티켓 목록 조회 (페이징)
+        Page<Ticket> ticketPage = ticketRepository.findAllByEventId(eventId, request);
+
+        // 2단계: 각 티켓별로 필요한 정보 조합
+        List<SellerEventParticipantResponse> participants = ticketPage.getContent().stream()
+            .map(ticket -> {
+
+                // orderItemId로 OrderItem 조회
+                OrderItem orderItem = orderItemRepository.findByOrderItemId(ticket.getOrderItemId())
+                    .orElseThrow(() -> new BusinessException(OrderItemErrorCode.ORDER_ITEM_NOT_FOUND));
+
+                // orderId로 Order 조회 → orderNumber 가져오기
+                Order order = orderRepository.findById(orderItem.getOrderId())
+                    .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+                // userId로 Member 서비스 호출 → email 가져오기
+                InternalMemberInfoResponse memberInfo = ticketToMemberClient.getMemberInfo(ticket.getUserId());
+
+                return SellerEventParticipantResponse.of(
+                    ticket.getTicketId().toString(),
+                    order.getOrderId().toString(),
+                    ticket.getUserId().toString(),
+                    memberInfo.email(),
+                    ticket.getIssuedAt().toString(),
+                    order.getOrderNumber()
+                );
+            })
+            .toList();
+
+        // 3단계: 응답 구성
+        return SellerEventParticipantListResponse.of(ticketPage, participants);
+
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/application/usecase/TicketUsecase.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/application/usecase/TicketUsecase.java
@@ -1,7 +1,9 @@
 package com.devticket.commerce.ticket.application.usecase;
 
+import com.devticket.commerce.ticket.presentation.dto.req.SellerEventParticipantListRequest;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketListRequest;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
+import com.devticket.commerce.ticket.presentation.dto.res.SellerEventParticipantListResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketListResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketResponse;
 import java.util.UUID;
@@ -12,4 +14,8 @@ public interface TicketUsecase {
 
     // --- internal request
     TicketResponse createTicket(TicketRequest request);
+
+    // 이벤트 참가자 조회
+    SellerEventParticipantListResponse getParticipantList(UUID userId, Long eventId,
+        SellerEventParticipantListRequest request);
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
@@ -1,6 +1,7 @@
 package com.devticket.commerce.ticket.domain.repository;
 
 import com.devticket.commerce.ticket.domain.model.Ticket;
+import com.devticket.commerce.ticket.presentation.dto.req.SellerEventParticipantListRequest;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketListRequest;
 import java.util.List;
 import java.util.UUID;
@@ -13,4 +14,6 @@ public interface TicketRepository {
     Page<Ticket> findAllByUserId(UUID userId, TicketListRequest request);
 
     List<Ticket> saveAll(List<Ticket> ticketList);
+
+    Page<Ticket> findAllByEventId(Long eventId, SellerEventParticipantListRequest request);
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/config/TicketRestClientConfig.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/config/TicketRestClientConfig.java
@@ -20,5 +20,14 @@ public class TicketRestClientConfig {
             .build();
     }
 
+    // 2. Ticket-Member 내부API용 설정
+    @Bean
+    public RestClient ticketToMemberRestClient(@Value("${external.member-base-url}") String baseUrl) {
+        return RestClient.builder()
+            .baseUrl(baseUrl)
+            .defaultHeader("Content-Type", "application/json")
+            .build();
+    }
+
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/external/client/TicketToMemberClient.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/external/client/TicketToMemberClient.java
@@ -1,0 +1,45 @@
+package com.devticket.commerce.ticket.infrastructure.external.client;
+
+import com.devticket.commerce.common.exception.BusinessException;
+import com.devticket.commerce.common.exception.CommonErrorCode;
+import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalMemberInfoResponse;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class TicketToMemberClient {
+
+    private final RestClient restClient;
+
+    public TicketToMemberClient(@Qualifier("ticketToMemberRestClient") RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    public InternalMemberInfoResponse getMemberInfo(UUID userId) {
+        try {
+            log.info("[TicketToMemberClient] getMemberInfo - userId: {}", userId);
+
+            return restClient.get()
+                .uri("/internal/members/{userId}", userId)
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    log.error("[TicketToMemberClient] External API Error: Status {}", res.getStatusCode());
+                    throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
+                })
+                .body(InternalMemberInfoResponse.class);
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[TicketToMemberClient] Critical Error: ", e);
+            throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/external/client/dto/InternalMemberInfoResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/external/client/dto/InternalMemberInfoResponse.java
@@ -1,0 +1,7 @@
+package com.devticket.commerce.ticket.infrastructure.external.client.dto;
+
+public record InternalMemberInfoResponse(
+    String email
+) {
+
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketJpaRepository.java
@@ -9,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TicketJpaRepository extends JpaRepository<Ticket, Long> {
 
     Page<Ticket> findAllByUserId(UUID userId, Pageable pageable);
+    
+    Page<Ticket> findAllByEventId(Long eventId, Pageable pageable);
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.devticket.commerce.ticket.infrastructure.persistence;
 
 import com.devticket.commerce.ticket.domain.model.Ticket;
 import com.devticket.commerce.ticket.domain.repository.TicketRepository;
+import com.devticket.commerce.ticket.presentation.dto.req.SellerEventParticipantListRequest;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketListRequest;
 import java.util.List;
 import java.util.UUID;
@@ -28,5 +29,10 @@ public class TicketRepositoryAdapter implements TicketRepository {
     @Override
     public List<Ticket> saveAll(List<Ticket> ticketList) {
         return ticketJpaRepository.saveAll(ticketList);
+    }
+
+    @Override
+    public Page<Ticket> findAllByEventId(Long eventId, SellerEventParticipantListRequest request) {
+        return ticketJpaRepository.findAllByEventId(eventId, request.toPageable());
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/SellerTicketController.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/SellerTicketController.java
@@ -1,0 +1,39 @@
+package com.devticket.commerce.ticket.presentation.controller;
+
+import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
+import com.devticket.commerce.ticket.presentation.dto.req.SellerEventParticipantListRequest;
+import com.devticket.commerce.ticket.presentation.dto.res.SellerEventParticipantListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/seller/events")
+@Tag(name = "Seller Ticket API", description = "판매자 대상 티켓 API")
+public class SellerTicketController {
+
+    private final TicketUsecase ticketUsecase;
+
+    @GetMapping("/{eventId}/participants")
+    @Operation(description = "이벤트 참여자 목록 조회")
+    public ResponseEntity<SellerEventParticipantListResponse> getParticipantList(
+        @RequestHeader("X-User-Id") UUID userId,
+        @PathVariable Long eventId,
+        @ModelAttribute SellerEventParticipantListRequest request
+    ) {
+        SellerEventParticipantListResponse response = ticketUsecase.getParticipantList(userId, eventId, request);
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(response);
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/SellerEventParticipantListRequest.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/SellerEventParticipantListRequest.java
@@ -1,0 +1,20 @@
+package com.devticket.commerce.ticket.presentation.dto.req;
+
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public record SellerEventParticipantListRequest(
+    Integer page,
+    Integer size,
+    String keyword
+) {
+
+    public Pageable toPageable() {
+        int targetPage = (page < 1) ? 0 : page - 1;
+        int targetSize = (size < 1) ? 10 : size;
+        return PageRequest.of(targetPage, targetSize, Sort.by("issuedAt").descending());
+    }
+
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantListResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantListResponse.java
@@ -1,0 +1,33 @@
+package com.devticket.commerce.ticket.presentation.dto.res;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record SellerEventParticipantListResponse(
+
+    List<SellerEventParticipantResponse> sellerEventParticipantListResponse,
+
+    int page,
+
+    int size,
+
+    long totalElements,
+
+    int totalPages
+) {
+
+    public static SellerEventParticipantListResponse of(
+        Page<?> pageInfo,
+        List<SellerEventParticipantResponse> content
+    ) {
+        return new SellerEventParticipantListResponse(
+            content,
+            pageInfo.getNumber(),
+            pageInfo.getSize(),
+            pageInfo.getTotalElements(),
+            pageInfo.getTotalPages()
+        );
+    }
+
+
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantResponse.java
@@ -1,0 +1,27 @@
+package com.devticket.commerce.ticket.presentation.dto.res;
+
+//SellerEventParticipantListResponse 내에 들어 가는 List dto
+public record SellerEventParticipantResponse(
+    String ticketId,
+    String orderId,
+    String userId,
+//    String userName, 차후 entity 수정 후 결정
+    String email,
+    String purchasedAt,
+    String orderNumber
+) {
+
+    public static SellerEventParticipantResponse of(
+        String ticketId,
+        String orderId,
+        String userId,
+//        String userName,
+        String email,
+        String purchasedAt,
+        String orderNumber) {
+        return new SellerEventParticipantResponse(
+            ticketId, orderId, userId, email, purchasedAt, orderNumber
+        );
+    }
+
+}

--- a/commerce/src/main/resources/application-local.yml
+++ b/commerce/src/main/resources/application-local.yml
@@ -29,3 +29,4 @@ logging:
 external:
   event-base-url: http://localhost:8083
   payment-base-url: http://localhost:8083
+  member-base-url: http://localhost:8083

--- a/commerce/src/test/java/com/devticket/commerce/cart/application/service/CartServiceTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/cart/application/service/CartServiceTest.java
@@ -1,4 +1,5 @@
 package com.devticket.commerce.cart.application.service;
 
 public class CartServiceTest {
+
 }


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- GET /seller/events/{eventId}/participants - 판매자 이벤트 참여자 목록 조회
- X-User-Id 헤더로 판매자 식별
- 이름/이메일 검색 키워드, 페이징 지원

## 변경 사항
- `SellerTicketController` - 신규 컨트롤러 추가
- `TicketUsecase` - getParticipantList() 추가
- `TicketService` - getParticipantList() 로직 구현
- `SellerEventParticipantListRequest` - 신규 DTO 추가
- `SellerEventParticipantListResponse` - 신규 DTO 추가
- `SellerEventParticipantResponse` - 신규 DTO 추가
- `TicketToMemberClient` - Member 서비스 호출 클라이언트 추가
- `InternalMemberInfoResponse` - Member API 응답 DTO 추가
- `TicketRestClientConfig` - Member RestClient 빈 추가
- `TicketRepository` - findAllByEventId() 추가
- `TicketJpaRepository` - findAllByEventId() 추가
- `TicketRepositoryAdapter` - findAllByEventId() 구현체 추가
- `OrderItemRepository` - findByOrderItemId() 추가
- `OrderItemJpaRepository` - findByOrderItemId() 추가
- `OrderItemRepositoryAdapter` - findByOrderItemId() 구현체 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷
<!-- API 응답, Swagger 캡처 등 필요 시 첨부 -->

## 참고 사항
- Member 서비스 미실행 시 외부 API 호출 실패
- nickname 필드는 Member API 스펙에 없어 현재 미포함
- base 브랜치: `feat/commerce-ticket`