### PR TITLE
[Payment] feat: 환불 내역 목록 조회 기능 구현

### DIFF
--- a/payment/src/main/java/com/devticket/payment/mock/RefundTestController.java
+++ b/payment/src/main/java/com/devticket/payment/mock/RefundTestController.java
@@ -2,12 +2,17 @@ package com.devticket.payment.mock;
 
 import com.devticket.payment.refund.application.service.RefundService;
 import com.devticket.payment.refund.presentation.dto.RefundInfoResponse;
+import com.devticket.payment.refund.presentation.dto.RefundListItemResponse;
 import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
 import com.devticket.payment.refund.presentation.dto.PgRefundResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,10 +32,17 @@ public class RefundTestController {
 
     private static final UUID TEST_USER_ID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
 
-    @GetMapping
+    @GetMapping("/info")
     public ResponseEntity<RefundInfoResponse> getRefundInfo(@RequestParam String ticketId) {
         RefundInfoResponse response = refundService.getRefundInfo(TEST_USER_ID, ticketId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<RefundListItemResponse>> getRefundList(
+        @PageableDefault(size = 10, sort = "requestedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(refundService.getRefundList(TEST_USER_ID, pageable));
     }
 
     @PostMapping("/pg/{ticketId}")

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundService.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundService.java
@@ -1,11 +1,15 @@
 package com.devticket.payment.refund.application.service;
 
 import com.devticket.payment.refund.presentation.dto.RefundInfoResponse;
+import com.devticket.payment.refund.presentation.dto.RefundListItemResponse;
 import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
 import com.devticket.payment.refund.presentation.dto.PgRefundResponse;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface RefundService {
     RefundInfoResponse getRefundInfo(UUID userId, String ticketId);
     PgRefundResponse refundPgTicket(UUID userId, String ticketId, PgRefundRequest request);
+    Page<RefundListItemResponse> getRefundList(UUID userId, Pageable pageable);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
@@ -19,6 +19,7 @@ import com.devticket.payment.refund.domain.repository.RefundRepository;
 import com.devticket.payment.refund.infrastructure.client.EventInternalClient;
 import com.devticket.payment.refund.infrastructure.client.dto.InternalEventInfoResponse;
 import com.devticket.payment.refund.presentation.dto.RefundInfoResponse;
+import com.devticket.payment.refund.presentation.dto.RefundListItemResponse;
 import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
 import com.devticket.payment.refund.presentation.dto.PgRefundResponse;
 import java.time.LocalDate;
@@ -26,6 +27,8 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -208,6 +211,12 @@ public class RefundServiceImpl implements RefundService {
         if (refundRate <= 0) {
             throw new RefundException(RefundErrorCode.REFUND_NOT_AVAILABLE);
         }
+    }
+
+    @Override
+    public Page<RefundListItemResponse> getRefundList(UUID userId, Pageable pageable) {
+        return refundRepository.findByUserId(userId, pageable)
+            .map(RefundListItemResponse::from);
     }
 
     private LocalDateTime parseCanceledAt(String canceledAt) {

--- a/payment/src/main/java/com/devticket/payment/refund/domain/repository/RefundRepository.java
+++ b/payment/src/main/java/com/devticket/payment/refund/domain/repository/RefundRepository.java
@@ -2,8 +2,11 @@ package com.devticket.payment.refund.domain.repository;
 
 import com.devticket.payment.refund.domain.model.Refund;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface RefundRepository {
     Refund save(Refund refund);
     int sumCompletedRefundAmountByPaymentId(Long paymentId);
+    Page<Refund> findByUserId(UUID userId, Pageable pageable);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundJpaRepository.java
@@ -2,6 +2,9 @@ package com.devticket.payment.refund.infrastructure.persistence;
 
 import com.devticket.payment.refund.domain.model.Refund;
 import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,4 +18,6 @@ public interface RefundJpaRepository extends JpaRepository<Refund, Long> {
       and r.status = com.devticket.payment.refund.domain.enums.RefundStatus.COMPLETED
 """)
     Optional<Integer> sumCompletedRefundAmountByPaymentId(@Param("paymentId") Long paymentId);
+
+    Page<Refund> findByUserId(UUID userId, Pageable pageable);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundRepositoryImpl.java
@@ -4,6 +4,8 @@ import com.devticket.payment.refund.domain.model.Refund;
 import com.devticket.payment.refund.domain.repository.RefundRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -23,4 +25,8 @@ public class RefundRepositoryImpl implements RefundRepository {
             .orElse(0);
     }
 
+    @Override
+    public Page<Refund> findByUserId(UUID userId, Pageable pageable) {
+        return refundJpaRepository.findByUserId(userId, pageable);
+    }
 }

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/controller/RefundController.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/controller/RefundController.java
@@ -2,6 +2,7 @@ package com.devticket.payment.refund.presentation.controller;
 
 import com.devticket.payment.refund.application.service.RefundService;
 import com.devticket.payment.refund.presentation.dto.RefundInfoResponse;
+import com.devticket.payment.refund.presentation.dto.RefundListItemResponse;
 import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
 import com.devticket.payment.refund.presentation.dto.PgRefundResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,12 +39,24 @@ public class RefundController {
         @ApiResponse(responseCode = "200", description = "조회 성공"),
         @ApiResponse(responseCode = "404", description = "결제 정보 없음")
     })
-    @GetMapping()
+    @GetMapping("/info")
     public ResponseEntity<RefundInfoResponse> getRefundInfo(
         @RequestHeader("X-User-Id") UUID userId,
         @RequestParam String ticketId) {
 
         return ResponseEntity.ok(refundService.getRefundInfo(userId, ticketId));
+    }
+
+    @Operation(summary = "환불 내역 목록 조회", description = "사용자의 환불 내역을 페이징으로 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping()
+    public ResponseEntity<Page<RefundListItemResponse>> getRefundList(
+        @RequestHeader("X-User-Id") UUID userId,
+        @PageableDefault(size = 10, sort = "requestedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(refundService.getRefundList(userId, pageable));
     }
 
     @PostMapping("/pg/{ticketId}")

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/dto/RefundListItemResponse.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/dto/RefundListItemResponse.java
@@ -1,0 +1,29 @@
+package com.devticket.payment.refund.presentation.dto;
+
+import com.devticket.payment.refund.domain.model.Refund;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record RefundListItemResponse(
+    String refundId,
+    Long orderId,
+    Long paymentId,
+    Integer refundAmount,
+    Integer refundRate,
+    String status,
+    LocalDateTime requestedAt,
+    LocalDateTime completedAt
+) {
+    public static RefundListItemResponse from(Refund refund) {
+        return new RefundListItemResponse(
+            refund.getRefundId().toString(),
+            refund.getOrderId(),
+            refund.getPaymentId(),
+            refund.getRefundAmount(),
+            refund.getRefundRate(),
+            refund.getStatus().name(),
+            refund.getRequestedAt(),
+            refund.getCompletedAt()
+        );
+    }
+}


### PR DESCRIPTION
## 관련 이슈
close #268 


## 작업 내용
 사용자의 환불 내역을 페이징으로 조회하는 API를 구현했습니다.                                                                                                                                  

  - 엔드포인트: GET /refunds
  - X-User-Id 헤더로 사용자를 식별하여 본인의 환불 내역만 조회
  - 기본값: 페이지당 10건, requestedAt 내림차순 정렬
  - page, size, sort 쿼리 파라미터로 페이징 제어 가능


## 변경 사항
도메인 / 인프라
  - RefundRepository: findByUserId(UUID, Pageable) 메서드 추가
  - RefundJpaRepository: Spring Data 쿼리 메서드 findByUserId 추가
  - RefundRepositoryImpl: 구현 추가

  서비스
  - RefundService: getRefundList(UUID, Pageable) 인터페이스 추가
  - RefundServiceImpl: userId로 환불 내역 조회 후 DTO 변환 구현

  프레젠테이션
  - RefundListItemResponse: 목록 응답 DTO 추가 (refundId, orderId, paymentId, refundAmount, refundRate, status, requestedAt, completedAt)
  - RefundController: GET /refunds 엔드포인트 추가
  - RefundTestController (local): 테스트용 GET /test/refunds 엔드포인트 추가, 기존 환불 정보 조회는 GET /test/refunds/info로 경로 변경


## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인
