### PR TITLE
내부API-getBulkEventInfo-requestDTO의 타입 UUID로 수정

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventInternalService.java
+++ b/event/src/main/java/com/devticket/event/application/EventInternalService.java
@@ -47,8 +47,8 @@ public class EventInternalService {
      * API 2: 벌크 이벤트 정보 조회
      * 없는 ID는 조용히 누락 (예외 없음) — 부분 성공 시나리오 허용
      */
-    public InternalBulkEventInfoResponse getBulkEventInfo(List<Long> ids) {
-        List<InternalEventInfoResponse> responses = eventRepository.findAllByIdIn(ids)
+    public InternalBulkEventInfoResponse getBulkEventInfo(List<UUID> eventIds) {
+        List<InternalEventInfoResponse> responses = eventRepository.findAllByEventIdIn(eventIds)
             .stream()
             .map(InternalEventInfoResponse::from)
             .toList();

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Repository;
 public interface EventRepository extends JpaRepository<Event, Long>, EventRepositoryCustom {
 
     // 외부 API
+    List<Event> findAllByEventIdIn(List<UUID> eventIds);
+
     Optional<Event> findByEventId(UUID eventId);
 
     @Query("SELECT DISTINCT e FROM Event e " +

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventInternalController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventInternalController.java
@@ -55,7 +55,7 @@ public class EventInternalController {
     public ResponseEntity<SuccessResponse<InternalBulkEventInfoResponse>> getBulkEventInfo(
         @RequestBody @Valid InternalBulkEventInfoRequest request) {
         return ResponseEntity.ok(SuccessResponse.success(
-            eventInternalService.getBulkEventInfo(request.ids())
+            eventInternalService.getBulkEventInfo(request.eventIds())
         ));
     }
 

--- a/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalBulkEventInfoRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalBulkEventInfoRequest.java
@@ -4,9 +4,10 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
+import java.util.UUID;
 
 public record InternalBulkEventInfoRequest(
     @NotEmpty(message = "ids는 비어있을 수 없습니다")
     @NotNull(message = "ids는 null이 될 수 없습니다")
-    List<@NotNull(message = "ids의 각 원소는 null이 될 수 없습니다") Long> ids
+    List<@NotNull(message = "ids의 각 원소는 null이 될 수 없습니다") UUID> eventIds
 ) {}


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
내부API-getBulkEventInfo-requestDTO의 타입 UUID로 수정

## 변경 사항

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항