### PR TITLE
[commerce] feat : 결제 전 주문 취소 API 구현

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -229,7 +229,11 @@ public class OrderService implements OrderUsecase {
         if (order.getStatus().equals(OrderStatus.PAID)) {
             throw new BusinessException(OrderErrorCode.ALREADY_PAID_ORDER);
         }
-        // 4. 주문 취소
+        // 4. 주문 아이템 조회
+        List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(order.getId());
+        // 5. 재고 복구
+        orderToEventClient.adjustStocks(InternalBulkStockAdjustmentRequest.createForCancelByOrderItems(orderItems));
+        // 6. 주문 취소
         order.cancel();
 
         orderRepository.save(order);

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -20,12 +20,9 @@ import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
 import com.devticket.commerce.order.presentation.dto.req.OrderListRequest;
 import com.devticket.commerce.order.presentation.dto.res.InternalOrderItemResponse;
 import com.devticket.commerce.order.presentation.dto.res.InternalSettlementDataResponse;
-
 import com.devticket.commerce.order.presentation.dto.res.OrderCancelResponse;
-
 import com.devticket.commerce.order.presentation.dto.res.OrderDetailResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderListResponse;
-
 import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
 import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
 import com.devticket.commerce.ticket.domain.enums.TicketStatus;
@@ -301,7 +298,8 @@ public class OrderService implements OrderUsecase {
 
         orderRepository.save(order);
 
-       return OrderCancelResponse.of(order);
+        return OrderCancelResponse.of(order);
+    }
 
 //    @Override
 //    public InternalEventOrdersResponse getOrdersByEvent(Long eventId, String status) {
@@ -358,6 +356,7 @@ public class OrderService implements OrderUsecase {
         return orderItemRepository.saveAll(orderItems);
     }
 
+
     @Override
     @Transactional(readOnly = true)
     public InternalOrderItemResponse getOrderItemByTicketId(Long ticketId) {
@@ -381,7 +380,7 @@ public class OrderService implements OrderUsecase {
             log.info("이미 환불 처리된 티켓입니다. ticketId: {}", ticketId);
             return;
         }
-        
+
         ticket.refundTicket();
 
         // 2. OrderItem 수량 -1, subtotalAmount 재계산

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/dto/InternalBulkStockAdjustmentRequest.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/dto/InternalBulkStockAdjustmentRequest.java
@@ -1,6 +1,7 @@
 package com.devticket.commerce.order.infrastructure.external.client.dto;
 
 import com.devticket.commerce.cart.domain.model.CartItem;
+import com.devticket.commerce.order.domain.model.OrderItem;
 import java.util.List;
 
 public record InternalBulkStockAdjustmentRequest(
@@ -36,6 +37,16 @@ public record InternalBulkStockAdjustmentRequest(
                 .toList()
         );
     }
+
+    // 취소 시 OrderItem 기반 재고 복구
+    public static InternalBulkStockAdjustmentRequest createForCancelByOrderItems(List<OrderItem> orderItems) {
+        return new InternalBulkStockAdjustmentRequest(
+            orderItems.stream()
+                .map(item -> new EventItem(item.getEventId(), item.getQuantity()))
+                .toList()
+        );
+    }
+
 
 }
 


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- PATCH /orders/{orderId}/cancel - 결제 전 주문 취소
- 주문자 검증 및 결제 완료 상태 체크

## 변경 사항
- `OrderController` - PATCH /{orderId}/cancel 엔드포인트 추가
- `OrderUsecase` - cancelOrder() 추가
- `OrderService` - cancelOrder() 로직 구현
- `OrderCancelResponse` - 신규 DTO 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] Swagger 동작 확인

## 참고 사항
- PAID 상태 주문 취소 시 ALREADY_PAID_ORDER 예외 반환
- 다른 사용자 주문 취소 시 ORDER_FORBIDDEN 예외 반환