### PR TITLE
[Member] feat: 어드민 판매자 신청 관리 Internal API 구현

### DIFF
--- a/member/src/main/java/com/devticket/member/application/InternalMemberService.java
+++ b/member/src/main/java/com/devticket/member/application/InternalMemberService.java
@@ -2,6 +2,7 @@ package com.devticket.member.application;
 
 import com.devticket.member.common.exception.BusinessException;
 import com.devticket.member.presentation.domain.MemberErrorCode;
+import com.devticket.member.presentation.domain.SellerApplicationDecision;
 import com.devticket.member.presentation.domain.UserRole;
 import com.devticket.member.presentation.domain.model.SellerApplication;
 import com.devticket.member.presentation.domain.model.User;
@@ -52,7 +53,7 @@ public class InternalMemberService {
 
     public InternalSellerInfoResponse getSellerInfo(UUID userId) {
         User user = findUserByUuidOrThrow(userId);
-        SellerApplication application = sellerApplicationRepository.findTopByUserIdOrderByCreatedAtDesc(user.getId())
+        SellerApplication application = sellerApplicationRepository.findTopByUserIdOrderByCreatedAtDesc(user.getUserId())
             .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         return InternalSellerInfoResponse.from(user, application);
     }
@@ -76,14 +77,14 @@ public class InternalMemberService {
             .orElseThrow(()-> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         // 판매자 승인 시
-        if(request.decision().equals("APPROVED")){
+        if(request.decision() == SellerApplicationDecision.APPROVED){
             application.approve();
             User user = userRepository.findByUserId(application.getUserId())
                 .orElseThrow(()-> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
             user.changeRole(UserRole.SELLER);
         }
         // 판매자 미승인 시
-        else if(request.decision().equals("REJECTED")){
+        else if(request.decision().equals(SellerApplicationDecision.REJECTED)){
             application.reject();
         }
 

--- a/member/src/main/java/com/devticket/member/application/InternalMemberService.java
+++ b/member/src/main/java/com/devticket/member/application/InternalMemberService.java
@@ -2,16 +2,22 @@ package com.devticket.member.application;
 
 import com.devticket.member.common.exception.BusinessException;
 import com.devticket.member.presentation.domain.MemberErrorCode;
+import com.devticket.member.presentation.domain.UserRole;
 import com.devticket.member.presentation.domain.model.SellerApplication;
 import com.devticket.member.presentation.domain.model.User;
 import com.devticket.member.presentation.domain.model.UserProfile;
 import com.devticket.member.presentation.domain.repository.SellerApplicationRepository;
 import com.devticket.member.presentation.domain.repository.UserProfileRepository;
 import com.devticket.member.presentation.domain.repository.UserRepository;
+import com.devticket.member.presentation.dto.internal.request.InternalDecideSellerApplicationRequest;
+import com.devticket.member.presentation.dto.internal.response.InternalDecideSellerApplicationResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberInfoResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberRoleResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberStatusResponse;
+import com.devticket.member.presentation.dto.internal.response.InternalSellerApplicationResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalSellerInfoResponse;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -54,5 +60,33 @@ public class InternalMemberService {
     private User findUserByUuidOrThrow(UUID userId) {
         return userRepository.findByUserId(userId)
             .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    // 셀러 변환 요청 리스트 전체 조회
+    public List<InternalSellerApplicationResponse>  getSellerApplications() {
+        return sellerApplicationRepository.findAll().stream()
+            .map(InternalSellerApplicationResponse::from)
+            .toList();
+    }
+
+    // 판매자 승인 결정
+    @Transactional
+    public InternalDecideSellerApplicationResponse decideSellerApplication(UUID applicationId, InternalDecideSellerApplicationRequest request) {
+        SellerApplication application = sellerApplicationRepository.findBySellerApplicationId(applicationId)
+            .orElseThrow(()-> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 판매자 승인 시
+        if(request.decision().equals("APPROVED")){
+            application.approve();
+            User user = userRepository.findByUserId(application.getUserId())
+                .orElseThrow(()-> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+            user.changeRole(UserRole.SELLER);
+        }
+        // 판매자 미승인 시
+        else if(request.decision().equals("REJECTED")){
+            application.reject();
+        }
+
+        return InternalDecideSellerApplicationResponse.from(application);
     }
 }

--- a/member/src/main/java/com/devticket/member/application/SellerApplicationService.java
+++ b/member/src/main/java/com/devticket/member/application/SellerApplicationService.java
@@ -30,7 +30,7 @@ public class SellerApplicationService {
     public SellerApplicationResponse apply(UUID userId, SellerApplicationRequest request) {
         User user = findUserByUuidOrThrow(userId);
         validateNotAlreadySeller(user);
-        validateNoPendingApplication(user.getId());
+        validateNoPendingApplication(user.getUserId());
 
         SellerApplication application = new SellerApplication(
             user.getUserId(),
@@ -46,7 +46,7 @@ public class SellerApplicationService {
 
     public SellerApplicationStatusResponse getMyApplication(UUID userId) {
         User user = findUserByUuidOrThrow(userId);
-        SellerApplication application = sellerApplicationRepository.findTopByUserIdOrderByCreatedAtDesc(user.getId())
+        SellerApplication application = sellerApplicationRepository.findTopByUserIdOrderByCreatedAtDesc(user.getUserId())
             .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         return SellerApplicationStatusResponse.from(application);
@@ -60,7 +60,7 @@ public class SellerApplicationService {
         }
     }
 
-    private void validateNoPendingApplication(Long userId) {
+    private void validateNoPendingApplication(UUID userId) {
         if (sellerApplicationRepository.existsByUserIdAndStatus(userId, SellerApplicationStatus.PENDING)) {
             throw new BusinessException(MemberErrorCode.SELLER_APPLICATION_DUPLICATED);
         }

--- a/member/src/main/java/com/devticket/member/application/SellerApplicationService.java
+++ b/member/src/main/java/com/devticket/member/application/SellerApplicationService.java
@@ -33,7 +33,7 @@ public class SellerApplicationService {
         validateNoPendingApplication(user.getId());
 
         SellerApplication application = new SellerApplication(
-            user.getId(),
+            user.getUserId(),
             request.bankName(),
             request.accountNumber(),
             request.accountHolder()

--- a/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
+++ b/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
@@ -1,19 +1,26 @@
 package com.devticket.member.presentation.controller;
 
 import com.devticket.member.application.InternalMemberService;
+import com.devticket.member.presentation.dto.internal.request.InternalDecideSellerApplicationRequest;
+import com.devticket.member.presentation.dto.internal.response.InternalDecideSellerApplicationResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberInfoResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberRoleResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberStatusResponse;
+import com.devticket.member.presentation.dto.internal.response.InternalSellerApplicationResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalSellerInfoResponse;
+import com.devticket.member.presentation.dto.internal.response.InternalUpdateStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -70,6 +77,40 @@ public class InternalMemberController {
     public ResponseEntity<InternalSellerInfoResponse> getSellerInfo(
         @PathVariable UUID userId) {
         InternalSellerInfoResponse response = internalMemberService.getSellerInfo(userId);
+        return ResponseEntity.ok(response);
+    }
+
+//    @Operation(summary = "회원 상태 변경", description = "내부 서비스용 — 어드민의 회원 상태 변경")
+//    @ApiResponses({
+//        @ApiResponse(responseCode = "200", description = "변경 성공"),
+//        @ApiResponse(responseCode = "404", description = "회원 없음")
+//    })
+//    @PatchMapping("/{userId}/status")
+//    public ResponseEntity<InternalUpdateStatusResponse> updateMemberStatus(){
+//
+//    }
+
+    // 판매자 등록 신청자 리스트
+    @Operation(summary = "판매자 신청 목록 조회", description = "내부 서비스용 — 판매자 신청 목록 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/seller-applications")
+    public ResponseEntity<List<InternalSellerApplicationResponse>> getSellerApplications(){
+        List<InternalSellerApplicationResponse> response = internalMemberService.getSellerApplications();
+        return ResponseEntity.ok(response);
+    }
+
+    // 판매자 승인 결정
+    @Operation(summary = "판매자 신청 승인/반려", description = "내부 서비스용 — 판매자 신청 승인/반려")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "처리 성공"),
+        @ApiResponse(responseCode = "404", description = "신청 없음")
+    })
+    @PatchMapping("/seller-applications/{applicationId}")
+    public ResponseEntity<InternalDecideSellerApplicationResponse> decideSellerApplication(
+        @PathVariable UUID applicationId,
+        @RequestBody InternalDecideSellerApplicationRequest request
+    ){
+        InternalDecideSellerApplicationResponse response=internalMemberService.decideSellerApplication(applicationId, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/member/src/main/java/com/devticket/member/presentation/domain/SellerApplicationDecision.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/SellerApplicationDecision.java
@@ -1,0 +1,6 @@
+package com.devticket.member.presentation.domain;
+
+public enum SellerApplicationDecision {
+    APPROVED,
+    REJECTED
+}

--- a/member/src/main/java/com/devticket/member/presentation/domain/model/SellerApplication.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/model/SellerApplication.java
@@ -29,7 +29,7 @@ public class SellerApplication {
     private UUID sellerApplicationId;
 
     @Column(name = "user_id", nullable = false)
-    private Long userId;
+    private UUID userId;
 
     @Column(name = "bank_name", nullable = false, length = 100)
     private String bankName;
@@ -50,7 +50,7 @@ public class SellerApplication {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    public SellerApplication(Long userId, String bankName,
+    public SellerApplication(UUID userId, String bankName,
         String accountNumber, String accountHolder) {
         this.sellerApplicationId = UUID.randomUUID();
         this.userId = userId;

--- a/member/src/main/java/com/devticket/member/presentation/domain/repository/SellerApplicationRepository.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/repository/SellerApplicationRepository.java
@@ -8,9 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SellerApplicationRepository extends JpaRepository<SellerApplication, Long> {
 
-    Optional<SellerApplication> findTopByUserIdOrderByCreatedAtDesc(Long userId);
+    Optional<SellerApplication> findTopByUserIdOrderByCreatedAtDesc(UUID userId);
 
     Optional<SellerApplication> findBySellerApplicationId(UUID sellerApplicationId);
 
-    boolean existsByUserIdAndStatus(Long userId, SellerApplicationStatus status);
+    boolean existsByUserIdAndStatus(UUID userId, SellerApplicationStatus status);
 }

--- a/member/src/main/java/com/devticket/member/presentation/domain/repository/UserRepository.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/repository/UserRepository.java
@@ -11,6 +11,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUserId(UUID userId);
 
+    Optional<User> findSellerById(Long id);
+
     boolean existsByEmail(String email);
 }
 

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/request/InternalDecideSellerApplicationRequest.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/request/InternalDecideSellerApplicationRequest.java
@@ -1,5 +1,8 @@
 package com.devticket.member.presentation.dto.internal.request;
 
-public record InternalDecideSellerApplicationRequest(String decision) {
+import com.devticket.member.presentation.domain.SellerApplicationDecision;
+
+public record InternalDecideSellerApplicationRequest(
+    SellerApplicationDecision decision) {
 
 }

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/request/InternalDecideSellerApplicationRequest.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/request/InternalDecideSellerApplicationRequest.java
@@ -1,0 +1,5 @@
+package com.devticket.member.presentation.dto.internal.request;
+
+public record InternalDecideSellerApplicationRequest(String decision) {
+
+}

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalDecideSellerApplicationResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalDecideSellerApplicationResponse.java
@@ -1,0 +1,15 @@
+package com.devticket.member.presentation.dto.internal.response;
+
+import com.devticket.member.presentation.domain.model.SellerApplication;
+
+public record InternalDecideSellerApplicationResponse(
+    String sellerApplicationId,
+    String status
+) {
+    public static InternalDecideSellerApplicationResponse from(SellerApplication application){
+        return new InternalDecideSellerApplicationResponse(
+            application.getSellerApplicationId().toString(),
+            application.getStatus().name()
+        );
+    }
+}

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalSellerApplicationResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalSellerApplicationResponse.java
@@ -1,0 +1,26 @@
+package com.devticket.member.presentation.dto.internal.response;
+
+import com.devticket.member.presentation.domain.model.SellerApplication;
+
+public record InternalSellerApplicationResponse(
+    String sellerApplicationId,
+    String userId,
+    String bankName,
+    String accountNumber,
+    String accountHolder,
+    String status,
+    String createdAt
+) {
+    public static InternalSellerApplicationResponse from(SellerApplication application) {
+        return new InternalSellerApplicationResponse(
+            application.getSellerApplicationId().toString(),
+            application.getUserId().toString(),
+            application.getBankName(),
+            application.getAccountNumber(),
+            application.getAccountHolder(),
+            application.getStatus().name(),
+            application.getCreatedAt().toString()
+        );
+    }
+
+}

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalUpdateRoleResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalUpdateRoleResponse.java
@@ -1,0 +1,21 @@
+package com.devticket.member.presentation.dto.internal.response;
+
+import com.devticket.member.presentation.domain.model.User;
+
+public record InternalUpdateRoleResponse(
+
+    String userId,
+
+    String role
+
+) {
+
+    public static InternalUpdateRoleResponse from(User user){
+        return new InternalUpdateRoleResponse(
+            user.getUserId().toString(),
+            user.getStatus().name()
+        );
+    }
+
+
+}

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalUpdateRoleResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalUpdateRoleResponse.java
@@ -13,7 +13,7 @@ public record InternalUpdateRoleResponse(
     public static InternalUpdateRoleResponse from(User user){
         return new InternalUpdateRoleResponse(
             user.getUserId().toString(),
-            user.getStatus().name()
+            user.getRole().name()
         );
     }
 

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalUpdateStatusResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalUpdateStatusResponse.java
@@ -1,0 +1,21 @@
+package com.devticket.member.presentation.dto.internal.response;
+
+
+import com.devticket.member.presentation.domain.model.User;
+
+public record InternalUpdateStatusResponse(
+
+    String userId,
+
+    String status
+
+) {
+
+    public static InternalUpdateStatusResponse from(User user){
+        return new InternalUpdateStatusResponse(
+            user.getUserId().toString(),
+            user.getStatus().name()
+        );
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- 판매자 신청 목록 조회 Internal API 추가 (`GET /internal/members/seller-applications`)
- 판매자 신청 승인/반려 Internal API 추가 (`PATCH /internal/members/seller-applications/{applicationId}`)
- 승인 시 User role SELLER로 변경

## 변경 사항
- `InternalMemberController`: 판매자 신청 관련 엔드포인트 추가
- `InternalMemberService`: getSellerApplications, decideSellerApplication 메서드 추가
- `InternalSellerApplicationResponse`, `InternalDecideSellerApplicationResponse`, `InternalDecideSellerApplicationRequest` DTO 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항
```

---

**Admin 서버:**

커밋:
```
feat(admin): 판매자 신청 심사 기능 구현
```

PR 제목:
```
[Admin] feat: 판매자 신청 심사 기능 구현