### PR TITLE
[Payment]: 환불 상세 조회 api 구현

### DIFF
--- a/payment/src/main/java/com/devticket/payment/mock/RefundTestController.java
+++ b/payment/src/main/java/com/devticket/payment/mock/RefundTestController.java
@@ -1,6 +1,7 @@
 package com.devticket.payment.mock;
 
 import com.devticket.payment.refund.application.service.RefundService;
+import com.devticket.payment.refund.presentation.dto.RefundDetailResponse;
 import com.devticket.payment.refund.presentation.dto.RefundInfoResponse;
 import com.devticket.payment.refund.presentation.dto.RefundListItemResponse;
 import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
@@ -43,6 +44,11 @@ public class RefundTestController {
         @PageableDefault(size = 10, sort = "requestedAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(refundService.getRefundList(TEST_USER_ID, pageable));
+    }
+
+    @GetMapping("/{refundId}")
+    public ResponseEntity<RefundDetailResponse> getRefundDetail(@PathVariable UUID refundId) {
+        return ResponseEntity.ok(refundService.getRefundDetail(TEST_USER_ID, refundId));
     }
 
     @PostMapping("/pg/{ticketId}")

--- a/payment/src/main/java/com/devticket/payment/payment/domain/repository/PaymentRepository.java
+++ b/payment/src/main/java/com/devticket/payment/payment/domain/repository/PaymentRepository.java
@@ -10,4 +10,6 @@ public interface PaymentRepository {
 
     Optional<Payment> findByOrderId(Long orderId);
 
+    Optional<Payment> findById(Long id);
+
 }

--- a/payment/src/main/java/com/devticket/payment/payment/infrastructure/persistence/PaymentRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/payment/infrastructure/persistence/PaymentRepositoryImpl.java
@@ -20,4 +20,9 @@ public class PaymentRepositoryImpl implements PaymentRepository {
 
     @Override
     public Optional<Payment> findByOrderId(Long orderId) { return paymentJpaRepository.findByOrderId(orderId); }
+
+    @Override
+    public Optional<Payment> findById(Long id) {
+        return paymentJpaRepository.findById(id);
+    }
 }

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundService.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundService.java
@@ -1,5 +1,6 @@
 package com.devticket.payment.refund.application.service;
 
+import com.devticket.payment.refund.presentation.dto.RefundDetailResponse;
 import com.devticket.payment.refund.presentation.dto.RefundInfoResponse;
 import com.devticket.payment.refund.presentation.dto.RefundListItemResponse;
 import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
@@ -12,4 +13,5 @@ public interface RefundService {
     RefundInfoResponse getRefundInfo(UUID userId, String ticketId);
     PgRefundResponse refundPgTicket(UUID userId, String ticketId, PgRefundRequest request);
     Page<RefundListItemResponse> getRefundList(UUID userId, Pageable pageable);
+    RefundDetailResponse getRefundDetail(UUID userId, UUID refundId);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
@@ -18,6 +18,7 @@ import com.devticket.payment.refund.domain.model.Refund;
 import com.devticket.payment.refund.domain.repository.RefundRepository;
 import com.devticket.payment.refund.infrastructure.client.EventInternalClient;
 import com.devticket.payment.refund.infrastructure.client.dto.InternalEventInfoResponse;
+import com.devticket.payment.refund.presentation.dto.RefundDetailResponse;
 import com.devticket.payment.refund.presentation.dto.RefundInfoResponse;
 import com.devticket.payment.refund.presentation.dto.RefundListItemResponse;
 import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
@@ -217,6 +218,16 @@ public class RefundServiceImpl implements RefundService {
     public Page<RefundListItemResponse> getRefundList(UUID userId, Pageable pageable) {
         return refundRepository.findByUserId(userId, pageable)
             .map(RefundListItemResponse::from);
+    }
+
+    @Override
+    public RefundDetailResponse getRefundDetail(UUID userId, UUID refundId) {
+        Refund refund = refundRepository.findByRefundId(refundId)
+            .orElseThrow(() -> new RefundException(RefundErrorCode.REFUND_NOT_FOUND));
+        validateOrderOwner(refund.getUserId(), userId);
+        Payment payment = paymentRepository.findById(refund.getPaymentId())
+            .orElseThrow(() -> new RefundException(RefundErrorCode.PAYMENT_NOT_FOUND));
+        return RefundDetailResponse.of(refund, payment.getPaymentMethod().name());
     }
 
     private LocalDateTime parseCanceledAt(String canceledAt) {

--- a/payment/src/main/java/com/devticket/payment/refund/domain/repository/RefundRepository.java
+++ b/payment/src/main/java/com/devticket/payment/refund/domain/repository/RefundRepository.java
@@ -1,6 +1,7 @@
 package com.devticket.payment.refund.domain.repository;
 
 import com.devticket.payment.refund.domain.model.Refund;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,4 +10,5 @@ public interface RefundRepository {
     Refund save(Refund refund);
     int sumCompletedRefundAmountByPaymentId(Long paymentId);
     Page<Refund> findByUserId(UUID userId, Pageable pageable);
+    Optional<Refund> findByRefundId(UUID refundId);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundJpaRepository.java
@@ -20,4 +20,6 @@ public interface RefundJpaRepository extends JpaRepository<Refund, Long> {
     Optional<Integer> sumCompletedRefundAmountByPaymentId(@Param("paymentId") Long paymentId);
 
     Page<Refund> findByUserId(UUID userId, Pageable pageable);
+
+    Optional<Refund> findByRefundId(UUID refundId);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.devticket.payment.refund.infrastructure.persistence;
 
 import com.devticket.payment.refund.domain.model.Refund;
 import com.devticket.payment.refund.domain.repository.RefundRepository;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,5 +29,10 @@ public class RefundRepositoryImpl implements RefundRepository {
     @Override
     public Page<Refund> findByUserId(UUID userId, Pageable pageable) {
         return refundJpaRepository.findByUserId(userId, pageable);
+    }
+
+    @Override
+    public Optional<Refund> findByRefundId(UUID refundId) {
+        return refundJpaRepository.findByRefundId(refundId);
     }
 }

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/controller/RefundController.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/controller/RefundController.java
@@ -1,6 +1,7 @@
 package com.devticket.payment.refund.presentation.controller;
 
 import com.devticket.payment.refund.application.service.RefundService;
+import com.devticket.payment.refund.presentation.dto.RefundDetailResponse;
 import com.devticket.payment.refund.presentation.dto.RefundInfoResponse;
 import com.devticket.payment.refund.presentation.dto.RefundListItemResponse;
 import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
@@ -57,6 +58,19 @@ public class RefundController {
         @PageableDefault(size = 10, sort = "requestedAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(refundService.getRefundList(userId, pageable));
+    }
+
+    @Operation(summary = "환불 상세 조회", description = "refundId로 환불 상세 정보를 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "환불 내역 없음")
+    })
+    @GetMapping("/{refundId}")
+    public ResponseEntity<RefundDetailResponse> getRefundDetail(
+        @RequestHeader("X-User-Id") UUID userId,
+        @PathVariable UUID refundId
+    ) {
+        return ResponseEntity.ok(refundService.getRefundDetail(userId, refundId));
     }
 
     @PostMapping("/pg/{ticketId}")

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/dto/RefundDetailResponse.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/dto/RefundDetailResponse.java
@@ -1,0 +1,30 @@
+package com.devticket.payment.refund.presentation.dto;
+
+import com.devticket.payment.refund.domain.model.Refund;
+import java.time.LocalDateTime;
+
+public record RefundDetailResponse(
+    String refundId,
+    Long orderId,
+    Long paymentId,
+    String paymentMethod,
+    Integer refundAmount,
+    Integer refundRate,
+    String status,
+    LocalDateTime requestedAt,
+    LocalDateTime completedAt
+) {
+    public static RefundDetailResponse of(Refund refund, String paymentMethod) {
+        return new RefundDetailResponse(
+            refund.getRefundId().toString(),
+            refund.getOrderId(),
+            refund.getPaymentId(),
+            paymentMethod,
+            refund.getRefundAmount(),
+            refund.getRefundRate(),
+            refund.getStatus().name(),
+            refund.getRequestedAt(),
+            refund.getCompletedAt()
+        );
+    }
+}


### PR DESCRIPTION
## 관련 이슈
close #270 


## 작업 내용
- refundId(UUID)를 기준으로 특정 환불 건의 상세 정보를 조회하는 API를 구현했습니다. 

## 변경 사항
도메인 / 인프라
  - RefundRepository: findByRefundId(UUID) 메서드 추가
  - RefundJpaRepository: Spring Data 쿼리 메서드 findByRefundId 추가
  - RefundRepositoryImpl: 구현 추가
  - PaymentRepository: findById(Long) 메서드 추가
  - PaymentRepositoryImpl: 구현 추가 (JPA 기본 제공 findById 위임)

  서비스
  - RefundService: getRefundDetail(UUID userId, UUID refundId) 인터페이스 추가
  - RefundServiceImpl: refundId로 환불 조회 → 소유자 검증 → paymentId로 결제 수단 조회 후 응답 구성

  프레젠테이션
  - RefundDetailResponse (신규): 상세 조회 응답 DTO (refundId, orderId, paymentId, paymentMethod, refundAmount, refundRate, status, requestedAt, completedAt)
  - RefundController: GET /refunds/{refundId} 엔드포인트 추가
  - RefundTestController (local): 테스트용 GET /test/refunds/{refundId} 엔드포인트 추가


## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인
