### PR TITLE
[Commerce] feat : order목록조회, order상세 조회

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -17,9 +17,13 @@ import com.devticket.commerce.order.infrastructure.external.client.OrderToEventC
 import com.devticket.commerce.order.infrastructure.external.client.dto.InternalBulkStockAdjustmentRequest;
 import com.devticket.commerce.order.infrastructure.external.client.dto.InternalStockAdjustmentResponse;
 import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
+import com.devticket.commerce.order.presentation.dto.req.OrderListRequest;
 import com.devticket.commerce.order.presentation.dto.res.InternalSettlementDataResponse;
+import com.devticket.commerce.order.presentation.dto.res.OrderDetailResponse;
+import com.devticket.commerce.order.presentation.dto.res.OrderListResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
 import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
+import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalEventInfoResponse;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -29,6 +33,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -81,6 +88,42 @@ public class OrderService implements OrderUsecase {
                 InternalBulkStockAdjustmentRequest.createForCancel(cartItems));
             throw new BusinessException(OrderErrorCode.ORDER_CREATION_FAILED);
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public OrderDetailResponse getOrderDetail(UUID userId, UUID orderId) {
+        Order order = orderRepository.findByOrderId(orderId)
+            .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.getUserId().equals(userId)) {
+            throw new BusinessException(OrderErrorCode.ORDER_FORBIDDEN);
+        }
+
+        List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(order.getId());
+
+        List<Long> eventIds = orderItems.stream()
+            .map(OrderItem::getEventId)
+            .distinct()
+            .toList();
+
+        Map<Long, String> eventTitles = orderToEventClient.getBulkEventInfo(eventIds).stream()
+            .collect(Collectors.toMap(InternalEventInfoResponse::id, InternalEventInfoResponse::eventTitle));
+
+        return OrderDetailResponse.of(order, orderItems, eventTitles);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public OrderListResponse getOrderList(UUID userId, OrderListRequest request) {
+        OrderStatus status = (request.status() != null && !request.status().isBlank())
+            ? OrderStatus.valueOf(request.status())
+            : null;
+
+        PageRequest pageable = PageRequest.of(request.page() - 1, request.size(), Sort.by("id").descending());
+        Page<Order> orderPage = orderRepository.findAllByUserId(userId, status, pageable);
+
+        return OrderListResponse.of(orderPage);
     }
 
     @Override

--- a/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
@@ -3,7 +3,10 @@ package com.devticket.commerce.order.application.usecase;
 import com.devticket.commerce.mock.controller.dto.InternalOrderInfoResponse;
 import com.devticket.commerce.mock.controller.dto.InternalOrderItemsResponse;
 import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
+import com.devticket.commerce.order.presentation.dto.req.OrderListRequest;
 import com.devticket.commerce.order.presentation.dto.res.InternalSettlementDataResponse;
+import com.devticket.commerce.order.presentation.dto.res.OrderDetailResponse;
+import com.devticket.commerce.order.presentation.dto.res.OrderListResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
 import java.util.UUID;
 
@@ -11,6 +14,12 @@ public interface OrderUsecase {
 
     //주문하기_장바구니에서 단건,다건 주문
     OrderResponse createOrderByCart(UUID userId, CartOrderRequest request);
+
+    //주문 목록 조회
+    OrderListResponse getOrderList(UUID userId, OrderListRequest request);
+
+    //주문 상세 조회
+    OrderDetailResponse getOrderDetail(UUID userId, UUID orderId);
 
     InternalOrderInfoResponse getOrderInfo(Long id);
 

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderRepository.java
@@ -1,9 +1,12 @@
 package com.devticket.commerce.order.domain.repository;
 
+import com.devticket.commerce.common.enums.OrderStatus;
 import com.devticket.commerce.order.domain.model.Order;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderRepository {
 
@@ -16,5 +19,7 @@ public interface OrderRepository {
     Optional<Order> findByOrderId(UUID orderId);
 
     List<Order> findAllByOrderIds(List<UUID> orderIds);
+
+    Page<Order> findAllByUserId(UUID userId, OrderStatus status, Pageable pageable);
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/OrderToEventClient.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/OrderToEventClient.java
@@ -4,6 +4,8 @@ import com.devticket.commerce.common.exception.BusinessException;
 import com.devticket.commerce.common.exception.CommonErrorCode;
 import com.devticket.commerce.order.infrastructure.external.client.dto.InternalBulkStockAdjustmentRequest;
 import com.devticket.commerce.order.infrastructure.external.client.dto.InternalStockAdjustmentResponse;
+import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalBulkEventInfoRequest;
+import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalEventInfoResponse;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -52,6 +54,29 @@ public class OrderToEventClient {
         }
     }
 
+    // 이벤트 정보 여러건 조회 (이벤트 타이틀 등)
+    public List<InternalEventInfoResponse> getBulkEventInfo(List<Long> eventIds) {
+        try {
+            log.info("[OrderToEventClient] getBulkEventInfo - eventIds: {}", eventIds);
+
+            return restClient.post()
+                .uri("/internal/events/bulk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(new InternalBulkEventInfoRequest(eventIds))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    log.error("[OrderToEventClient] API Error Status: {} {}", res.getStatusCode(), res.getStatusText());
+                    throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
+                })
+                .body(new ParameterizedTypeReference<List<InternalEventInfoResponse>>() {});
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[OrderToEventClient] Critical Error (getBulkEventInfo): ", e);
+            throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
 
 }
 

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderJpaRepository.java
@@ -1,9 +1,12 @@
 package com.devticket.commerce.order.infrastructure.persistence;
 
+import com.devticket.commerce.common.enums.OrderStatus;
 import com.devticket.commerce.order.domain.model.Order;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
@@ -15,5 +18,9 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByOrderId(UUID orderId);
 
     List<Order> findAllByOrderIdIn(List<UUID> orderIds);
+
+    Page<Order> findAllByUserId(UUID userId, Pageable pageable);
+
+    Page<Order> findAllByUserIdAndStatus(UUID userId, OrderStatus status, Pageable pageable);
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderRepositoryAdapter.java
@@ -1,11 +1,14 @@
 package com.devticket.commerce.order.infrastructure.persistence;
 
+import com.devticket.commerce.common.enums.OrderStatus;
 import com.devticket.commerce.order.domain.model.Order;
 import com.devticket.commerce.order.domain.repository.OrderRepository;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -38,5 +41,13 @@ public class OrderRepositoryAdapter implements OrderRepository {
     public List<Order> findAllByOrderIds(List<UUID> orderIds) {
         return orderJpaRepository.findAllByOrderIdIn(orderIds);
     }
-    
+
+    @Override
+    public Page<Order> findAllByUserId(UUID userId, OrderStatus status, Pageable pageable) {
+        if (status == null) {
+            return orderJpaRepository.findAllByUserId(userId, pageable);
+        }
+        return orderJpaRepository.findAllByUserIdAndStatus(userId, status, pageable);
+    }
+
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java
@@ -2,6 +2,9 @@ package com.devticket.commerce.order.presentation.controller;
 
 import com.devticket.commerce.order.application.usecase.OrderUsecase;
 import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
+import com.devticket.commerce.order.presentation.dto.req.OrderListRequest;
+import com.devticket.commerce.order.presentation.dto.res.OrderDetailResponse;
+import com.devticket.commerce.order.presentation.dto.res.OrderListResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,6 +12,9 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -33,7 +39,26 @@ public class OrderController {
         return ResponseEntity
             .status(HttpStatus.CREATED)
             .body(response);
+    }
 
+    @GetMapping
+    @Operation(description = "주문 목록 조회 : 내 주문 목록을 페이징으로 조회 (status 파라미터로 필터링 가능)")
+    public ResponseEntity<OrderListResponse> getOrderList(
+        @RequestHeader("X-User-Id") UUID userId,
+        @ModelAttribute OrderListRequest request
+    ) {
+        OrderListResponse response = orderUsecase.getOrderList(userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{orderId}")
+    @Operation(description = "주문 상세 조회 : 특정 주문의 상세 정보 조회")
+    public ResponseEntity<OrderDetailResponse> getOrderDetail(
+        @RequestHeader("X-User-Id") UUID userId,
+        @PathVariable UUID orderId
+    ) {
+        OrderDetailResponse response = orderUsecase.getOrderDetail(userId, orderId);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/OrderListRequest.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/OrderListRequest.java
@@ -1,0 +1,12 @@
+package com.devticket.commerce.order.presentation.dto.req;
+
+public record OrderListRequest(
+    int page,
+    int size,
+    String status
+) {
+    public OrderListRequest {
+        if (page < 1) page = 1;
+        if (size <= 0) size = 10;
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailResponse.java
@@ -1,0 +1,61 @@
+package com.devticket.commerce.order.presentation.dto.res;
+
+import com.devticket.commerce.common.enums.OrderStatus;
+import com.devticket.commerce.common.enums.PaymentMethod;
+import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.model.OrderItem;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "주문 상세 조회 응답 데이터")
+public record OrderDetailResponse(
+    UUID orderId,
+    OrderStatus status,
+    int totalAmount,
+    List<OrderDetailItemResponse> orderItems,
+    PaymentMethod paymentMethod,
+    LocalDateTime createdAt
+) {
+
+    public static OrderDetailResponse of(Order order, List<OrderItem> orderItems, Map<Long, String> eventTitles) {
+        List<OrderDetailItemResponse> itemResponses = orderItems.stream()
+            .map(item -> {
+                String title = eventTitles.getOrDefault(item.getEventId(), "알 수 없는 이벤트");
+                return OrderDetailItemResponse.of(item, title);
+            })
+            .toList();
+
+        return OrderDetailResponse.builder()
+            .orderId(order.getOrderId())
+            .status(order.getStatus())
+            .totalAmount(order.getTotalAmount())
+            .orderItems(itemResponses)
+            .paymentMethod(order.getPaymentMethod())
+            .createdAt(order.getCreatedAt())
+            .build();
+    }
+}
+
+
+@Builder
+record OrderDetailItemResponse(
+    Long eventId,
+    String eventTitle,
+    int quantity,
+    int price
+) {
+
+    static OrderDetailItemResponse of(OrderItem orderItem, String eventTitle) {
+        return OrderDetailItemResponse.builder()
+            .eventId(orderItem.getEventId())
+            .eventTitle(eventTitle)
+            .quantity(orderItem.getQuantity())
+            .price(orderItem.getPrice())
+            .build();
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderListResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderListResponse.java
@@ -1,0 +1,50 @@
+package com.devticket.commerce.order.presentation.dto.res;
+
+import com.devticket.commerce.common.enums.OrderStatus;
+import com.devticket.commerce.order.domain.model.Order;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+@Builder
+@Schema(description = "주문 목록 조회 응답 데이터")
+public record OrderListResponse(
+    List<OrderSummary> orders,
+    int totalPages,
+    long totalElements
+) {
+
+    public static OrderListResponse of(Page<Order> orderPage) {
+        List<OrderSummary> orders = orderPage.getContent().stream()
+            .map(OrderSummary::of)
+            .toList();
+
+        return OrderListResponse.builder()
+            .orders(orders)
+            .totalPages(orderPage.getTotalPages())
+            .totalElements(orderPage.getTotalElements())
+            .build();
+    }
+}
+
+
+@Builder
+record OrderSummary(
+    UUID orderId,
+    int totalAmount,
+    OrderStatus status,
+    LocalDateTime createdAt
+) {
+
+    static OrderSummary of(Order order) {
+        return OrderSummary.builder()
+            .orderId(order.getOrderId())
+            .totalAmount(order.getTotalAmount())
+            .status(order.getStatus())
+            .createdAt(order.getCreatedAt())
+            .build();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #257

## 작업 내용
Order목록조회 Order상세조회
- GET /orders
- GET /orders/{orderId}

## 변경 사항
- OrderController - getOrderList,getOrderDetail 추가 
- DTO - OrderDetailResponse, OrderListResponse, OrderListRequest
- Repository - findAllByUserId, findAllByUserIdAndStatus추가 

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인

## 스크린샷

## 참고 사항

