### PR TITLE
[Member] feat: tech-stack 컨트롤러 분리

### DIFF
--- a/member/src/main/java/com/devticket/member/application/UserService.java
+++ b/member/src/main/java/com/devticket/member/application/UserService.java
@@ -164,6 +164,10 @@ public class UserService {
             .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
+    public List<TechStack> getAllTechStacks() {
+        return techStackRepository.findAll();
+    }
+
     // ========== 유틸 ==========
 
     private Position parsePosition(String position) {

--- a/member/src/main/java/com/devticket/member/presentation/controller/TechStackController.java
+++ b/member/src/main/java/com/devticket/member/presentation/controller/TechStackController.java
@@ -1,0 +1,30 @@
+package com.devticket.member.presentation.controller;
+
+import com.devticket.member.application.UserService;
+import com.devticket.member.presentation.domain.model.TechStack;
+import com.devticket.member.presentation.domain.repository.TechStackRepository;
+import com.devticket.member.presentation.dto.response.TechStackListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "TechStack", description = "기술 스택 API")
+@RestController
+@RequestMapping("/api/tech-stacks")
+@RequiredArgsConstructor
+public class TechStackController {
+
+    private final UserService userService;
+
+    @Operation(summary = "기술 스택 목록 조회", description = "회원가입·프로필·이벤트 생성 시 기술스택 선택용")
+    @GetMapping
+    public ResponseEntity<TechStackListResponse> getTechStacks() {
+        List<TechStack> techStacks = userService.getAllTechStacks();
+        return ResponseEntity.ok(TechStackListResponse.from(techStacks));
+    }
+}

--- a/member/src/main/java/com/devticket/member/presentation/dto/response/TechStackListResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/response/TechStackListResponse.java
@@ -1,0 +1,18 @@
+package com.devticket.member.presentation.dto.response;
+
+import com.devticket.member.presentation.domain.model.TechStack;
+import java.util.List;
+
+public record TechStackListResponse(
+    List<TechStackItem> techStacks
+) {
+    public record TechStackItem(Long techStackId, String name) {}
+
+    public static TechStackListResponse from(List<TechStack> stacks) {
+        List<TechStackItem> items = stacks.stream()
+            .map(s -> new TechStackItem(s.getId(), s.getName()))
+            .toList();
+        return new TechStackListResponse(items);
+    }
+}
+


### PR DESCRIPTION
## 관련 이슈
close #

## 작업 내용
tech-stack의 id를 long타입으로 반환 및 컨트롤러 분리

## 변경 사항
  - tech-stack의 id를 long타입으로 반환 및 컨트롤러 분리



## 테스트
- [x] 단위 테스트 통과
- [x] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인