### PR TITLE
[Event] feat: 정산 배치를 위한 기간별 판매자 이벤트 목록 조회 API 추가

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventInternalService.java
+++ b/event/src/main/java/com/devticket/event/application/EventInternalService.java
@@ -13,6 +13,7 @@ import com.devticket.event.presentation.dto.internal.InternalSellerEventsRespons
 import com.devticket.event.presentation.dto.internal.InternalStockAdjustmentResponse;
 import com.devticket.event.presentation.dto.internal.InternalStockOperationResponse;
 import com.devticket.event.presentation.dto.internal.PurchaseUnavailableReason;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -227,4 +228,17 @@ public class EventInternalService {
         }
         return PurchaseUnavailableReason.INSUFFICIENT_STOCK;
     }
+
+
+    // 기간 별 판매자 이벤트
+    public List<InternalEventInfoResponse> getEventsBySellerForSettlement(UUID sellerId, String periodStart, String periodEnd) {
+        LocalDateTime start = LocalDate.parse(periodStart).atStartOfDay();
+        LocalDateTime end = LocalDate.parse(periodEnd).atTime(23, 59, 59);
+
+        return eventRepository.findEventsBySellerAndPeriod(sellerId, start, end)
+            .stream()
+            .map(InternalEventInfoResponse::from)
+            .toList();
+    }
+
 }

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepositoryCustom.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.devticket.event.infrastructure.persistence;
 import com.devticket.event.domain.enums.EventCategory;
 import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.domain.model.Event;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -19,4 +20,6 @@ public interface EventRepositoryCustom {
     );
 
     List<Event> findEventsBySeller(UUID sellerId, EventStatus status);
+
+    List<Event> findEventsBySellerAndPeriod(UUID sellerId, LocalDateTime periodStart, LocalDateTime periodEnd);
 }

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepositoryImpl.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -111,6 +112,19 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
             .where(
                 sellerEq(sellerId),
                 statusEq(status)
+            )
+            .orderBy(event.createdAt.desc())
+            .fetch();
+    }
+
+    @Override
+    public List<Event> findEventsBySellerAndPeriod(UUID sellerId, LocalDateTime periodStart, LocalDateTime periodEnd) {
+        return queryFactory
+            .selectFrom(event)
+            .where(
+                sellerEq(sellerId),
+                event.saleStartAt.goe(periodStart),
+                event.saleEndAt.loe(periodEnd)
             )
             .orderBy(event.createdAt.desc())
             .fetch();

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventInternalController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventInternalController.java
@@ -15,6 +15,7 @@ import com.devticket.event.presentation.dto.internal.InternalStockOperationRespo
 import com.devticket.event.presentation.dto.internal.InternalStockRestoreRequest;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -121,6 +122,17 @@ public class EventInternalController {
         @RequestParam(required = false) EventStatus status) {
         return ResponseEntity.ok(SuccessResponse.success(
             eventInternalService.getEventsBySeller(sellerId, status)
+        ));
+    }
+
+    // 기간 별 판매자 이벤트
+    @GetMapping("/by-seller/{sellerId}/settlement")
+    public ResponseEntity<SuccessResponse<List<InternalEventInfoResponse>>> getEventsBySellerForSettlement(
+        @PathVariable UUID sellerId,
+        @RequestParam String periodStart,
+        @RequestParam String periodEnd) {
+        return ResponseEntity.ok(SuccessResponse.success(
+            eventInternalService.getEventsBySellerForSettlement(sellerId, periodStart, periodEnd)
         ));
     }
 }


### PR DESCRIPTION
## 작업 내용
- Settlement 배치에서 기간 내 판매자의 이벤트를 조회하기 위한 정산 전용 API 추가
- 기존 getEventsBySeller와 분리하여 정산 전용 기간 조건 쿼리 구현

## 변경 사항
- EventInternalController.java: GET /internal/events/by-seller/{sellerId}/settlement 엔드포인트 추가
- EventInternalService.java: getEventsBySellerForSettlement() 메서드 추가
- EventRepositoryCustom.java: findEventsBySellerAndPeriod() 메서드 추가
- EventRepositoryImpl.java: findEventsBySellerAndPeriod() QueryDSL 구현 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)

## 관련 문서
- ERD 변경 없음