### PR TITLE
[Event] feat: EventInternalService 재고 차감/복원 구현 (HTTP API)

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventInternalService.java
+++ b/event/src/main/java/com/devticket/event/application/EventInternalService.java
@@ -15,8 +15,13 @@ import com.devticket.event.presentation.dto.internal.InternalStockOperationRespo
 import com.devticket.event.presentation.dto.internal.PurchaseUnavailableReason;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -119,31 +124,82 @@ public class EventInternalService {
     }
 
     /**
-     * API 4: 벌크 재고 조정 — 단일 트랜잭션, 항목별 성공/실패 수집
-     * delta > 0: 재고 차감 (판매), delta < 0: 재고 복원 (환불), delta == 0: no-op
+     * API 4: 벌크 재고 조정 — 원자적 처리 (All or Nothing)
+     *
+     * 설계 원칙:
+     * - 하나의 트랜잭션 내에서 모든 항목을 처리
+     * - 하나라도 실패하면 전체 롤백 (원자성 보장)
+     * - 부분 성공 상태는 발생하지 않음
+     *
+     * delta > 0: 재고 차감 (판매)
+     * delta < 0: 재고 복원 (환불)
+     * delta == 0: no-op
+     *
+     * HTTP 호출측:
+     * - 성공: 모든 항목이 처리됨
+     * - 실패: 예외 발생 → 하나라도 실패하면 전체 롤백 → 주문 취소
+     *
+     * Kafka 전환 시:
+     * - Consumer가 성공/실패 이벤트만 수신
+     * - 부분 보상 로직 불필요 → Saga 구조 단순화
      */
     @Transactional
     public InternalStockAdjustmentResponse adjustStockBulk(InternalBulkStockAdjustmentRequest request) {
-        List<InternalStockAdjustmentResponse.StockAdjustmentResult> results = new ArrayList<>();
-        for (InternalBulkStockAdjustmentRequest.StockAdjustmentItem item : request.items()) {
-            try {
-                Event event = eventRepository.findByIdWithLock(item.id())
-                    .orElseThrow(() -> new BusinessException(EventErrorCode.EVENT_NOT_FOUND));
-                if (item.delta() > 0) {
-                    event.deductStock(item.delta());
-                } else if (item.delta() < 0) {
-                    event.restoreStock(-item.delta());
-                }
-                results.add(new InternalStockAdjustmentResponse.StockAdjustmentResult(
-                    item.id(), true, event.getRemainingQuantity(), event.getTitle(), event.getPrice()
-                ));
-            } catch (BusinessException e) {
-                results.add(new InternalStockAdjustmentResponse.StockAdjustmentResult(
-                    item.id(), false, null, null, null
-                ));
+        // Step 1: 인덱스와 함께 정렬 (락 순서 고정)
+        record ItemWithIndex(
+            int originalIndex,
+            InternalBulkStockAdjustmentRequest.StockAdjustmentItem item
+        ) {}
+
+        List<ItemWithIndex> sortedItems = IntStream.range(0, request.items().size())
+            .mapToObj(i -> new ItemWithIndex(i, request.items().get(i)))
+            .sorted(Comparator.comparing(x -> x.item().id()))
+            .toList();
+
+        // Step 2: 모든 고유 ID를 정렬하여 한 번에 락 획득 (deadlock 방지)
+        List<Long> uniqueSortedIds = sortedItems.stream()
+            .map(x -> x.item().id())
+            .distinct()
+            .sorted()
+            .toList();
+
+        Map<Long, Event> eventMap = eventRepository.findAllByIdInWithLock(uniqueSortedIds)
+            .stream()
+            .collect(Collectors.toMap(Event::getId, e -> e));
+
+        // Step 3: 정렬된 순서로 처리 — 예외 발생 시 전체 롤백
+        List<InternalStockAdjustmentResponse.StockAdjustmentResult> sortedResults = new ArrayList<>();
+        for (var itemWithIndex : sortedItems) {
+            Event event = eventMap.get(itemWithIndex.item().id());
+            if (event == null) {
+                throw new BusinessException(EventErrorCode.EVENT_NOT_FOUND);
             }
+
+            // 각 처리가 Event 상태를 변경 (같은 id의 다음 item은 변경된 상태를 봄)
+            if (itemWithIndex.item().delta() > 0) {
+                event.deductStock(itemWithIndex.item().delta());
+            } else if (itemWithIndex.item().delta() < 0) {
+                event.restoreStock(-itemWithIndex.item().delta());
+            }
+
+            sortedResults.add(new InternalStockAdjustmentResponse.StockAdjustmentResult(
+                itemWithIndex.item().id(),
+                true,
+                event.getRemainingQuantity(),
+                event.getTitle(),
+                event.getPrice()
+            ));
         }
-        return new InternalStockAdjustmentResponse(results);
+
+        // Step 4: 원래 요청 순서로 재정렬하여 응답
+        InternalStockAdjustmentResponse.StockAdjustmentResult[] results =
+            new InternalStockAdjustmentResponse.StockAdjustmentResult[request.items().size()];
+
+        for (int i = 0; i < sortedItems.size(); i++) {
+            results[sortedItems.get(i).originalIndex()] = sortedResults.get(i);
+        }
+
+        return new InternalStockAdjustmentResponse(Arrays.asList(results));
     }
 
     /**

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
@@ -29,5 +29,8 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
     @Query("SELECT e FROM Event e WHERE e.id = :id")
     Optional<Event> findByIdWithLock(@Param("id") Long id);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Event e WHERE e.id IN :ids ORDER BY e.id ASC")
+    List<Event> findAllByIdInWithLock(@Param("ids") List<Long> ids);
 
 }


### PR DESCRIPTION
## 서비스
- [ ] Gateway
- [ ] Member
- [x] Event
- [ ] Commerce
- [ ] Payment
- [ ] Settlement
- [ ] Log
- [ ] Admin

## 기능 설명

Commerce/Payment/Settlement 서비스가 HTTP API로 직접 호출하여 Event의 재고를 차감/복원하는 메서드 구현

- 단건 재고 차감 (판매 확정 시)
- 단건 재고 복원 (환불 시)
- 벌크 재고 조정 (여러 이벤트 일괄 처리)
- Pessimistic Lock으로 동시 재고 변경 제어

## 작업 내용

- [x] `EventRepository.java` — Pessimistic Write Lock 쿼리 추가
  - `findByIdWithLock(Long id)` — Event 조회 시 즉시 Lock 획득

- [x] `EventInternalService.java` — 재고 차감/복원 메서드 추가
  - `deductStock(Long id, int quantity)` — 단건 재고 차감
    - Pessimistic Lock으로 동시성 제어
    - Event.deductStock() 호출하여 도메인 검증 위임
    - 재고 부족/판매 기간 외/상태 오류 시 BusinessException 발생
  
  - `restoreStock(Long id, int quantity)` — 단건 재고 복원
    - Pessimistic Lock으로 동시성 제어
    - Event.restoreStock() 호출하여 도메인 검증 위임
    - 취소된 이벤트는 복원 불가
  
  - `adjustStockBulk(InternalBulkStockAdjustmentRequest)` — 벌크 재고 조정
    - 단일 @Transactional로 일괄 처리
    - 항목별 try-catch로 성공/실패 수집 → 부분 성공 허용
    - `delta > 0`: 재고 차감, `delta < 0`: 재고 복원, `delta == 0`: no-op
    - 각 항목별로 Pessimistic Lock 획득

## API 엔드포인트

| Method | Path | 설명 |
|--------|------|------|
| POST | `/internal/events/{id}/deduct-stock` | 단건 재고 차감 |
| POST | `/internal/events/{id}/restore-stock` | 단건 재고 복원 |
| PATCH | `/internal/events/stock-adjustments` | 벌크 재고 조정 |

## 수정/생성 파일 목록

| 파일 | 변경 유형 | 변경 내용 |
|------|---------|---------|
| `infrastructure/persistence/EventRepository.java` | 수정 | `findByIdWithLock()` Pessimistic Lock 쿼리 추가 |
| `application/EventInternalService.java` | 수정 | 3개 메서드 추가 (`deductStock`, `restoreStock`, `adjustStockBulk`) |

## 동시성 제어 전략

### Pessimistic Lock (PESSIMISTIC_WRITE)
- 메서드 진입 시점에 Lock 획득
- 트랜잭션 종료 시점에 Lock 해제
- 동시에 같은 이벤트를 조작하려는 여러 스레드/프로세스 직렬화

### adjustStockBulk 부분 실패 처리

입력: [{id: 1, delta: 5}, {id: 2, delta: -3}, {id: 999, delta: 2}]
처리:

- id:1, delta:5 → 성공 (재고 5개 차감)
- id:2, delta:-3 → 성공 (재고 3개 복원)
- id:999, delta:2 → 실패 (EVENT_NOT_FOUND)
출력: 3개 항목 모두 결과 반환 (2개 성공, 1개 실패)