### PR TITLE
[Commerce] feat: 정산 배치를 위한 기간별 판매자 이벤트 조회 클라이언트 수정

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
@@ -41,5 +41,6 @@ public interface OrderUsecase {
 
     // 결제 전 주문 취소
     OrderCancelResponse cancelOrder(UUID userId, UUID orderId);
+
 }
 

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/OrderToEventClient.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/OrderToEventClient.java
@@ -73,19 +73,19 @@ public class OrderToEventClient {
         }
     }
 
-    public List<InternalEventInfoResponse> getSellerEventsByPeriod(UUID sellerId, String periodStart,
-        String periodEnd) {
+    public List<InternalEventInfoResponse> getSellerEventsByPeriod(UUID sellerId, String periodStart, String periodEnd) {
         try {
-            var response = restClient.post()
-                .uri("/internal/events/seller-period")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(new InternalSellerEventsByPeriodRequest(sellerId, periodStart, periodEnd))
+            var response = restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                    .path("/internal/events/by-seller/{sellerId}/settlement")
+                    .queryParam("periodStart", periodStart)
+                    .queryParam("periodEnd", periodEnd)
+                    .build(sellerId))
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, (req, res) -> {
                     throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
                 })
-                .body(new ParameterizedTypeReference<EventSuccessResponse<List<InternalEventInfoResponse>>>() {
-                });
+                .body(new ParameterizedTypeReference<EventSuccessResponse<List<InternalEventInfoResponse>>>() {});
             return response.data();
         } catch (BusinessException e) {
             throw e;


### PR DESCRIPTION
## 작업 내용
- Settlement 배치의 전체 정산 처리를 위해 Event 서비스 호출 방식 변경
- 기존 POST /internal/events/seller-period → GET /internal/events/by-seller/{sellerId}/settlement로 변경

## 변경 사항
- OrderToEventClient.java: getSellerEventsByPeriod() 메서드 호출 URL 및 방식 수정 (POST → GET)

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)

## 관련 문서
- ERD 변경 없음