### PR TITLE
[Infra] chore: EC2 배포용 인프라 docker-compose 추가

### DIFF
--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,0 +1,4 @@
+POSTGRES_USER=devticket
+POSTGRES_PASSWORD=your_password_here
+POSTGRES_DB=devticket
+KAFKA_CLUSTER_ID=your-unique-cluster-id-here

--- a/infra/docker-compose.infra.yml
+++ b/infra/docker-compose.infra.yml
@@ -1,0 +1,35 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: devticket-postgres
+    network_mode: host
+    restart: always
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: devticket-kafka
+    network_mode: host
+    restart: always
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9094
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      CLUSTER_ID: ${KAFKA_CLUSTER_ID}
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+
+volumes:
+  postgres-data:
+  kafka-data:

--- a/infra/docker-compose.infra.yml
+++ b/infra/docker-compose.infra.yml
@@ -2,7 +2,8 @@ services:
   postgres:
     image: postgres:16
     container_name: devticket-postgres
-    network_mode: host
+    ports:
+      - "5432:5432"
     restart: always
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
@@ -14,7 +15,8 @@ services:
   kafka:
     image: confluentinc/cp-kafka:7.5.0
     container_name: devticket-kafka
-    network_mode: host
+    ports:
+      - "9092:9092"
     restart: always
     environment:
       KAFKA_NODE_ID: 1


### PR DESCRIPTION
## 작업 내용

- EC2 환경에 PostgreSQL + Kafka를 배포하기 위한 인프라 구성 파일 추가
- 기존 루트의 docker-compose.yml은 로컬 개발용으로 유지, EC2 배포용은 infra/ 폴더로 분리

## 변경 사항

- `infra/docker-compose.infra.yml` 추가
  - PostgreSQL 16, Kafka 7.5.0 (KRaft 모드)
  - `network_mode: host` 적용 → 모든 서비스가 localhost로 통신
  - `restart: always` 적용 → EC2 재시작 시 자동 실행
  - 민감정보는 `.env` 파일로 분리
- `infra/.env.example` 추가
  - EC2 초기 설정 시 참고용 템플릿

## 관련 문서

- EC2 초기 실행: `cp infra/.env.example infra/.env` 후 실제 값 입력 → `docker compose -f infra/docker-compose.infra.yml up -d`
