### PR TITLE
[Settlement] feat: Member 서비스 연동 및 정산 배치 sellerId 처리

### DIFF
--- a/settlement/src/main/java/com/devticket/settlement/SettlementApplication.java
+++ b/settlement/src/main/java/com/devticket/settlement/SettlementApplication.java
@@ -2,8 +2,10 @@ package com.devticket.settlement;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
 public class SettlementApplication {

--- a/settlement/src/main/java/com/devticket/settlement/domain/model/Settlement.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/model/Settlement.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "settlement")
+@Table(name = "settlement", schema = "settlement")
 public class Settlement extends BaseEntity {
 
     @Id

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/batch/SettlementItemReader.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/batch/SettlementItemReader.java
@@ -1,10 +1,13 @@
 package com.devticket.settlement.infrastructure.batch;
 
 import com.devticket.settlement.infrastructure.client.SettlementToCommerceClient;
+import com.devticket.settlement.infrastructure.client.SettlementToMemberClient;
 import com.devticket.settlement.infrastructure.client.dto.req.InternalSettlementDataRequest;
 import com.devticket.settlement.infrastructure.client.dto.res.InternalSettlementDataResponse;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.infrastructure.item.ItemReader;
 import org.springframework.stereotype.Component;
@@ -14,16 +17,20 @@ import org.springframework.stereotype.Component;
 public class SettlementItemReader implements ItemReader<InternalSettlementDataResponse> {
 
     private final SettlementToCommerceClient settlementToCommerceClient;
-    // read 플래그로 한 번만 읽기
-    private boolean read = false;
+    private final SettlementToMemberClient settlementToMemberClient;
+
+    private List<UUID> sellerIds;
+    private int index = 0;
+
 
     public void init() {
-        this.read = false;
+        this.sellerIds = settlementToMemberClient.getSellerIds();
+        this.index = 0;
     }
 
     @Override
     public InternalSettlementDataResponse read() throws Exception {
-        if (read) {
+        if (sellerIds == null || index >= sellerIds.size()){
             return null;
         }
         // 저번 달 1일
@@ -34,11 +41,11 @@ public class SettlementItemReader implements ItemReader<InternalSettlementDataRe
         String periodStart = firstDayOfLastMonth.format(DateTimeFormatter.ISO_DATE);
         String periodEnd = lastDayOfLastMonth.format(DateTimeFormatter.ISO_DATE);
 
-        // 전체 데이터 조회
-        InternalSettlementDataRequest request = new InternalSettlementDataRequest(null, periodStart, periodEnd);
-        InternalSettlementDataResponse response = settlementToCommerceClient.getSettlementData(request);
+        // 인덱스 추가
+        UUID sellerId = sellerIds.get(index++);
 
-        read = true;
-        return response;
+        // 전체 데이터 조회
+        InternalSettlementDataRequest request = new InternalSettlementDataRequest(sellerId, periodStart, periodEnd);
+        return settlementToCommerceClient.getSettlementData(request);
     }
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToMemberClient.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToMemberClient.java
@@ -1,0 +1,41 @@
+package com.devticket.settlement.infrastructure.client;
+
+import com.devticket.settlement.common.exception.BusinessException;
+import com.devticket.settlement.common.exception.CommonErrorCode;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class SettlementToMemberClient {
+
+    private final RestClient restClient;
+
+    public SettlementToMemberClient(@Qualifier("settlementToMemberRestClient") RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    public List<UUID> getSellerIds() {
+        try {
+            return restClient.get()
+                .uri("/internal/members/sellers")
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    log.error("[SettlementToMemberClient] External API Error: Status {}", res.getStatusCode());
+                    throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
+                })
+                .body(new ParameterizedTypeReference<List<UUID>>() {});
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[SettlementToMemberClient] Critical Error: ", e);
+            throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/InternalSettlementDataResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/InternalSettlementDataResponse.java
@@ -11,7 +11,7 @@ public record InternalSettlementDataResponse(
 ) {
 
     public record EventSettlements(
-        Long eventId,
+        UUID eventId,
         int totalSalesAmount,
         int totalRefundAmount,
         int soldQuantity,

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/config/SettlementRestClientConfig.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/config/SettlementRestClientConfig.java
@@ -17,4 +17,14 @@ public class SettlementRestClientConfig {
             .defaultHeader("Content-Type", "application/json")
             .build();
     }
+
+    @Bean
+    public RestClient settlementToMemberRestClient(
+        @Value("${external.member-base-url}") String baseUrl) {
+        return RestClient.builder()
+            .baseUrl(baseUrl)
+            .defaultHeader("Content-Type", "application/json")
+            .build();
+    }
+
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/external/MockCommerceController.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/external/MockCommerceController.java
@@ -24,7 +24,7 @@ public class MockCommerceController {
             periodEnd,
             List.of(
                 new InternalSettlementDataResponse.EventSettlements(
-                    15L,
+                    UUID.randomUUID(),
                     810000,
                     45000,
                     27,

--- a/settlement/src/main/resources/application-local.yml
+++ b/settlement/src/main/resources/application-local.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5433/devticket
+    url: jdbc:postgresql://localhost:5433/devticket?currentSchema=settlement
     username: devticket
     password: devticket
     driver-class-name: org.postgresql.Driver
@@ -24,4 +24,5 @@ logging:
     com.devticket: DEBUG
 
 external:
-  commerce-base-url: http://localhost:8085
+  commerce-base-url: http://localhost:8083
+  member-base-url: http://localhost:8081


### PR DESCRIPTION
## 작업 내용
- Settlement 서비스에서 Member 서비스 연동을 위한 SettlementToMemberClient 추가
- 전체 판매자 ID 목록을 조회하여 sellerId별로 정산 배치 처리
- SettlementItemReader에서 sellerId를 null로 보내던 문제 수정, Member 서비스에서 SELLER 목록을 받아 순회하도록 변경
- Settlement DB 스키마 지정 (currentSchema=settlement)
- InternalSettlementDataResponse의 eventId 타입 Long → UUID 수정
- @EnableJpaAuditing 추가로 BaseEntity createdAt null 오류 해결

## 변경 사항
- SettlementApplication.java: @EnableJpaAuditing 추가
- Settlement.java: @Table schema 지정
- SettlementItemReader.java: Member 서비스에서 sellerId 리스트 조회 후 순회
- SettlementToMemberClient.java: Member 서비스 내부 API 클라이언트 추가
- SettlementRestClientConfig.java: settlementToMemberRestClient 빈 추가
- InternalSettlementDataResponse.java: eventId 타입 UUID로 수정
- application-local.yml: member-base-url 추가, currentSchema=settlement 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)

## 관련 문서
- ERD 변경 없음
- settlement 스키마에 settlement 테이블 생성