### PR TITLE
[Payment] fix: refund 엔티티의 paymentId를 Long에서 UUID로 변경

### DIFF
--- a/payment/src/main/java/com/devticket/payment/payment/domain/repository/PaymentRepository.java
+++ b/payment/src/main/java/com/devticket/payment/payment/domain/repository/PaymentRepository.java
@@ -10,6 +10,6 @@ public interface PaymentRepository {
 
     Optional<Payment> findByOrderId(UUID orderId);
 
-    Optional<Payment> findById(Long id);
+    Optional<Payment> findByPaymentId(UUID id);
 
 }

--- a/payment/src/main/java/com/devticket/payment/payment/infrastructure/persistence/PaymentJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/payment/infrastructure/persistence/PaymentJpaRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByOrderId(UUID orderId);
+    Optional<Payment> findByPaymentId(UUID paymentId);
 }

--- a/payment/src/main/java/com/devticket/payment/payment/infrastructure/persistence/PaymentRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/payment/infrastructure/persistence/PaymentRepositoryImpl.java
@@ -22,7 +22,7 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     public Optional<Payment> findByOrderId(UUID orderId) { return paymentJpaRepository.findByOrderId(orderId); }
 
     @Override
-    public Optional<Payment> findById(Long id) {
-        return paymentJpaRepository.findById(id);
+    public Optional<Payment> findByPaymentId(UUID paymentId) {
+        return paymentJpaRepository.findByPaymentId(paymentId);
     }
 }

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
@@ -105,7 +105,7 @@ public class RefundServiceImpl implements RefundService {
 
         Refund refund = Refund.create(
             orderItem.orderId(),
-            payment.getId(),
+            payment.getPaymentId(),
             userId,
             refundAmount,
             refundRate
@@ -224,7 +224,7 @@ public class RefundServiceImpl implements RefundService {
         Refund refund = refundRepository.findByRefundId(refundId)
             .orElseThrow(() -> new RefundException(RefundErrorCode.REFUND_NOT_FOUND));
         validateOrderOwner(refund.getUserId(), userId);
-        Payment payment = paymentRepository.findById(refund.getPaymentId())
+        Payment payment = paymentRepository.findByPaymentId(refund.getPaymentId())
             .orElseThrow(() -> new RefundException(RefundErrorCode.PAYMENT_NOT_FOUND));
         return RefundDetailResponse.of(refund, payment.getPaymentMethod().name());
     }

--- a/payment/src/main/java/com/devticket/payment/refund/domain/model/Refund.java
+++ b/payment/src/main/java/com/devticket/payment/refund/domain/model/Refund.java
@@ -36,7 +36,7 @@ public class Refund extends BaseEntity {
     private UUID orderId;
 
     @Column(name = "payment_id", nullable = false)
-    private Long paymentId;
+    private UUID paymentId;
 
     @Column(name = "refund_amount", nullable = false)
     private Integer refundAmount;
@@ -63,7 +63,7 @@ public class Refund extends BaseEntity {
 
     public static Refund create(
         UUID orderId,
-        Long paymentId,
+        UUID paymentId,
         UUID userId,
         Integer amount,
         Integer refundRate

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/dto/RefundDetailResponse.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/dto/RefundDetailResponse.java
@@ -2,11 +2,12 @@ package com.devticket.payment.refund.presentation.dto;
 
 import com.devticket.payment.refund.domain.model.Refund;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record RefundDetailResponse(
     String refundId,
-    java.util.UUID orderId,
-    Long paymentId,
+    UUID orderId,
+    UUID paymentId,
     String paymentMethod,
     Integer refundAmount,
     Integer refundRate,

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/dto/RefundListItemResponse.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/dto/RefundListItemResponse.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 public record RefundListItemResponse(
     String refundId,
     UUID orderId,
-    Long paymentId,
+    UUID paymentId,
     Integer refundAmount,
     Integer refundRate,
     String status,


### PR DESCRIPTION
refund의 paymentId를 Long에서 UUID로 변경, 그에 따른 다른 파일 수정