### PR TITLE
[Commerce] fix: 장바구니 조회 응답에 cartItemId 필드 추가

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDetail.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDetail.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record CartItemDetail(
+    Long cartItemId,
     Long eventId,
     String eventTitle,
     int price,
@@ -14,6 +15,7 @@ public record CartItemDetail(
     //엔티티와 외부 정보를 조합하여 DTO로 변환하는 정적 팩토리 메서드
     public static CartItemDetail of(CartItem cartItem, String title, int price) {
         return CartItemDetail.builder()
+            .cartItemId(cartItem.getId())
             .eventId(cartItem.getEventId())
             .eventTitle(title)
             .price(price)

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -18,6 +18,7 @@ import com.devticket.commerce.order.infrastructure.external.client.dto.InternalB
 import com.devticket.commerce.order.infrastructure.external.client.dto.InternalStockAdjustmentResponse;
 import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
 import com.devticket.commerce.order.presentation.dto.res.InternalSettlementDataResponse;
+import com.devticket.commerce.order.presentation.dto.res.OrderCancelResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
 import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
@@ -212,6 +213,28 @@ public class OrderService implements OrderUsecase {
             log.error("[Settlement Debug] 에러 발생 원인: ", e);
             throw e;
         }
+    }
+
+    // 결제 전 주문 취소
+    @Override
+    public OrderCancelResponse cancelOrder(UUID userId, UUID orderId) {
+        // 1. 주문 정보 확인
+        Order order = orderRepository.findByOrderId(orderId)
+            .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        // 2. 주문자 검증
+        if (!order.getUserId().equals(userId)) {
+            throw new BusinessException(OrderErrorCode.ORDER_FORBIDDEN);
+        }
+        // 3. 결제 상태 체크
+        if (order.getStatus().equals(OrderStatus.PAID)) {
+            throw new BusinessException(OrderErrorCode.ALREADY_PAID_ORDER);
+        }
+        // 4. 주문 취소
+        order.cancel();
+
+        orderRepository.save(order);
+
+        return OrderCancelResponse.of(order);
     }
 
 //    @Override

--- a/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
@@ -4,6 +4,7 @@ import com.devticket.commerce.mock.controller.dto.InternalOrderInfoResponse;
 import com.devticket.commerce.mock.controller.dto.InternalOrderItemsResponse;
 import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
 import com.devticket.commerce.order.presentation.dto.res.InternalSettlementDataResponse;
+import com.devticket.commerce.order.presentation.dto.res.OrderCancelResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
 import java.util.UUID;
 
@@ -21,5 +22,8 @@ public interface OrderUsecase {
     InternalSettlementDataResponse getSettelmentData(UUID sellerId, String periodStart, String periodEnd);
 
     //InternalEventOrdersResponse getOrdersByEvent(Long eventId, String status);
+
+    // 결제 전 주문 취소
+    OrderCancelResponse cancelOrder(UUID userId, UUID orderId);
 }
 

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java
@@ -2,6 +2,7 @@ package com.devticket.commerce.order.presentation.controller;
 
 import com.devticket.commerce.order.application.usecase.OrderUsecase;
 import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
+import com.devticket.commerce.order.presentation.dto.res.OrderCancelResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,6 +10,8 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -34,6 +37,18 @@ public class OrderController {
             .status(HttpStatus.CREATED)
             .body(response);
 
+    }
+    
+    @Operation(description = "결제 전 주문 취소")
+    @PatchMapping("/{orderId}/cancel")
+    public ResponseEntity<OrderCancelResponse> cancelOrder(
+        @RequestHeader("X-User-Id") UUID userId,
+        @PathVariable UUID orderId
+    ) {
+        OrderCancelResponse response = orderUsecase.cancelOrder(userId, orderId);
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(response);
     }
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderCancelResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderCancelResponse.java
@@ -1,0 +1,23 @@
+package com.devticket.commerce.order.presentation.dto.res;
+
+import com.devticket.commerce.order.domain.model.Order;
+import java.time.LocalDateTime;
+
+public record OrderCancelResponse(
+
+    String orderId,
+
+    String status,
+
+    String cancelledAt
+
+) {
+
+    public static OrderCancelResponse of(Order order) {
+        return new OrderCancelResponse(
+            order.getOrderId().toString(),
+            order.getStatus().name(),
+            LocalDateTime.now().toString()
+        );
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- 장바구니 조회(GET /cart) 응답에 cartItemId 필드 추가
- 주문 생성 시 cartItemId를 알 수 없어 주문 불가 문제 해결

## 변경 사항
- `CartItemDetail` - cartItemId 필드 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] Swagger 동작 확인
```

---

**2. 결제 전 주문 취소 PR**

제목:
```
[Commerce] feat: 결제 전 주문 취소 API 구현