### PR TITLE
[Member] feat: 정산 배치를 위한 전체 판매자 ID 목록 조회 API 추가

### DIFF
--- a/member/src/main/java/com/devticket/member/application/InternalMemberService.java
+++ b/member/src/main/java/com/devticket/member/application/InternalMemberService.java
@@ -90,4 +90,11 @@ public class InternalMemberService {
 
         return InternalDecideSellerApplicationResponse.from(application);
     }
+
+    // seller 아이디 전체 반환
+    public List<UUID> getSellerIds() {
+        return userRepository.findByRole(UserRole.SELLER).stream()
+            .map(User::getUserId)
+            .toList();
+    }
 }

--- a/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
+++ b/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
@@ -113,4 +113,12 @@ public class InternalMemberController {
         InternalDecideSellerApplicationResponse response=internalMemberService.decideSellerApplication(applicationId, request);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "판매자 ID 목록 조회", description = "내부 서비스용 — 전체 판매자 ID 목록 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/sellers")
+    public ResponseEntity<List<UUID>> getSellerId(){
+        List<UUID> response = internalMemberService.getSellerIds();
+        return ResponseEntity.ok(response);
+    }
 }

--- a/member/src/main/java/com/devticket/member/presentation/domain/repository/UserRepository.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.devticket.member.presentation.domain.repository;
 
+import com.devticket.member.presentation.domain.UserRole;
 import com.devticket.member.presentation.domain.model.User;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,5 +16,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findSellerById(Long id);
 
     boolean existsByEmail(String email);
+
+    List<User> findByRole(UserRole role);
 }
 


### PR DESCRIPTION
## 작업 내용
- Settlement 서비스의 정산 배치에서 전체 판매자 대상 정산 처리를 위해 SELLER 목록 조회 API 추가

## 변경 사항
- InternalMemberController.java: GET /internal/members/sellers 엔드포인트 추가
- InternalMemberService.java: getSellerIds() 메서드 추가
- UserRepository.java: findByRole(UserRole role) 메서드 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)

## 관련 문서
- ERD 변경 없음