### PR TITLE
[Gateway] Feat/gateway oauth

### DIFF
--- a/apigateway/build.gradle
+++ b/apigateway/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     // Security (WebFlux용은 starter-security가 webflux 자동 감지)
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // OAuth2 Client (소셜 로그인)
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
     // Swagger (WebFlux용)
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:3.0.2'
 

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/config/RoutePolicy.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/config/RoutePolicy.java
@@ -72,6 +72,18 @@ public final class RoutePolicy {
     );
 
     // ──────────────────────────────────────────────
+    // OAuth2 소셜 로그인 (인증 제외)
+    // ──────────────────────────────────────────────
+
+    /**
+     * OAuth2 인가 요청 및 콜백 경로. Spring Security가 처리하므로 JWT 필터에서 제외합니다.
+     */
+    public static final List<PathPattern> OAUTH_PATTERNS = List.of(
+        PARSER.parse("/oauth2/**"),
+        PARSER.parse("/login/oauth2/**")
+    );
+
+    // ──────────────────────────────────────────────
     // 외부 차단 (Internal API)
     // ──────────────────────────────────────────────
 

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/config/SecurityConfig.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/config/SecurityConfig.java
@@ -1,12 +1,18 @@
 package com.devticket.apigateway.infrastructure.config;
 
+import com.devticket.apigateway.infrastructure.oauth.OAuthFailureHandler;
+import com.devticket.apigateway.infrastructure.oauth.OAuthSuccessHandler;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.server.DefaultServerOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizationRequestResolver;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.reactive.CorsConfigurationSource;
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
@@ -14,6 +20,20 @@ import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 @Configuration
 @EnableWebFluxSecurity
 public class SecurityConfig {
+
+    private final OAuthSuccessHandler oAuthSuccessHandler;
+    private final OAuthFailureHandler oAuthFailureHandler;
+    private final ReactiveClientRegistrationRepository clientRegistrationRepository;
+
+    public SecurityConfig(
+        OAuthSuccessHandler oAuthSuccessHandler,
+        OAuthFailureHandler oAuthFailureHandler,
+        ReactiveClientRegistrationRepository clientRegistrationRepository
+    ) {
+        this.oAuthSuccessHandler = oAuthSuccessHandler;
+        this.oAuthFailureHandler = oAuthFailureHandler;
+        this.clientRegistrationRepository = clientRegistrationRepository;
+    }
 
     @Bean
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
@@ -25,7 +45,24 @@ public class SecurityConfig {
             .authorizeExchange(exchanges -> exchanges
                 .anyExchange().permitAll()
             )
+            .oauth2Login(oauth2 -> oauth2
+                .authorizationRequestResolver(authorizationRequestResolver())
+                .authenticationSuccessHandler(oAuthSuccessHandler)
+                .authenticationFailureHandler(oAuthFailureHandler)
+            )
+            .exceptionHandling(e -> e
+                .authenticationEntryPoint(new HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED))
+            )
             .build();
+    }
+
+    private ServerOAuth2AuthorizationRequestResolver authorizationRequestResolver() {
+        DefaultServerOAuth2AuthorizationRequestResolver resolver =
+            new DefaultServerOAuth2AuthorizationRequestResolver(clientRegistrationRepository);
+        resolver.setAuthorizationRequestCustomizer(
+            customizer -> customizer.additionalParameters(params -> params.put("prompt", "select_account"))
+        );
+        return resolver;
     }
 
     private CorsConfigurationSource corsConfigurationSource() {

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/exception/GatewayErrorCode.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/exception/GatewayErrorCode.java
@@ -15,7 +15,8 @@ public enum GatewayErrorCode {
     SERVICE_CONNECT_FAILED(502, "COMMON_007", "외부 서비스 연동에 실패했습니다."),
     SERVICE_UNAVAILABLE(503, "COMMON_008", "서비스를 일시적으로 이용할 수 없습니다."),
     RATE_LIMIT_EXCEEDED(429, "COMMON_009", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
-    PROFILE_INCOMPLETE(403, "COMMON_010", "프로필 설정을 완료해야 서비스를 이용할 수 있습니다.");
+    PROFILE_INCOMPLETE(403, "COMMON_010", "프로필 설정을 완료해야 서비스를 이용할 수 있습니다."),
+    OAUTH_LOGIN_FAILED(502, "AUTH_001", "소셜 로그인 처리 중 오류가 발생했습니다.");
 
     private final int status;
     private final String code;

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthFailureHandler.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthFailureHandler.java
@@ -1,0 +1,38 @@
+package com.devticket.apigateway.infrastructure.oauth;
+
+import java.net.URI;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.security.web.server.authentication.ServerAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+/**
+ * OAuth2 인증 실패 핸들러.
+ *
+ * <p>사용자가 소셜 로그인을 취소하거나 provider 측에서 오류가 발생한 경우
+ * 프론트엔드 콜백 URI로 error 파라미터를 담아 리다이렉트합니다.</p>
+ */
+@Slf4j
+@Component
+public class OAuthFailureHandler implements ServerAuthenticationFailureHandler {
+
+    private final String redirectUri;
+
+    public OAuthFailureHandler(@Value("${oauth2.redirect-uri}") String redirectUri) {
+        this.redirectUri = redirectUri;
+    }
+
+    @Override
+    public Mono<Void> onAuthenticationFailure(WebFilterExchange webFilterExchange,
+        AuthenticationException exception) {
+        log.error("OAuth2 인증 실패: {}", exception.getMessage());
+        var response = webFilterExchange.getExchange().getResponse();
+        response.setStatusCode(HttpStatus.FOUND);
+        response.getHeaders().setLocation(URI.create(redirectUri + "?error=OAUTH_LOGIN_FAILED"));
+        return response.setComplete();
+    }
+}

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthSuccessHandler.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthSuccessHandler.java
@@ -1,0 +1,99 @@
+package com.devticket.apigateway.infrastructure.oauth;
+
+import com.devticket.apigateway.infrastructure.exception.GatewayErrorCode;
+import com.devticket.apigateway.infrastructure.security.GatewayAuthenticationEntryPoint;
+import java.net.URI;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.security.web.server.authentication.ServerAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * OAuth2 인증 성공 핸들러.
+ *
+ * <p>소셜 로그인 성공 시:
+ * <ol>
+ *   <li>provider별로 사용자 정보(provider, providerId, email, name)를 추출합니다.</li>
+ *   <li>member-service의 {@code /internal/oauth/users}를 호출해 JWT를 발급받습니다.</li>
+ *   <li>프론트엔드 콜백 URI로 accessToken을 쿼리 파라미터에 담아 리다이렉트합니다.</li>
+ * </ol>
+ * </p>
+ */
+@Slf4j
+@Component
+public class OAuthSuccessHandler implements ServerAuthenticationSuccessHandler {
+
+    private final OAuthToMemberClient memberClient;
+    private final GatewayAuthenticationEntryPoint entryPoint;
+    private final String redirectUri;
+
+    public OAuthSuccessHandler(
+        OAuthToMemberClient memberClient,
+        GatewayAuthenticationEntryPoint entryPoint,
+        @Value("${oauth2.redirect-uri}") String redirectUri
+    ) {
+        this.memberClient = memberClient;
+        this.entryPoint = entryPoint;
+        this.redirectUri = redirectUri;
+    }
+
+    @Override
+    public Mono<Void> onAuthenticationSuccess(WebFilterExchange webFilterExchange,
+        Authentication authentication) {
+        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+        String registrationId = token.getAuthorizedClientRegistrationId();
+        OAuth2User oAuth2User = token.getPrincipal();
+
+        log.debug("OAuth2 로그인 성공: provider={}", registrationId);
+
+        OAuthUserInfo userInfo = extractUserInfo(registrationId, oAuth2User);
+        ServerWebExchange exchange = webFilterExchange.getExchange();
+
+        return memberClient.registerOrLogin(userInfo)
+            .flatMap(response -> redirectToFrontend(exchange, response.accessToken()))
+            .onErrorResume(e -> {
+                log.error("OAuth2 member-service 호출 실패: provider={}, error={}", registrationId, e.getMessage());
+                if (e instanceof WebClientResponseException wcEx) {
+                    String body = wcEx.getResponseBodyAsString();
+                    if (body.contains("MEMBER_012")) {
+                        return redirectToFrontendWithError(exchange, "SOCIAL_EMAIL_CONFLICT");
+                    }
+                }
+                return entryPoint.writeErrorResponse(exchange.getResponse(), GatewayErrorCode.OAUTH_LOGIN_FAILED);
+            });
+    }
+
+    private OAuthUserInfo extractUserInfo(String registrationId, OAuth2User user) {
+        if (!"google".equals(registrationId)) {
+            throw new IllegalArgumentException("지원하지 않는 OAuth2 provider: " + registrationId);
+        }
+        return new OAuthUserInfo(
+            "google",
+            user.getAttribute("sub"),
+            user.getAttribute("email"),
+            user.getAttribute("name")
+        );
+    }
+
+    private Mono<Void> redirectToFrontendWithError(ServerWebExchange exchange, String errorCode) {
+        URI location = URI.create(redirectUri + "?error=" + errorCode);
+        exchange.getResponse().setStatusCode(HttpStatus.FOUND);
+        exchange.getResponse().getHeaders().setLocation(location);
+        return exchange.getResponse().setComplete();
+    }
+
+    private Mono<Void> redirectToFrontend(ServerWebExchange exchange, String accessToken) {
+        URI location = URI.create(redirectUri + "?token=" + accessToken);
+        exchange.getResponse().setStatusCode(HttpStatus.FOUND);
+        exchange.getResponse().getHeaders().setLocation(location);
+        return exchange.getResponse().setComplete();
+    }
+}

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthToMemberClient.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthToMemberClient.java
@@ -1,0 +1,41 @@
+package com.devticket.apigateway.infrastructure.oauth;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+/**
+ * member-service 의 내부 OAuth 엔드포인트를 호출하는 WebClient 래퍼.
+ *
+ * <p>소셜 로그인 성공 후 사용자 등록/조회와 JWT 발급을 member-service에 위임합니다.</p>
+ */
+@Component
+public class OAuthToMemberClient {
+
+    private static final String OAUTH_REGISTER_PATH = "/api/auth/google-signup";
+
+    private final WebClient webClient;
+
+    public OAuthToMemberClient(@Value("${services.member.url}") String memberServiceUrl) {
+        this.webClient = WebClient.builder()
+            .baseUrl(memberServiceUrl)
+            .build();
+    }
+
+    /**
+     * 소셜 사용자 정보를 member-service에 전달해 JWT를 발급받습니다.
+     *
+     * @param userInfo 소셜 로그인 사용자 정보
+     * @return accessToken, refreshToken을 담은 응답
+     */
+    public Mono<OAuthTokenResponse> registerOrLogin(OAuthUserInfo userInfo) {
+        return webClient.post()
+            .uri(OAUTH_REGISTER_PATH)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(userInfo)
+            .retrieve()
+            .bodyToMono(OAuthTokenResponse.class);
+    }
+}

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthTokenResponse.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthTokenResponse.java
@@ -1,0 +1,14 @@
+package com.devticket.apigateway.infrastructure.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * member-service 의 /internal/oauth/users 응답 DTO.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record OAuthTokenResponse(
+    String accessToken,
+    String refreshToken
+) {
+
+}

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthUserInfo.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthUserInfo.java
@@ -1,0 +1,13 @@
+package com.devticket.apigateway.infrastructure.oauth;
+
+/**
+ * Gateway → member-service 로 전달하는 소셜 로그인 사용자 정보.
+ */
+public record OAuthUserInfo(
+    String provider,    // "google"
+    String providerId,  // 플랫폼이 발급하는 고유 식별자
+    String email,
+    String name
+) {
+
+}

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/security/JwtAuthenticationFilter.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/security/JwtAuthenticationFilter.java
@@ -122,6 +122,9 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
         if (RoutePolicy.matchesAny(RoutePolicy.ACTUATOR_PUBLIC_PATTERNS, path)) {
             return true;
         }
+        if (RoutePolicy.matchesAny(RoutePolicy.OAUTH_PATTERNS, path)) {
+            return true;
+        }
         return RoutePolicy.matchesAny(RoutePolicy.HEALTH_PATTERNS, path);
     }
 

--- a/apigateway/src/main/resources/application-local.yml
+++ b/apigateway/src/main/resources/application-local.yml
@@ -12,3 +12,20 @@ springdoc:
     enabled: true
   swagger-ui:
     enabled: true
+
+# OAuth2 소셜 로그인 자격증명 (로컬 개발용 - 각 플랫폼 개발자 콘솔에서 발급)
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID:your-google-client-id}
+            client-secret: ${GOOGLE_CLIENT_SECRET:your-google-client-secret}
+
+services:
+  member:
+    url: http://localhost:8081
+
+oauth2:
+  redirect-uri: http://localhost:13000/oauth/callback

--- a/apigateway/src/main/resources/application-prod.yml
+++ b/apigateway/src/main/resources/application-prod.yml
@@ -1,5 +1,21 @@
 jwt:
   secret-key: ${JWT_SECRET_KEY}
+
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+
+services:
+  member:
+    url: ${MEMBER_SERVICE_URL}
+
+oauth2:
+  redirect-uri: ${OAUTH_REDIRECT_URI}
   access-token-ttl: 1800000
   refresh-token-ttl: 604800000
 

--- a/apigateway/src/main/resources/application.yml
+++ b/apigateway/src/main/resources/application.yml
@@ -3,6 +3,15 @@ spring:
     name: devticket-gateway
   profiles:
     active: local
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID:}
+            client-secret: ${GOOGLE_CLIENT_SECRET:}
+            scope: email, profile
+
   cloud:
     gateway:
       server:
@@ -57,6 +66,15 @@ springdoc:
     path: /swagger-ui.html
   api-docs:
     path: /v1/api-docs
+
+# 내부 서비스 URL (OAuth 콜백 시 member-service 호출용)
+services:
+  member:
+    url: http://localhost:8081
+
+# OAuth2 소셜 로그인 성공 후 프론트엔드 리다이렉트 URI
+oauth2:
+  redirect-uri: http://localhost:13000/oauth/callback
 
 # Rate Limiting
 gateway:

--- a/apigateway/src/test/resources/application-test.yml
+++ b/apigateway/src/test/resources/application-test.yml
@@ -1,0 +1,21 @@
+jwt:
+  secret-key: test-jwt-secret-key-devticket-2025-must-be-256-bits
+  access-token-ttl: 1800000
+  refresh-token-ttl: 604800000
+
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-google-client-id
+            client-secret: test-google-client-secret
+            scope: email, profile
+
+services:
+  member:
+    url: http://localhost:8081
+
+oauth2:
+  redirect-uri: http://localhost:13000/oauth/callback


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- OAuth(google) 구현 

## 변경 사항
신규파일  
- OAuthSuccessHandler
    - ServerAuthenticationSuccessHandler 구현체
    - Google에서 받은 사용자 정보를 OAuthToMemberClient를 통해 member-service에 전달하고, 
      응답받은 JWT를 쿼리 파라미터에 담아 프론트엔드 콜백 URI로 리다이렉트
    - SOCIAL_EMAIL_CONFLICT 에러 코드 감지 시 별도 에러 리다이렉트 처리
 - OAuthFailureHandler
    - ServerAuthenticationFailureHandler 구현체
    - 사용자가 Google 로그인을 취소하거나 인증 오류 발생 시 프론트엔드로 error=OAUTH_LOGIN_FAILED 파라미터를 담아 리다이렉트
  - OAuthToMemberClient
    - WebClient 기반 member-service 호출 클라이언트
    - POST /api/auth/google-signup으로 소셜 사용자 정보를 전달해 JWT 발급 위임
    - member-service URL은 services.member.url 프로퍼티로 주입
  - DTO : OAuthUserInfo
    - 게이트웨이 → member-service 전달용 DTO (provider, providerId, email, name)
  - DTO : OAuthTokenResponse
    - member-service 응답 DTO (accessToken, refreshToken)


수정파일 
 - SecurityConfig
    - oauth2Login 활성화, OAuthSuccessHandler / OAuthFailureHandler 등록
    - DefaultServerOAuth2AuthorizationRequestResolver에 prompt=select_account 파라미터 추가로 항상 계정 선택 화면 강제
    - exceptionHandling에 HttpStatusServerEntryPoint(401) 명시 → WWW-Authenticate: Basic 헤더 제거로 브라우저 Basic Auth 모달 방지
  - RoutePolicy
    - OAUTH_PATTERNS 추가 (/oauth2/**, /login/oauth2/**) — JWT 필터 인증 제외 경로
    - PROFILE_EXEMPT_PATTERNS 추가 (/api/auth/**) — 프로필 미완성 사용자 접근 허용 경로
    - PROFILE_EXEMPT_POST_PATTERNS 추가 (POST /api/users/profile) — 프로필 등록 API 허용
  - JwtAuthenticationFilter
    - isPublicPath()에 OAUTH_PATTERNS 매칭 추가 — OAuth2 콜백 경로에서 JWT 검증 건너뜀
    - isProfileExemptPath()로 프로필 미완성 사용자 차단 로직 분리
  - GatewayErrorCode
    - OAUTH_LOGIN_FAILED(502, "AUTH_001") 에러 코드 추가 : member-service 호출 실패 시 사용
  - application.yml
    - spring.security.oauth2.client.registration.google 설정 추가 (client-id, client-secret, scope)
    - services.member.url 추가 — OAuthToMemberClient의 base URL
    - oauth2.redirect-uri 추가 — OAuth 성공/실패 후 프론트엔드 리다이렉트 URI
  - application-local.yml
    - Google OAuth2 클라이언트 자격증명을 환경변수(GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET)로 주입 
    - 로컬 member-service URL 및 OAuth 콜백 URI 설정
  - application-prod.yml
    - Google OAuth2 자격증명 및 member-service URL을 환경변수로 주입
    - oauth2.redirect-uri를 OAUTH_REDIRECT_URI 환경변수로 주입


## 참고 사항
- GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET 환경변수 설정 필수
  .env 또는 IDE 환경변수 설정이 선행되어야 합니다.
- WWW-Authenticate: Basic 모달 방지 처리 배경
  SecurityConfig에 exceptionHandling을 명시한 이유는 브라우저 UX 버그 수정입니다. 
  httpBasic(disable)만으로는 ExceptionTranslationWebFilter의 기본 entry point(HttpBasicServerAuthenticationEntryPoint)가 교체되지 않아,
 특정 조건에서 WWW-Authenticate: Basic 헤더가 포함된 401 응답이 반환되고 크롬이 시스템 모달을 띄우는 문제가 있었습니다.