### PR TITLE
[Member] feat(member) : oauth적용

### DIFF
--- a/member/src/main/java/com/devticket/member/application/AuthService.java
+++ b/member/src/main/java/com/devticket/member/application/AuthService.java
@@ -13,6 +13,8 @@ import com.devticket.member.presentation.domain.model.User;
 import com.devticket.member.presentation.domain.repository.RefreshTokenRepository;
 import com.devticket.member.presentation.domain.repository.UserProfileRepository;
 import com.devticket.member.presentation.domain.repository.UserRepository;
+import com.devticket.member.presentation.dto.internal.request.InternalOAuthRequest;
+import com.devticket.member.presentation.dto.internal.response.InternalOAuthResponse;
 import com.devticket.member.presentation.dto.request.LoginRequest;
 import com.devticket.member.presentation.dto.request.SignUpRequest;
 import com.devticket.member.presentation.dto.request.SocialSignUpOrLoginRequest;
@@ -110,6 +112,47 @@ public class AuthService {
         refreshTokenRepository.deleteByToken(refreshToken);
         log.info("로그아웃 완료");
         return new LogoutResponse(true);
+    }
+
+    // API Gateway에서 OAuth 토큰 검증 후 회원가입/로그인 처리
+    @Transactional
+    public InternalOAuthResponse internalOAuthSignUpOrLogin(InternalOAuthRequest request) {
+        ProviderType providerType = parseProviderType(request.provider());
+
+        Optional<User> userByProvider = userRepository.findByProviderTypeAndProviderId(
+            providerType, request.providerId());
+
+        if (userByProvider.isPresent()) {
+            User user = userByProvider.get();
+            validateUserStatus(user);
+            boolean profileCompleted = isProfileCompleted(user.getId());
+            String accessToken = issueAccessToken(user, profileCompleted);
+            String refreshToken = saveRefreshToken(user.getId());
+            log.info("내부 OAuth 로그인 완료: provider={}, providerId={}", providerType, request.providerId());
+            return new InternalOAuthResponse(accessToken, refreshToken);
+        }
+
+        Optional<User> userByEmail = userRepository.findByEmail(request.email());
+        if (userByEmail.isPresent()) {
+            User user = userByEmail.get();
+            if (user.getProviderType() == ProviderType.LOCAL) {
+                throw new BusinessException(MemberErrorCode.SOCIAL_EMAIL_CONFLICT);
+            }
+            validateUserStatus(user);
+            boolean profileCompleted = isProfileCompleted(user.getId());
+            String accessToken = issueAccessToken(user, profileCompleted);
+            String refreshToken = saveRefreshToken(user.getId());
+            log.info("내부 OAuth 로그인 완료 (이메일 매칭): email={}", request.email());
+            return new InternalOAuthResponse(accessToken, refreshToken);
+        }
+
+        User newUser = new User(request.email(), providerType, request.providerId());
+        User savedUser = userRepository.save(newUser);
+        boolean profileCompleted = isProfileCompleted(savedUser.getId());
+        String accessToken = issueAccessToken(savedUser, profileCompleted);
+        String refreshToken = saveRefreshToken(savedUser.getId());
+        log.info("내부 OAuth 회원가입 완료: email={}, provider={}", request.email(), providerType);
+        return new InternalOAuthResponse(accessToken, refreshToken);
     }
 
     // ========== 소셜 로그인 분기 ==========

--- a/member/src/main/java/com/devticket/member/application/UserService.java
+++ b/member/src/main/java/com/devticket/member/application/UserService.java
@@ -1,9 +1,11 @@
 package com.devticket.member.application;
 
 import com.devticket.member.common.exception.BusinessException;
+import com.devticket.member.infrastructure.jwt.JwtTokenProvider;
 import com.devticket.member.presentation.domain.MemberErrorCode;
 import com.devticket.member.presentation.domain.Position;
 import com.devticket.member.presentation.domain.ProviderType;
+import com.devticket.member.presentation.domain.model.RefreshToken;
 import com.devticket.member.presentation.domain.model.TechStack;
 import com.devticket.member.presentation.domain.model.User;
 import com.devticket.member.presentation.domain.model.UserProfile;
@@ -21,6 +23,7 @@ import com.devticket.member.presentation.dto.response.GetProfileResponse;
 import com.devticket.member.presentation.dto.response.SignUpProfileResponse;
 import com.devticket.member.presentation.dto.response.UpdateProfileResponse;
 import com.devticket.member.presentation.dto.response.WithdrawResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +44,7 @@ public class UserService {
     private final TechStackRepository techStackRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     public SignUpProfileResponse createProfile(UUID userId, SignUpProfileRequest request) {
@@ -58,8 +62,11 @@ public class UserService {
 
         saveTechStacks(user.getId(), request.techStackIds());
 
+        String accessToken = jwtTokenProvider.createAccessToken(user.getUserId(), user.getEmail(), user.getRole(), true);
+        String refreshToken = saveRefreshToken(user.getId());
+
         log.info("프로필 생성 완료: userId={}, nickname={}", userId, request.nickname());
-        return SignUpProfileResponse.from(savedProfile);
+        return SignUpProfileResponse.from(savedProfile, accessToken, refreshToken);
     }
 
     public GetProfileResponse getProfile(UUID userId) {
@@ -166,6 +173,16 @@ public class UserService {
 
     public List<TechStack> getAllTechStacks() {
         return techStackRepository.findAll();
+    }
+
+    // ========== 토큰 ==========
+
+    private String saveRefreshToken(Long userId) {
+        String token = jwtTokenProvider.createRefreshToken();
+        long ttl = jwtTokenProvider.getRefreshTokenTtl();
+        LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(ttl / 1000);
+        refreshTokenRepository.save(new RefreshToken(userId, token, expiresAt));
+        return token;
     }
 
     // ========== 유틸 ==========

--- a/member/src/main/java/com/devticket/member/presentation/controller/AuthController.java
+++ b/member/src/main/java/com/devticket/member/presentation/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.devticket.member.presentation.controller;
 
 import com.devticket.member.application.AuthService;
+import com.devticket.member.presentation.dto.internal.request.InternalOAuthRequest;
+import com.devticket.member.presentation.dto.internal.response.InternalOAuthResponse;
 import com.devticket.member.presentation.dto.request.LoginRequest;
 import com.devticket.member.presentation.dto.request.SignUpRequest;
 import com.devticket.member.presentation.dto.request.SocialSignUpOrLoginRequest;
@@ -41,6 +43,22 @@ public class AuthController {
     public ResponseEntity<SignUpResponse> signup(@Valid @RequestBody SignUpRequest request) {
         SignUpResponse response = authService.signup(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(
+        summary = "OAuth 회원가입/로그인",
+        description = "API Gateway에서 OAuth 토큰 검증 후 호출 — 신규 가입 또는 기존 계정 조회 후 토큰 발급"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "토큰 발급 성공"),
+        @ApiResponse(responseCode = "409", description = "동일 이메일의 로컬 계정 존재"),
+        @ApiResponse(responseCode = "403", description = "정지 또는 탈퇴 계정")
+    })
+    @PostMapping("/google-signup")
+    public ResponseEntity<InternalOAuthResponse> oauthSignUpOrLogin(
+        @Valid @RequestBody InternalOAuthRequest request) {
+        InternalOAuthResponse response = authService.internalOAuthSignUpOrLogin(request);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "일반 로그인", description = "이메일, 비밀번호로 로그인")

--- a/member/src/main/java/com/devticket/member/presentation/domain/MemberErrorCode.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/MemberErrorCode.java
@@ -19,7 +19,7 @@ public enum MemberErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND(404, "MEMBER_009", "존재하지 않는 회원입니다."),
     PASSWORD_MISMATCH(400, "MEMBER_010", "기존 비밀번호가 일치하지 않습니다."),
     SELLER_APPLICATION_DUPLICATED(409, "MEMBER_011", "이미 판매자 전환 신청이 진행 중입니다."),
-    SOCIAL_EMAIL_CONFLICT(409, "MEMBER_012", "동일 이메일의 계정이 이미 존재하여 소셜 가입이 불가합니다."),
+    SOCIAL_EMAIL_CONFLICT(409, "MEMBER_012", "이미 이메일로 가입된 계정입니다. 이메일 로그인을 이용해주세요."),
     REFRESH_TOKEN_INVALID(401, "MEMBER_013", "Refresh Token이 유효하지 않습니다.");
 
     private final int status;

--- a/member/src/main/java/com/devticket/member/presentation/domain/repository/UserRepository.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.devticket.member.presentation.domain.repository;
 
+import com.devticket.member.presentation.domain.ProviderType;
 import com.devticket.member.presentation.domain.model.User;
 import java.util.Optional;
 import java.util.UUID;
@@ -14,5 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findSellerById(Long id);
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByProviderTypeAndProviderId(ProviderType providerType, String providerId);
 }
 

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/request/InternalOAuthRequest.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/request/InternalOAuthRequest.java
@@ -1,0 +1,13 @@
+package com.devticket.member.presentation.dto.internal.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record InternalOAuthRequest(
+    @NotBlank String provider,
+    @NotBlank String providerId,
+    @Email @NotBlank String email,
+    String name
+) {
+
+}

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalOAuthResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalOAuthResponse.java
@@ -1,0 +1,8 @@
+package com.devticket.member.presentation.dto.internal.response;
+
+public record InternalOAuthResponse(
+    String accessToken,
+    String refreshToken
+) {
+
+}

--- a/member/src/main/java/com/devticket/member/presentation/dto/response/SignUpProfileResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/response/SignUpProfileResponse.java
@@ -3,10 +3,10 @@ package com.devticket.member.presentation.dto.response;
 import com.devticket.member.presentation.domain.model.UserProfile;
 import java.util.UUID;
 
-public record SignUpProfileResponse(UUID profileId) {
+public record SignUpProfileResponse(UUID profileId, String accessToken, String refreshToken) {
 
-    public static SignUpProfileResponse from(UserProfile profile) {
-        return new SignUpProfileResponse(profile.getUserProfileId());
+    public static SignUpProfileResponse from(UserProfile profile, String accessToken, String refreshToken) {
+        return new SignUpProfileResponse(profile.getUserProfileId(), accessToken, refreshToken);
     }
 }
 

--- a/member/src/main/resources/application-local.yml
+++ b/member/src/main/resources/application-local.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5433/devticket
+    url: jdbc:postgresql://localhost:5433/devticket?currentSchema=member
     username: devticket
     password: devticket
     driver-class-name: org.postgresql.Driver

--- a/member/src/test/java/com/devticket/member/application/InternalMemberServiceTest.java
+++ b/member/src/test/java/com/devticket/member/application/InternalMemberServiceTest.java
@@ -11,6 +11,7 @@ import com.devticket.member.presentation.domain.UserRole;
 import com.devticket.member.presentation.domain.model.SellerApplication;
 import com.devticket.member.presentation.domain.model.User;
 import com.devticket.member.presentation.domain.repository.SellerApplicationRepository;
+import com.devticket.member.presentation.domain.repository.UserProfileRepository;
 import com.devticket.member.presentation.domain.repository.UserRepository;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberInfoResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberRoleResponse;
@@ -37,6 +38,9 @@ class InternalMemberServiceTest {
 
     @Mock
     private SellerApplicationRepository sellerApplicationRepository;
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
 
     private static final UUID TEST_USER_UUID = UUID.randomUUID();
 

--- a/member/src/test/java/com/devticket/member/application/InternalMemberServiceTest.java
+++ b/member/src/test/java/com/devticket/member/application/InternalMemberServiceTest.java
@@ -152,7 +152,7 @@ class InternalMemberServiceTest {
             // given
             User user = new User("test@test.com", "$2a$10$hashedPassword");
             SellerApplication application = new SellerApplication(
-                user.getId(), "국민은행", "123-456-789", "홍길동");
+                user.getUserId(), "국민은행", "123-456-789", "홍길동");
             application.approve();
             given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
             given(sellerApplicationRepository.findTopByUserIdOrderByCreatedAtDesc(any())).willReturn(

--- a/member/src/test/java/com/devticket/member/application/SellerApplicationServiceTest.java
+++ b/member/src/test/java/com/devticket/member/application/SellerApplicationServiceTest.java
@@ -146,7 +146,7 @@ class SellerApplicationServiceTest {
             // given
             User user = new User("test@test.com", "$2a$10$hashedPassword");
             SellerApplication application = new SellerApplication(
-                user.getId(), "국민은행", "123-456-789", "홍길동");
+                user.getUserId(), "국민은행", "123-456-789", "홍길동");
             given(userRepository.findByUserId(any(UUID.class))).willReturn(Optional.of(user));
             given(sellerApplicationRepository.findTopByUserIdOrderByCreatedAtDesc(any())).willReturn(
                 Optional.of(application));

--- a/member/src/test/java/com/devticket/member/application/UserServiceTest.java
+++ b/member/src/test/java/com/devticket/member/application/UserServiceTest.java
@@ -16,6 +16,7 @@ import com.devticket.member.presentation.domain.ProviderType;
 import com.devticket.member.presentation.domain.model.User;
 import com.devticket.member.presentation.domain.model.UserProfile;
 import com.devticket.member.presentation.domain.model.UserTechStack;
+import com.devticket.member.infrastructure.jwt.JwtTokenProvider;
 import com.devticket.member.presentation.domain.repository.RefreshTokenRepository;
 import com.devticket.member.presentation.domain.repository.TechStackRepository;
 import com.devticket.member.presentation.domain.repository.UserProfileRepository;
@@ -64,6 +65,9 @@ class UserServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
 
     private static final UUID TEST_USER_UUID = UUID.randomUUID();
 


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- API Gateway OAuth 연동을 위한 내부 엔드포인트 구현 및 신규 소셜 유저 프로필 설정 흐름 개선

## 변경 사항
  - OAuth 내부 API 추가 : POST /api/auth/google-signup 
  - API Gateway가 OAuth 토큰 검증 후 호출하는 내부 엔드포인트 신규 구현
  - DTO추가 : InternalOAuthRequest (provider, providerId, email, name)
  - DTO추가 : InternalOAuthResponse (accessToken, refreshToken)
  
  - 처리 우선순위: providerId 매칭 → 이메일 매칭 → 신규 가입
  - 동일 이메일의 로컬 계정 존재 시 SOCIAL_EMAIL_CONFLICT(409) 반환
  - UserRepository에 findByProviderTypeAndProviderId 쿼리 메서드 추가

  - POST /api/users/profile — 프로필 생성 응답에 토큰 포함
  - SignUpProfileResponse에 accessToken, refreshToken 필드 추가
  - 프로필 생성 완료 시 profileCompleted: true가 포함된 새 토큰을 즉시 발급하여 반환
  - 기존 흐름에서 신규 소셜 유저가 프로필 생성 후 별도로 /api/auth/reissue를 호출해야 했던 문제 해소

  - 에러 메시지 개선
    - SOCIAL_EMAIL_CONFLICT 에러 메시지를 프론트 표시에 맞게 사용자 친화적으로 수정

## 참고 사항
  신규 소셜 유저 인증 흐름:
  Google OAuth
    → API Gateway (토큰 검증)
    → POST /api/auth/google-signup  (accessToken[profileCompleted=false] + refreshToken 발급)
    → 프론트: JWT payload의 profileCompleted 확인 → false면 프로필 설정 페이지로 이동
    → POST /api/users/profile  (프로필 저장 + accessToken[profileCompleted=true] + refreshToken 즉시 발급)

