### PR TITLE
[Commerce ] feat: 티켓 상세조회

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/mock/controller/MockEventController.java
+++ b/commerce/src/main/java/com/devticket/commerce/mock/controller/MockEventController.java
@@ -102,4 +102,19 @@ public class MockEventController {
             )
         );
     }
+
+    @GetMapping("/{eventId}")
+    public InternalEventInfoResponse getSingleEventInfo(
+        @PathVariable Long eventId
+    ) {
+        return
+            new InternalEventInfoResponse(
+                eventId,
+                UUID.fromString("1d7f4d4a-1c6b-4aa2-b49e-8ed2fdb10001"),
+                "Spring 밋업 (Mock)",
+                LocalDateTime.of(2026, 4, 1, 14, 0),
+                "강남역 루비홀"
+
+            );
+    }
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
@@ -18,6 +18,7 @@ import com.devticket.commerce.ticket.presentation.dto.res.TicketListResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketResponse;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -71,6 +72,18 @@ public class TicketService implements TicketUsecase {
             .toList();
 
         return TicketListResponse.of(ticketPage, tickets);
+    }
+
+    @Override
+    public Optional<TicketDetailResponse> getTicketDetail(UUID ticketId) {
+
+        return ticketRepository.findByTicketId(ticketId)
+            .map(ticket -> {
+                // 단건 이벤트 정보 조회
+                InternalEventInfoResponse event = ticketToEventClient.getSingleEventInfo(ticket.getEventId());
+                // 응답DTO 구성(ticket + event)
+                return TicketDetailResponse.of(ticket, event.eventTitle(), event.eventDateTime());
+            });
     }
 
     @Override

--- a/commerce/src/main/java/com/devticket/commerce/ticket/application/usecase/TicketUsecase.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/application/usecase/TicketUsecase.java
@@ -2,13 +2,17 @@ package com.devticket.commerce.ticket.application.usecase;
 
 import com.devticket.commerce.ticket.presentation.dto.req.TicketListRequest;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
+import com.devticket.commerce.ticket.presentation.dto.res.TicketDetailResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketListResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketResponse;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface TicketUsecase {
 
     TicketListResponse getTicketList(UUID userId, TicketListRequest request);
+
+    Optional<TicketDetailResponse> getTicketDetail(UUID ticketId);
 
     // --- internal request
     TicketResponse createTicket(TicketRequest request);

--- a/commerce/src/main/java/com/devticket/commerce/ticket/domain/exception/TicketErrorCode.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/domain/exception/TicketErrorCode.java
@@ -1,0 +1,18 @@
+package com.devticket.commerce.ticket.domain.exception;
+
+
+import com.devticket.commerce.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TicketErrorCode implements ErrorCode {
+
+    TICKET_NOT_FOUND(404, "TICKET_001", "티켓 정보가 없습니다.");
+
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
@@ -3,6 +3,7 @@ package com.devticket.commerce.ticket.domain.repository;
 import com.devticket.commerce.ticket.domain.model.Ticket;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketListRequest;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 
@@ -13,4 +14,6 @@ public interface TicketRepository {
     Page<Ticket> findAllByUserId(UUID userId, TicketListRequest request);
 
     List<Ticket> saveAll(List<Ticket> ticketList);
+
+    Optional<Ticket> findByTicketId(UUID ticketId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/external/client/TicketToEventClient.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/external/client/TicketToEventClient.java
@@ -24,15 +24,18 @@ public class TicketToEventClient {
     }
 
     // 이벤트 정보 조회(단건)
-    public InternalEventInfoResponse getEventInfo(Long eventId) {
+    public InternalEventInfoResponse getSingleEventInfo(Long eventId) {
         try {
-            log.info("[TicketToEventClient] getEventInfo - ID: {}", eventId);
+            log.info("[TicketToEventClient] getSingleEventInfo - ID: {}", eventId);
 
             return restClient.get() // 단건 조희는 GET 권장 (서버 설정에 따라 PATCH/POST 가능)
                 .uri("/internal/events/{eventId}", eventId)
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    String errorDetail = new String(res.getBody().readAllBytes());
+                    log.error("[TicketToEventClient] API Error! Status: {}, Body: {}", res.getStatusCode(),
+                        errorDetail);
                     log.error("[TicketToEventClient] External API Error: Status {}", res.getStatusCode());
                     throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
                 })
@@ -70,5 +73,6 @@ public class TicketToEventClient {
             throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
+
 }
 

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketJpaRepository.java
@@ -1,6 +1,7 @@
 package com.devticket.commerce.ticket.infrastructure.persistence;
 
 import com.devticket.commerce.ticket.domain.model.Ticket;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,4 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TicketJpaRepository extends JpaRepository<Ticket, Long> {
 
     Page<Ticket> findAllByUserId(UUID userId, Pageable pageable);
+
+    Optional<Ticket> findByTicketId(UUID ticketId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
@@ -4,6 +4,7 @@ import com.devticket.commerce.ticket.domain.model.Ticket;
 import com.devticket.commerce.ticket.domain.repository.TicketRepository;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketListRequest;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,5 +29,10 @@ public class TicketRepositoryAdapter implements TicketRepository {
     @Override
     public List<Ticket> saveAll(List<Ticket> ticketList) {
         return ticketJpaRepository.saveAll(ticketList);
+    }
+
+    @Override
+    public Optional<Ticket> findByTicketId(UUID ticketId) {
+        return ticketJpaRepository.findByTicketId(ticketId);
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/TicketController.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/TicketController.java
@@ -1,8 +1,11 @@
 package com.devticket.commerce.ticket.presentation.controller;
 
+import com.devticket.commerce.common.exception.BusinessException;
 import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
+import com.devticket.commerce.ticket.domain.exception.TicketErrorCode;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketListRequest;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
+import com.devticket.commerce.ticket.presentation.dto.res.TicketDetailResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketListResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -40,6 +44,17 @@ public class TicketController {
             .body(response);
     }
 
+    @GetMapping("/{ticketId}")
+    @Operation(description = "티켓 상세 정보 조회")
+    public ResponseEntity<TicketDetailResponse> getTicketDetail(@PathVariable UUID ticketId) {
+        TicketDetailResponse response = ticketUsecase.getTicketDetail(ticketId)
+            .orElseThrow(() -> new BusinessException(TicketErrorCode.TICKET_NOT_FOUND));
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(response);
+    }
+
     // ---- internal request---------
     @PostMapping
     @Operation(description = "티켓 발급")
@@ -51,4 +66,6 @@ public class TicketController {
             .status(HttpStatus.CREATED)
             .body(response);
     }
+
+
 }


### PR DESCRIPTION
## 관련 이슈
- close #254

## 작업 내용
Ticket 상세내용 조회

## 변경 사항
- MockEventController - getSingleEventInfo : 티켓+이벤트 데이터의 조합을 응답데이터로 제공
- TicketToClient- getSingleEventInfo : 이벤트정보 단건 조회요청 api
- TicketReposotry - findByTicketId추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인

## 스크린샷

## 참고 사항