### PR TITLE
[Payment] 판매자 이벤트별 환불 내역 조회 api 구현

### DIFF
--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundService.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundService.java
@@ -14,4 +14,5 @@ public interface RefundService {
     PgRefundResponse refundPgTicket(UUID userId, String ticketId, PgRefundRequest request);
     Page<RefundListItemResponse> getRefundList(UUID userId, Pageable pageable);
     RefundDetailResponse getRefundDetail(UUID userId, UUID refundId);
+    Page<RefundListItemResponse> getRefundListByEventId(Long eventId, Pageable pageable);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundService.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundService.java
@@ -3,6 +3,7 @@ package com.devticket.payment.refund.application.service;
 import com.devticket.payment.refund.presentation.dto.RefundDetailResponse;
 import com.devticket.payment.refund.presentation.dto.RefundInfoResponse;
 import com.devticket.payment.refund.presentation.dto.RefundListItemResponse;
+import com.devticket.payment.refund.presentation.dto.SellerRefundListItemResponse;
 import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
 import com.devticket.payment.refund.presentation.dto.PgRefundResponse;
 import java.util.UUID;
@@ -14,5 +15,5 @@ public interface RefundService {
     PgRefundResponse refundPgTicket(UUID userId, String ticketId, PgRefundRequest request);
     Page<RefundListItemResponse> getRefundList(UUID userId, Pageable pageable);
     RefundDetailResponse getRefundDetail(UUID userId, UUID refundId);
-    Page<RefundListItemResponse> getRefundListByEventId(Long eventId, Pageable pageable);
+    Page<SellerRefundListItemResponse> getSellerRefundListByEventId(UUID sellerId, String eventId, Pageable pageable);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
@@ -12,6 +12,7 @@ import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderItem
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.refund.domain.RefundPolicyConstants;
 import com.devticket.payment.refund.domain.RefundRateConstants;
+import com.devticket.payment.refund.domain.enums.RefundStatus;
 import com.devticket.payment.refund.domain.exception.RefundErrorCode;
 import com.devticket.payment.refund.domain.exception.RefundException;
 import com.devticket.payment.refund.domain.model.Refund;
@@ -21,6 +22,7 @@ import com.devticket.payment.refund.infrastructure.client.dto.InternalEventInfoR
 import com.devticket.payment.refund.presentation.dto.RefundDetailResponse;
 import com.devticket.payment.refund.presentation.dto.RefundInfoResponse;
 import com.devticket.payment.refund.presentation.dto.RefundListItemResponse;
+import com.devticket.payment.refund.presentation.dto.SellerRefundListItemResponse;
 import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
 import com.devticket.payment.refund.presentation.dto.PgRefundResponse;
 import com.devticket.payment.wallet.infrastructure.client.dto.InternalEventOrdersResponse;
@@ -233,10 +235,15 @@ public class RefundServiceImpl implements RefundService {
     }
 
     @Override
-    public Page<RefundListItemResponse> getRefundListByEventId(Long eventId, Pageable pageable) {
-        InternalEventOrdersResponse eventOrders = commerceInternalClient.getOrdersByEvent(eventId);
+    public Page<SellerRefundListItemResponse> getSellerRefundListByEventId(UUID sellerId, String eventId, Pageable pageable) {
+        InternalEventInfoResponse event = getEventInfo(UUID.fromString(eventId));
+        if (!event.sellerId().equals(sellerId)) {
+            throw new RefundException(RefundErrorCode.REFUND_INVALID_REQUEST);
+        }
 
-        List<Long> orderIds = eventOrders.getOrders() == null
+        InternalEventOrdersResponse eventOrders = commerceInternalClient.getOrdersByEvent(UUID.fromString(eventId));
+
+        List<UUID> orderIds = eventOrders.getOrders() == null
             ? Collections.emptyList()
             : eventOrders.getOrders().stream()
                 .map(InternalEventOrdersResponse.OrderInfo::getOrderId)
@@ -246,8 +253,13 @@ public class RefundServiceImpl implements RefundService {
             return Page.empty(pageable);
         }
 
-        return refundRepository.findByOrderIdIn(orderIds, pageable)
-            .map(RefundListItemResponse::from);
+        return refundRepository.findByOrderIdInAndStatus(orderIds, RefundStatus.COMPLETED, pageable)
+            .map(refund -> {
+                String paymentMethod = paymentRepository.findByPaymentId(refund.getPaymentId())
+                    .map(payment -> payment.getPaymentMethod().name())
+                    .orElse(null);
+                return SellerRefundListItemResponse.of(refund, paymentMethod);
+            });
     }
 
     private LocalDateTime parseCanceledAt(String canceledAt) {

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
@@ -23,10 +23,13 @@ import com.devticket.payment.refund.presentation.dto.RefundInfoResponse;
 import com.devticket.payment.refund.presentation.dto.RefundListItemResponse;
 import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
 import com.devticket.payment.refund.presentation.dto.PgRefundResponse;
+import com.devticket.payment.wallet.infrastructure.client.dto.InternalEventOrdersResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -228,6 +231,24 @@ public class RefundServiceImpl implements RefundService {
         Payment payment = paymentRepository.findById(refund.getPaymentId())
             .orElseThrow(() -> new RefundException(RefundErrorCode.PAYMENT_NOT_FOUND));
         return RefundDetailResponse.of(refund, payment.getPaymentMethod().name());
+    }
+
+    @Override
+    public Page<RefundListItemResponse> getRefundListByEventId(Long eventId, Pageable pageable) {
+        InternalEventOrdersResponse eventOrders = commerceInternalClient.getOrdersByEvent(eventId);
+
+        List<Long> orderIds = eventOrders.getOrders() == null
+            ? Collections.emptyList()
+            : eventOrders.getOrders().stream()
+                .map(InternalEventOrdersResponse.OrderInfo::getOrderId)
+                .toList();
+
+        if (orderIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        return refundRepository.findByOrderIdIn(orderIds, pageable)
+            .map(RefundListItemResponse::from);
     }
 
     private LocalDateTime parseCanceledAt(String canceledAt) {

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
@@ -1,5 +1,7 @@
 package com.devticket.payment.refund.application.service;
 
+import com.devticket.payment.common.exception.BusinessException;
+import com.devticket.payment.common.exception.CommonErrorCode;
 import com.devticket.payment.payment.application.dto.PgPaymentCancelCommand;
 import com.devticket.payment.payment.application.dto.PgPaymentCancelResult;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
@@ -236,14 +238,21 @@ public class RefundServiceImpl implements RefundService {
 
     @Override
     public Page<SellerRefundListItemResponse> getSellerRefundListByEventId(UUID sellerId, String eventId, Pageable pageable) {
-        InternalEventInfoResponse event = getEventInfo(UUID.fromString(eventId));
+        UUID eventUUID;
+        try {
+            eventUUID = UUID.fromString(eventId);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(CommonErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        InternalEventInfoResponse event = getEventInfo(eventUUID);
         if (!event.sellerId().equals(sellerId)) {
             throw new RefundException(RefundErrorCode.REFUND_INVALID_REQUEST);
         }
 
         InternalEventOrdersResponse eventOrders = commerceInternalClient.getOrdersByEvent(UUID.fromString(eventId));
 
-        List<UUID> orderIds = eventOrders.getOrders() == null
+        List<UUID> orderIds = (eventOrders == null || eventOrders.getOrders() == null)
             ? Collections.emptyList()
             : eventOrders.getOrders().stream()
                 .map(InternalEventOrdersResponse.OrderInfo::getOrderId)

--- a/payment/src/main/java/com/devticket/payment/refund/domain/repository/RefundRepository.java
+++ b/payment/src/main/java/com/devticket/payment/refund/domain/repository/RefundRepository.java
@@ -1,5 +1,6 @@
 package com.devticket.payment.refund.domain.repository;
 
+import com.devticket.payment.refund.domain.enums.RefundStatus;
 import com.devticket.payment.refund.domain.model.Refund;
 import java.util.List;
 import java.util.Optional;
@@ -12,5 +13,5 @@ public interface RefundRepository {
     int sumCompletedRefundAmountByPaymentId(Long paymentId);
     Page<Refund> findByUserId(UUID userId, Pageable pageable);
     Optional<Refund> findByRefundId(UUID refundId);
-    Page<Refund> findByOrderIdIn(List<Long> orderIds, Pageable pageable);
+    Page<Refund> findByOrderIdInAndStatus(List<UUID> orderIds, RefundStatus status, Pageable pageable);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/domain/repository/RefundRepository.java
+++ b/payment/src/main/java/com/devticket/payment/refund/domain/repository/RefundRepository.java
@@ -1,6 +1,7 @@
 package com.devticket.payment.refund.domain.repository;
 
 import com.devticket.payment.refund.domain.model.Refund;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -11,4 +12,5 @@ public interface RefundRepository {
     int sumCompletedRefundAmountByPaymentId(Long paymentId);
     Page<Refund> findByUserId(UUID userId, Pageable pageable);
     Optional<Refund> findByRefundId(UUID refundId);
+    Page<Refund> findByOrderIdIn(List<Long> orderIds, Pageable pageable);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/client/dto/InternalEventInfoResponse.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/client/dto/InternalEventInfoResponse.java
@@ -4,8 +4,8 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record InternalEventInfoResponse(
-    Long id,
-    Long sellerId,
+    UUID eventId,
+    UUID sellerId,
     String title,
     Integer price,
     String status,

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundJpaRepository.java
@@ -1,5 +1,6 @@
 package com.devticket.payment.refund.infrastructure.persistence;
 
+import com.devticket.payment.refund.domain.enums.RefundStatus;
 import com.devticket.payment.refund.domain.model.Refund;
 import java.util.List;
 import java.util.Optional;
@@ -24,5 +25,5 @@ public interface RefundJpaRepository extends JpaRepository<Refund, Long> {
 
     Optional<Refund> findByRefundId(UUID refundId);
 
-    Page<Refund> findByOrderIdIn(List<Long> orderIds, Pageable pageable);
+    Page<Refund> findByOrderIdInAndStatus(List<UUID> orderIds, RefundStatus status, Pageable pageable);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundJpaRepository.java
@@ -1,6 +1,7 @@
 package com.devticket.payment.refund.infrastructure.persistence;
 
 import com.devticket.payment.refund.domain.model.Refund;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -22,4 +23,6 @@ public interface RefundJpaRepository extends JpaRepository<Refund, Long> {
     Page<Refund> findByUserId(UUID userId, Pageable pageable);
 
     Optional<Refund> findByRefundId(UUID refundId);
+
+    Page<Refund> findByOrderIdIn(List<Long> orderIds, Pageable pageable);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.devticket.payment.refund.infrastructure.persistence;
 
 import com.devticket.payment.refund.domain.model.Refund;
 import com.devticket.payment.refund.domain.repository.RefundRepository;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -34,5 +35,10 @@ public class RefundRepositoryImpl implements RefundRepository {
     @Override
     public Optional<Refund> findByRefundId(UUID refundId) {
         return refundJpaRepository.findByRefundId(refundId);
+    }
+
+    @Override
+    public Page<Refund> findByOrderIdIn(List<Long> orderIds, Pageable pageable) {
+        return refundJpaRepository.findByOrderIdIn(orderIds, pageable);
     }
 }

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.devticket.payment.refund.infrastructure.persistence;
 
+import com.devticket.payment.refund.domain.enums.RefundStatus;
 import com.devticket.payment.refund.domain.model.Refund;
 import com.devticket.payment.refund.domain.repository.RefundRepository;
 import java.util.List;
@@ -38,7 +39,7 @@ public class RefundRepositoryImpl implements RefundRepository {
     }
 
     @Override
-    public Page<Refund> findByOrderIdIn(List<Long> orderIds, Pageable pageable) {
-        return refundJpaRepository.findByOrderIdIn(orderIds, pageable);
+    public Page<Refund> findByOrderIdInAndStatus(List<UUID> orderIds, RefundStatus status, Pageable pageable) {
+        return refundJpaRepository.findByOrderIdInAndStatus(orderIds, status, pageable);
     }
 }

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/controller/RefundController.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/controller/RefundController.java
@@ -73,6 +73,18 @@ public class RefundController {
         return ResponseEntity.ok(refundService.getRefundDetail(userId, refundId));
     }
 
+    @Operation(summary = "이벤트별 환불 내역 조회", description = "특정 이벤트의 전체 환불 내역을 페이징으로 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/events/{eventId}")
+    public ResponseEntity<Page<RefundListItemResponse>> getRefundListByEventId(
+        @PathVariable Long eventId,
+        @PageableDefault(size = 10, sort = "requestedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(refundService.getRefundListByEventId(eventId, pageable));
+    }
+
     @PostMapping("/pg/{ticketId}")
     public ResponseEntity<PgRefundResponse> refundPgTicket(
         @RequestHeader("X-User-Id") UUID userId,

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/controller/RefundController.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/controller/RefundController.java
@@ -73,18 +73,6 @@ public class RefundController {
         return ResponseEntity.ok(refundService.getRefundDetail(userId, refundId));
     }
 
-    @Operation(summary = "이벤트별 환불 내역 조회", description = "특정 이벤트의 전체 환불 내역을 페이징으로 조회합니다.")
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "조회 성공")
-    })
-    @GetMapping("/events/{eventId}")
-    public ResponseEntity<Page<RefundListItemResponse>> getRefundListByEventId(
-        @PathVariable Long eventId,
-        @PageableDefault(size = 10, sort = "requestedAt", direction = Sort.Direction.DESC) Pageable pageable
-    ) {
-        return ResponseEntity.ok(refundService.getRefundListByEventId(eventId, pageable));
-    }
-
     @PostMapping("/pg/{ticketId}")
     public ResponseEntity<PgRefundResponse> refundPgTicket(
         @RequestHeader("X-User-Id") UUID userId,

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/controller/SellerRefundController.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/controller/SellerRefundController.java
@@ -1,0 +1,41 @@
+package com.devticket.payment.refund.presentation.controller;
+
+import com.devticket.payment.refund.application.service.RefundService;
+import com.devticket.payment.refund.presentation.dto.SellerRefundListItemResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/seller/refunds")
+@Tag(name = "Seller Refund", description = "판매자 대상 환불 API")
+@RequiredArgsConstructor
+public class SellerRefundController {
+    private final RefundService refundService;
+
+    @Operation(summary = "판매자 이벤트별 환불 내역 조회", description = "특정 이벤트의 전체 환불 내역을 페이징으로 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/events/{eventId}")
+    public ResponseEntity<Page<SellerRefundListItemResponse>> getSellerRefundListByEventId(
+        @RequestHeader("X-User-Id") UUID sellerId,
+        @PathVariable String eventId,
+        @PageableDefault(size = 10, sort = "requestedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(refundService.getSellerRefundListByEventId(sellerId, eventId, pageable));
+    }
+}

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/dto/SellerRefundListItemResponse.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/dto/SellerRefundListItemResponse.java
@@ -1,0 +1,32 @@
+package com.devticket.payment.refund.presentation.dto;
+
+import com.devticket.payment.refund.domain.model.Refund;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SellerRefundListItemResponse(
+    String refundId,
+    UUID orderId,
+    UUID paymentId,
+    Integer refundAmount,
+    Integer refundRate,
+    String status,
+    String paymentMethod,
+    LocalDateTime requestedAt,
+    LocalDateTime completedAt
+    //TODO: 환불자 이름 추가
+) {
+    public static SellerRefundListItemResponse of(Refund refund, String paymentMethod) {
+        return new SellerRefundListItemResponse(
+            refund.getRefundId().toString(),
+            refund.getOrderId(),
+            refund.getPaymentId(),
+            refund.getRefundAmount(),
+            refund.getRefundRate(),
+            refund.getStatus().name(),
+            paymentMethod,
+            refund.getRequestedAt(),
+            refund.getCompletedAt()
+        );
+    }
+}

--- a/payment/src/main/resources/application-local.yml
+++ b/payment/src/main/resources/application-local.yml
@@ -40,5 +40,5 @@ internal:
 pg:
   toss:
     base-url: https://api.tosspayments.com
-    secret-key:
+    secret-key: ${PG_SECRET_KEY}
 

--- a/payment/src/test/java/com/devticket/payment/application/service/RefundServiceImplTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/RefundServiceImplTest.java
@@ -1,0 +1,244 @@
+package com.devticket.payment.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.devticket.payment.payment.domain.enums.PaymentMethod;
+import com.devticket.payment.payment.domain.model.Payment;
+import com.devticket.payment.payment.domain.repository.PaymentRepository;
+import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
+import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
+import com.devticket.payment.refund.application.service.RefundServiceImpl;
+import com.devticket.payment.refund.domain.enums.RefundStatus;
+import com.devticket.payment.refund.domain.exception.RefundErrorCode;
+import com.devticket.payment.refund.domain.exception.RefundException;
+import com.devticket.payment.refund.domain.model.Refund;
+import com.devticket.payment.refund.domain.repository.RefundRepository;
+import com.devticket.payment.refund.infrastructure.client.EventInternalClient;
+import com.devticket.payment.refund.infrastructure.client.dto.InternalEventInfoResponse;
+import com.devticket.payment.refund.presentation.dto.SellerRefundListItemResponse;
+import com.devticket.payment.wallet.infrastructure.client.dto.InternalEventOrdersResponse;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
+class RefundServiceImplTest {
+
+    @Mock private CommerceInternalClient commerceInternalClient;
+    @Mock private EventInternalClient eventInternalClient;
+    @Mock private PaymentRepository paymentRepository;
+    @Mock private PgPaymentClient pgPaymentClient;
+    @Mock private RefundRepository refundRepository;
+
+    @InjectMocks
+    private RefundServiceImpl refundService;
+
+    private static final UUID SELLER_ID = UUID.fromString("d25a18fd-69e1-45e6-aae8-880abc14ef8f");
+    private static final UUID OTHER_SELLER_ID = UUID.fromString("d25a18fd-69e1-45e6-aae8-880abc14ef8c");
+    private static final String EVENT_ID = UUID.randomUUID().toString();
+    private static final UUID ORDER_ID = UUID.randomUUID();
+    private static final UUID PAYMENT_ID = UUID.randomUUID();
+
+    private InternalEventInfoResponse eventInfo;
+    private Pageable pageable;
+
+    @BeforeEach
+    void setUp() {
+        pageable = PageRequest.of(0, 10);
+        eventInfo = new InternalEventInfoResponse(
+            UUID.fromString(EVENT_ID),
+            SELLER_ID,
+            "테스트 이벤트",
+            50000,
+            "ACTIVE",
+            "CONCERT",
+            100,
+            4,
+            50,
+            LocalDateTime.now().plusDays(10).toString(),
+            LocalDateTime.now().minusDays(5).toString(),
+            LocalDateTime.now().plusDays(5).toString()
+        );
+    }
+
+    private Refund createCompletedRefund() {
+        Refund refund = Refund.create(ORDER_ID, PAYMENT_ID, UUID.randomUUID(), 50000, 100);
+        refund.complete(LocalDateTime.now());
+        return refund;
+    }
+
+    private Payment createApprovedPayment() {
+        Payment payment = Payment.create(ORDER_ID, UUID.randomUUID(), PaymentMethod.PG, 50000);
+        payment.approve("payment-key-123");
+        return payment;
+    }
+
+    private InternalEventOrdersResponse mockEventOrders(List<UUID> orderIds) {
+        InternalEventOrdersResponse response = mock(InternalEventOrdersResponse.class);
+        List<InternalEventOrdersResponse.OrderInfo> orderInfos = orderIds.stream()
+            .map(id -> {
+                InternalEventOrdersResponse.OrderInfo info =
+                    mock(InternalEventOrdersResponse.OrderInfo.class);
+                given(info.getOrderId()).willReturn(id);
+                return info;
+            })
+            .toList();
+        given(response.getOrders()).willReturn(orderInfos);
+        return response;
+    }
+
+    // =========================================================
+    // getSellerRefundListByEventId
+    // =========================================================
+
+    @Nested
+    @DisplayName("판매자 이벤트별 환불 내역 조회")
+    class GetSellerRefundListByEventIdTest {
+
+        @Test
+        @DisplayName("성공 — COMPLETED 환불 목록과 paymentMethod 반환")
+        void 성공() {
+            // given
+            Refund refund = createCompletedRefund();
+            Payment payment = createApprovedPayment();
+            InternalEventOrdersResponse eventOrders = mockEventOrders(List.of(ORDER_ID));
+
+            given(eventInternalClient.getEventInfo(UUID.fromString(EVENT_ID))).willReturn(eventInfo);
+            given(commerceInternalClient.getOrdersByEvent(UUID.fromString(EVENT_ID))).willReturn(eventOrders);
+            given(refundRepository.findByOrderIdInAndStatus(
+                eq(List.of(ORDER_ID)), eq(RefundStatus.COMPLETED), any(Pageable.class))
+            ).willReturn(new PageImpl<>(List.of(refund)));
+            given(paymentRepository.findByPaymentId(PAYMENT_ID)).willReturn(Optional.of(payment));
+
+            // when
+            Page<SellerRefundListItemResponse> result =
+                refundService.getSellerRefundListByEventId(SELLER_ID, EVENT_ID, pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            SellerRefundListItemResponse item = result.getContent().get(0);
+            assertThat(item.orderId()).isEqualTo(ORDER_ID);
+            assertThat(item.paymentId()).isEqualTo(PAYMENT_ID);
+            assertThat(item.status()).isEqualTo(RefundStatus.COMPLETED.name());
+            assertThat(item.paymentMethod()).isEqualTo(PaymentMethod.PG.name());
+        }
+
+        @Test
+        @DisplayName("판매자 불일치 — REFUND_INVALID_REQUEST 예외")
+        void 판매자_불일치() {
+            // given
+            given(eventInternalClient.getEventInfo(UUID.fromString(EVENT_ID))).willReturn(eventInfo);
+
+            // when & then
+            assertThatThrownBy(() ->
+                refundService.getSellerRefundListByEventId(OTHER_SELLER_ID, EVENT_ID, pageable))
+                .isInstanceOf(RefundException.class)
+                .extracting(e -> ((RefundException) e).getErrorCode())
+                .isEqualTo(RefundErrorCode.REFUND_INVALID_REQUEST);
+
+            verify(commerceInternalClient, never()).getOrdersByEvent(any());
+            verify(refundRepository, never()).findByOrderIdInAndStatus(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("이벤트 주문이 없을 때(null) — 빈 페이지 반환")
+        void 이벤트_주문_null() {
+            // given — orders 필드가 null인 응답
+            InternalEventOrdersResponse eventOrders = new InternalEventOrdersResponse();
+
+            given(eventInternalClient.getEventInfo(UUID.fromString(EVENT_ID))).willReturn(eventInfo);
+            given(commerceInternalClient.getOrdersByEvent(UUID.fromString(EVENT_ID))).willReturn(eventOrders);
+
+            // when
+            Page<SellerRefundListItemResponse> result =
+                refundService.getSellerRefundListByEventId(SELLER_ID, EVENT_ID, pageable);
+
+            // then
+            assertThat(result.isEmpty()).isTrue();
+            verify(refundRepository, never()).findByOrderIdInAndStatus(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("이벤트 주문이 없을 때(빈 리스트) — 빈 페이지 반환")
+        void 이벤트_주문_빈_리스트() {
+            // given
+            InternalEventOrdersResponse eventOrders = mockEventOrders(Collections.emptyList());
+
+            given(eventInternalClient.getEventInfo(UUID.fromString(EVENT_ID))).willReturn(eventInfo);
+            given(commerceInternalClient.getOrdersByEvent(UUID.fromString(EVENT_ID))).willReturn(eventOrders);
+
+            // when
+            Page<SellerRefundListItemResponse> result =
+                refundService.getSellerRefundListByEventId(SELLER_ID, EVENT_ID, pageable);
+
+            // then
+            assertThat(result.isEmpty()).isTrue();
+            verify(refundRepository, never()).findByOrderIdInAndStatus(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("COMPLETED 환불 없음 — 빈 페이지 반환")
+        void COMPLETED_환불_없음() {
+            // given
+            InternalEventOrdersResponse eventOrders = mockEventOrders(List.of(ORDER_ID));
+
+            given(eventInternalClient.getEventInfo(UUID.fromString(EVENT_ID))).willReturn(eventInfo);
+            given(commerceInternalClient.getOrdersByEvent(UUID.fromString(EVENT_ID))).willReturn(eventOrders);
+            given(refundRepository.findByOrderIdInAndStatus(
+                eq(List.of(ORDER_ID)), eq(RefundStatus.COMPLETED), any(Pageable.class))
+            ).willReturn(Page.empty(pageable));
+
+            // when
+            Page<SellerRefundListItemResponse> result =
+                refundService.getSellerRefundListByEventId(SELLER_ID, EVENT_ID, pageable);
+
+            // then
+            assertThat(result.isEmpty()).isTrue();
+        }
+
+        @Test
+        @DisplayName("결제 정보 미존재 — paymentMethod가 null로 반환")
+        void 결제_정보_미존재() {
+            // given
+            Refund refund = createCompletedRefund();
+            InternalEventOrdersResponse eventOrders = mockEventOrders(List.of(ORDER_ID));
+
+            given(eventInternalClient.getEventInfo(UUID.fromString(EVENT_ID))).willReturn(eventInfo);
+            given(commerceInternalClient.getOrdersByEvent(UUID.fromString(EVENT_ID))).willReturn(eventOrders);
+            given(refundRepository.findByOrderIdInAndStatus(
+                eq(List.of(ORDER_ID)), eq(RefundStatus.COMPLETED), any(Pageable.class))
+            ).willReturn(new PageImpl<>(List.of(refund)));
+            given(paymentRepository.findByPaymentId(PAYMENT_ID)).willReturn(Optional.empty());
+
+            // when
+            Page<SellerRefundListItemResponse> result =
+                refundService.getSellerRefundListByEventId(SELLER_ID, EVENT_ID, pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent().get(0).paymentMethod()).isNull();
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
close #271 


## 작업 내용

  판매자가 자신의 이벤트에 대한 환불 완료 내역을 조회할 수 있는 API를 구현했습니다.


 ## 변경 사항

  신규 파일

  - SellerRefundController — GET /api/seller/refunds/events/{eventId} 엔드포인트. X-User-Id 헤더로 sellerId를 받아 서비스에 전달
  - SellerRefundListItemResponse — 환불 수단(paymentMethod)을 포함한 판매자용 응답 DTO

  수정 파일

  - RefundService — getSellerRefundListByEventId(UUID sellerId, String eventId, Pageable) 메서드 추가.
  - RefundServiceImpl
    - Event Internal API로 이벤트 조회 후 sellerId 일치 여부 검증 (불일치 시 REFUND_INVALID_REQUEST 예외)
    - 상태 필터를 COMPLETED로 고정 (findByOrderIdInAndStatus)
    - 각 환불 건에 대해 Payment 조회 후 paymentMethod 포함하여 응답 생성
  - RefundRepository / RefundJpaRepository / RefundRepositoryImpl — findByOrderIdInAndStatus(List<UUID>, RefundStatus)
  - InternalEventInfoResponse — id(Long) / sellerId(Long) → eventId(UUID) / sellerId(UUID) 타입 수정

  테스트

  - RefundServiceImplTest — getSellerRefundListByEventId 단위 테스트 추가
    - 정상 조회 (paymentMethod 포함 검증)
    - 판매자 불일치 → REFUND_INVALID_REQUEST 예외
    - 이벤트 주문 없음 (null / 빈 리스트) → 빈 페이지
    - COMPLETED 환불 없음 → 빈 페이지
    - 결제 정보 미존재 → paymentMethod null 반환
