### PR TITLE
[Commerce] docs: API/DTO 문서화 및 서비스 현황 정리

### DIFF
--- a/docs/api-overview.json
+++ b/docs/api-overview.json
@@ -1,0 +1,33 @@
+{
+  "module": "commerce",
+  "generatedFrom": "controller mappings",
+  "externalApis": [
+    {"domain":"cart","httpMethod":"POST","path":"/api/cart/items","controller":"CartController","method":"addToCart","requestDto":"CartItemRequest","responseDto":"CartItemResponse","summary":"장바구니 아이템 추가"},
+    {"domain":"cart","httpMethod":"GET","path":"/api/cart","controller":"CartController","method":"getCart","requestDto":null,"responseDto":"CartResponse","summary":"내 장바구니 조회"},
+    {"domain":"cart","httpMethod":"PATCH","path":"/api/cart/items/{cartItemId}","controller":"CartController","method":"updateCartItemQuantity","requestDto":"CartItemQuantityRequest","responseDto":"CartItemQuantityResponse","summary":"장바구니 수량 증감"},
+    {"domain":"cart","httpMethod":"DELETE","path":"/api/cart/items/{cartItemId}","controller":"CartController","method":"deleteCartItem","requestDto":null,"responseDto":"CartItemDeleteResponse","summary":"장바구니 단건 삭제"},
+    {"domain":"cart","httpMethod":"DELETE","path":"/api/cart","controller":"CartController","method":"deleteCartItemAll","requestDto":null,"responseDto":"CartClearResponse","summary":"장바구니 전체 삭제"},
+
+    {"domain":"order","httpMethod":"POST","path":"/api/orders","controller":"OrderController","method":"createOrderByCart","requestDto":"CartOrderRequest","responseDto":"OrderResponse","summary":"장바구니 기반 주문 생성"},
+    {"domain":"order","httpMethod":"GET","path":"/api/orders","controller":"OrderController","method":"getOrderList","requestDto":"OrderListRequest","responseDto":"OrderListResponse","summary":"주문 목록 조회"},
+    {"domain":"order","httpMethod":"GET","path":"/api/orders/{orderId}","controller":"OrderController","method":"getOrderDetail","requestDto":null,"responseDto":"OrderDetailResponse","summary":"주문 상세 조회"},
+    {"domain":"order","httpMethod":"PATCH","path":"/api/orders/{orderId}/cancel","controller":"OrderController","method":"cancelOrder","requestDto":null,"responseDto":"OrderCancelResponse","summary":"결제 전 주문 취소"},
+
+    {"domain":"ticket","httpMethod":"GET","path":"/api/tickets","controller":"TicketController","method":"getTicketList","requestDto":"TicketListRequest","responseDto":"TicketListResponse","summary":"내 티켓 목록 조회"},
+    {"domain":"ticket","httpMethod":"GET","path":"/api/tickets/{ticketId}","controller":"TicketController","method":"getTicketDetail","requestDto":null,"responseDto":"TicketDetailResponse","summary":"티켓 상세 조회"},
+    {"domain":"ticket","httpMethod":"POST","path":"/api/tickets","controller":"TicketController","method":"createTickets","requestDto":"TicketRequest","responseDto":"TicketResponse","summary":"티켓 발급(내부성격 API)"},
+    {"domain":"seller-ticket","httpMethod":"GET","path":"/seller/events/{eventId}/participants","controller":"SellerTicketController","method":"getParticipantList","requestDto":"SellerEventParticipantListRequest","responseDto":"SellerEventParticipantListResponse","summary":"이벤트 참여자 목록 조회"}
+  ],
+  "internalApis": [
+    {"domain":"order-internal","httpMethod":"GET","path":"/internal/orders/{orderId}","controller":"InternalOrderController","method":"getOrderInfo","responseDto":"InternalOrderInfoResponse","summary":"결제 전 주문 정보 조회"},
+    {"domain":"order-internal","httpMethod":"GET","path":"/internal/orders/{id}/items","controller":"InternalOrderController","method":"getOrderListForSettlement","responseDto":"InternalOrderItemsResponse","summary":"정산용 주문 항목 조회"},
+    {"domain":"order-internal","httpMethod":"GET","path":"/internal/orders/settlement-data","controller":"InternalOrderController","method":"getSettlementData","responseDto":"InternalSettlementDataResponse","summary":"판매자 기간 정산 데이터 조회"},
+    {"domain":"order-internal","httpMethod":"POST","path":"/internal/orders/{orderId}/payment-completed","controller":"InternalOrderController","method":"completeOrder","responseDto":"Void","summary":"결제 성공 처리 + 티켓 발급"},
+    {"domain":"order-internal","httpMethod":"PATCH","path":"/internal/orders/{orderId}/payment-failed","controller":"InternalOrderController","method":"failOrder","responseDto":"Void","summary":"결제 실패 처리"},
+    {"domain":"order-internal","httpMethod":"GET","path":"/internal/order-items/by-ticket/{ticketId}","controller":"InternalOrderController","method":"getOrderItemByTicketId","responseDto":"InternalOrderItemResponse","summary":"티켓 기준 주문항목 조회"},
+    {"domain":"order-internal","httpMethod":"PATCH","path":"/internal/tickets/{ticketId}/refund-completed","controller":"InternalOrderController","method":"completeRefund","responseDto":"Void","summary":"환불 완료 처리"}
+  ],
+  "notImplemented": [
+    {"path":"/internal/orders/by-event/{eventId}","controller":"InternalOrderController","status":"commented-out"}
+  ]
+}

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -1,0 +1,33 @@
+# Commerce API 문서 (구현 기준)
+
+## 1) External API
+
+| 영역 | 메서드 | 경로 | Controller 메서드 | 요청 DTO | 응답 DTO | 설명 |
+|---|---|---|---|---|---|---|
+| Cart | POST | `/api/cart/items` | `addToCart` | `CartItemRequest` | `CartItemResponse` | 장바구니 아이템 추가 |
+| Cart | GET | `/api/cart` | `getCart` | - | `CartResponse` | 내 장바구니 조회 |
+| Cart | PATCH | `/api/cart/items/{cartItemId}` | `updateCartItemQuantity` | `CartItemQuantityRequest` | `CartItemQuantityResponse` | 장바구니 수량 증감 |
+| Cart | DELETE | `/api/cart/items/{cartItemId}` | `deleteCartItem` | - | `CartItemDeleteResponse` | 장바구니 단건 삭제 |
+| Cart | DELETE | `/api/cart` | `deleteCartItemAll` | - | `CartClearResponse` | 장바구니 전체 삭제 |
+| Order | POST | `/api/orders` | `createOrderByCart` | `CartOrderRequest` | `OrderResponse` | 장바구니 기반 주문 생성 |
+| Order | GET | `/api/orders` | `getOrderList` | `OrderListRequest`(query) | `OrderListResponse` | 주문 목록 조회 |
+| Order | GET | `/api/orders/{orderId}` | `getOrderDetail` | - | `OrderDetailResponse` | 주문 상세 조회 |
+| Order | PATCH | `/api/orders/{orderId}/cancel` | `cancelOrder` | - | `OrderCancelResponse` | 결제 전 주문 취소 |
+| Ticket | GET | `/api/tickets` | `getTicketList` | `TicketListRequest`(query) | `TicketListResponse` | 내 티켓 목록 조회 |
+| Ticket | GET | `/api/tickets/{ticketId}` | `getTicketDetail` | - | `TicketDetailResponse` | 티켓 상세 조회 |
+| Ticket | POST | `/api/tickets` | `createTickets` | `TicketRequest` | `TicketResponse` | 티켓 발급(내부성격 API) |
+| Seller Ticket | GET | `/seller/events/{eventId}/participants` | `getParticipantList` | `SellerEventParticipantListRequest`(query) | `SellerEventParticipantListResponse` | 이벤트 참여자 목록 조회 |
+
+## 2) Internal API
+
+| 영역 | 메서드 | 경로 | Controller 메서드 | 응답 DTO | 설명 |
+|---|---|---|---|---|---|
+| Order Internal | GET | `/internal/orders/{orderId}` | `getOrderInfo` | `InternalOrderInfoResponse` | 결제 전 주문 정보 조회 |
+| Order Internal | GET | `/internal/orders/{id}/items` | `getOrderListForSettlement` | `InternalOrderItemsResponse` | 정산용 주문 항목 조회 |
+| Order Internal | GET | `/internal/orders/settlement-data` | `getSettlementData` | `InternalSettlementDataResponse` | 판매자 기간 정산 데이터 조회 |
+| Order Internal | POST | `/internal/orders/{orderId}/payment-completed` | `completeOrder` | `Void` | 결제 성공 처리 + 티켓 발급 |
+| Order Internal | PATCH | `/internal/orders/{orderId}/payment-failed` | `failOrder` | `Void` | 결제 실패 처리 |
+| Order Internal | GET | `/internal/order-items/by-ticket/{ticketId}` | `getOrderItemByTicketId` | `InternalOrderItemResponse` | 티켓 기준 주문항목 조회 |
+| Order Internal | PATCH | `/internal/tickets/{ticketId}/refund-completed` | `completeRefund` | `Void` | 환불 완료 처리 |
+
+> 참고: `/internal/orders/by-event/{eventId}`는 주석 처리되어 현재 미구현 상태입니다.

--- a/docs/dto-overview.json
+++ b/docs/dto-overview.json
@@ -1,0 +1,662 @@
+{
+  "module": "commerce",
+  "dtoCount": 30,
+  "dtos": [
+    {
+      "name": "CartItemQuantityRequest",
+      "group": "request",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/req/CartItemQuantityRequest.java",
+      "fields": [
+        {
+          "name": "quantity",
+          "type": "int"
+        }
+      ]
+    },
+    {
+      "name": "CartItemRequest",
+      "group": "request",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/req/CartItemRequest.java",
+      "fields": [
+        {
+          "name": "eventId",
+          "type": "UUID"
+        },
+        {
+          "name": "quantity",
+          "type": "int"
+        }
+      ]
+    },
+    {
+      "name": "CartClearResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartClearResponse.java",
+      "fields": [
+        {
+          "name": "message",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "CartItemDeleteResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDeleteResponse.java",
+      "fields": [
+        {
+          "name": "message",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "CartItemDetail",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDetail.java",
+      "fields": [
+        {
+          "name": "cartItemId",
+          "type": "UUID"
+        },
+        {
+          "name": "eventId",
+          "type": "UUID"
+        },
+        {
+          "name": "eventTitle",
+          "type": "String"
+        },
+        {
+          "name": "price",
+          "type": "int"
+        },
+        {
+          "name": "quantity",
+          "type": "int"
+        }
+      ]
+    },
+    {
+      "name": "CartItemQuantityResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemQuantityResponse.java",
+      "fields": [
+        {
+          "name": "cartItemId",
+          "type": "String"
+        },
+        {
+          "name": "quantity",
+          "type": "int"
+        }
+      ]
+    },
+    {
+      "name": "CartItemResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemResponse.java",
+      "fields": [
+        {
+          "name": "cartId",
+          "type": "String"
+        },
+        {
+          "name": "items",
+          "type": "List<CartItemDetail>"
+        },
+        {
+          "name": "totalAmount",
+          "type": "long"
+        }
+      ]
+    },
+    {
+      "name": "CartResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartResponse.java",
+      "fields": [
+        {
+          "name": "cartId",
+          "type": "String"
+        },
+        {
+          "name": "items",
+          "type": "List<CartItemDetail>"
+        },
+        {
+          "name": "totalAmount",
+          "type": "int"
+        }
+      ]
+    },
+    {
+      "name": "CartOrderRequest",
+      "group": "request",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/CartOrderRequest.java",
+      "fields": [
+        {
+          "name": "cartItemIds",
+          "type": "List<UUID>"
+        }
+      ]
+    },
+    {
+      "name": "OrderListRequest",
+      "group": "request",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/OrderListRequest.java",
+      "fields": [
+        {
+          "name": "page",
+          "type": "int"
+        },
+        {
+          "name": "size",
+          "type": "int"
+        },
+        {
+          "name": "status",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "OrderRequest",
+      "group": "request",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/OrderRequest.java",
+      "fields": [
+        {
+          "name": "cartItemEventIds",
+          "type": "List<String>"
+        }
+      ]
+    },
+    {
+      "name": "InternalOrderInfoResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderInfoResponse.java",
+      "fields": [
+        {
+          "name": "id",
+          "type": "UUID"
+        },
+        {
+          "name": "userId",
+          "type": "UUID"
+        },
+        {
+          "name": "orderNumber",
+          "type": "String"
+        },
+        {
+          "name": "paymentMethod",
+          "type": "String"
+        },
+        {
+          "name": "totalAmount",
+          "type": "Integer"
+        },
+        {
+          "name": "status",
+          "type": "String"
+        },
+        {
+          "name": "orderedAt",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "InternalOrderItemResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderItemResponse.java",
+      "fields": [
+        {
+          "name": "id",
+          "type": "Long"
+        },
+        {
+          "name": "orderItemId",
+          "type": "UUID"
+        },
+        {
+          "name": "orderId",
+          "type": "Long"
+        },
+        {
+          "name": "userId",
+          "type": "UUID"
+        },
+        {
+          "name": "eventId",
+          "type": "UUID"
+        },
+        {
+          "name": "price",
+          "type": "int"
+        },
+        {
+          "name": "quantity",
+          "type": "int"
+        },
+        {
+          "name": "subtotalAmount",
+          "type": "int"
+        },
+        {
+          "name": "createdAt",
+          "type": "LocalDateTime"
+        },
+        {
+          "name": "updatedAt",
+          "type": "LocalDateTime"
+        }
+      ]
+    },
+    {
+      "name": "InternalOrderItemsResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderItemsResponse.java",
+      "fields": [
+        {
+          "name": "eventId",
+          "type": "Long"
+        },
+        {
+          "name": "orders",
+          "type": "List<InternalOrderItemsResponse.OrderItems>"
+        }
+      ]
+    },
+    {
+      "name": "InternalSettlementDataResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalSettlementDataResponse.java",
+      "fields": [
+        {
+          "name": "sellerId",
+          "type": "UUID"
+        },
+        {
+          "name": "periodStart",
+          "type": "String"
+        },
+        {
+          "name": "periodEnd",
+          "type": "String"
+        },
+        {
+          "name": "eventSettlements",
+          "type": "List<EventSettlements>"
+        }
+      ]
+    },
+    {
+      "name": "OrderCancelResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderCancelResponse.java",
+      "fields": [
+        {
+          "name": "orderId",
+          "type": "String"
+        },
+        {
+          "name": "status",
+          "type": "String"
+        },
+        {
+          "name": "cancelledAt",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "OrderDetailItemResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailItemResponse.java",
+      "fields": [
+        {
+          "name": "eventId",
+          "type": "UUID"
+        },
+        {
+          "name": "eventTitle",
+          "type": "String"
+        },
+        {
+          "name": "quantity",
+          "type": "int"
+        },
+        {
+          "name": "price",
+          "type": "int"
+        }
+      ]
+    },
+    {
+      "name": "OrderDetailResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailResponse.java",
+      "fields": [
+        {
+          "name": "orderId",
+          "type": "UUID"
+        },
+        {
+          "name": "status",
+          "type": "OrderStatus"
+        },
+        {
+          "name": "totalAmount",
+          "type": "int"
+        },
+        {
+          "name": "orderItems",
+          "type": "List<OrderDetailItemResponse>"
+        },
+        {
+          "name": "paymentMethod",
+          "type": "PaymentMethod"
+        },
+        {
+          "name": "createdAt",
+          "type": "LocalDateTime"
+        }
+      ]
+    },
+    {
+      "name": "OrderItemsResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderItemsResponse.java",
+      "fields": [
+        {
+          "name": "eventId",
+          "type": "UUID"
+        },
+        {
+          "name": "eventTitle",
+          "type": "String"
+        },
+        {
+          "name": "quantity",
+          "type": "int"
+        },
+        {
+          "name": "price",
+          "type": "int"
+        }
+      ]
+    },
+    {
+      "name": "OrderListResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderListResponse.java",
+      "fields": [
+        {
+          "name": "orders",
+          "type": "List<OrderSummary>"
+        },
+        {
+          "name": "totalPages",
+          "type": "int"
+        },
+        {
+          "name": "totalElements",
+          "type": "long"
+        }
+      ]
+    },
+    {
+      "name": "OrderResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderResponse.java",
+      "fields": [
+        {
+          "name": "orderId",
+          "type": "UUID"
+        },
+        {
+          "name": "totalAmount",
+          "type": "Long"
+        },
+        {
+          "name": "orderStatus",
+          "type": "OrderStatus"
+        },
+        {
+          "name": "orderItems",
+          "type": "List<OrderItemsResponse>"
+        },
+        {
+          "name": "createdAt",
+          "type": "LocalDateTime"
+        }
+      ]
+    },
+    {
+      "name": "OrderSummary",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderSummary.java",
+      "fields": [
+        {
+          "name": "orderId",
+          "type": "UUID"
+        },
+        {
+          "name": "totalAmount",
+          "type": "int"
+        },
+        {
+          "name": "status",
+          "type": "OrderStatus"
+        },
+        {
+          "name": "createdAt",
+          "type": "LocalDateTime"
+        }
+      ]
+    },
+    {
+      "name": "SellerEventParticipantListRequest",
+      "group": "request",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/SellerEventParticipantListRequest.java",
+      "fields": [
+        {
+          "name": "page",
+          "type": "Integer"
+        },
+        {
+          "name": "size",
+          "type": "Integer"
+        },
+        {
+          "name": "keyword",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "TicketListRequest",
+      "group": "request",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/TicketListRequest.java",
+      "fields": [
+        {
+          "name": "page",
+          "type": "int"
+        },
+        {
+          "name": "size",
+          "type": "int"
+        }
+      ]
+    },
+    {
+      "name": "TicketRequest",
+      "group": "request",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/TicketRequest.java",
+      "fields": [
+        {
+          "name": "orderId",
+          "type": "Long"
+        }
+      ]
+    },
+    {
+      "name": "SellerEventParticipantListResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantListResponse.java",
+      "fields": [
+        {
+          "name": "sellerEventParticipantListResponse",
+          "type": "List<SellerEventParticipantResponse>"
+        },
+        {
+          "name": "page",
+          "type": "int"
+        },
+        {
+          "name": "size",
+          "type": "int"
+        },
+        {
+          "name": "totalElements",
+          "type": "long"
+        },
+        {
+          "name": "totalPages",
+          "type": "int"
+        }
+      ]
+    },
+    {
+      "name": "SellerEventParticipantResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantResponse.java",
+      "fields": [
+        {
+          "name": "ticketId",
+          "type": "String"
+        },
+        {
+          "name": "orderId",
+          "type": "String"
+        },
+        {
+          "name": "userId",
+          "type": "String"
+        },
+        {
+          "name": "email",
+          "type": "String"
+        },
+        {
+          "name": "purchasedAt",
+          "type": "String"
+        },
+        {
+          "name": "orderNumber",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "TicketDetailResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketDetailResponse.java",
+      "fields": [
+        {
+          "name": "ticketId",
+          "type": "UUID"
+        },
+        {
+          "name": "eventId",
+          "type": "UUID"
+        },
+        {
+          "name": "eventTitle",
+          "type": "String"
+        },
+        {
+          "name": "eventDateTime",
+          "type": "String"
+        },
+        {
+          "name": "status",
+          "type": "String"
+        },
+        {
+          "name": "issuedAt",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "TicketListResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketListResponse.java",
+      "fields": [
+        {
+          "name": "totalPages",
+          "type": "int"
+        },
+        {
+          "name": "totalElements",
+          "type": "Long"
+        },
+        {
+          "name": "tickets",
+          "type": "List<TicketDetailResponse>"
+        }
+      ]
+    },
+    {
+      "name": "TicketResponse",
+      "group": "response",
+      "kind": "record",
+      "path": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketResponse.java",
+      "fields": [
+        {
+          "name": "orderItemId",
+          "type": "Long"
+        },
+        {
+          "name": "totalCount",
+          "type": "Integer"
+        },
+        {
+          "name": "tickets",
+          "type": "List<TicketInfo>"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/dto-overview.md
+++ b/docs/dto-overview.md
@@ -1,0 +1,259 @@
+# Commerce DTO 문서 (presentation/dto 기준)
+
+## Request DTO
+
+### CartItemQuantityRequest
+- 파일: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/req/CartItemQuantityRequest.java`
+- 타입: `record`
+- 필드:
+  - `quantity`: `int`
+
+### CartItemRequest
+- 파일: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/req/CartItemRequest.java`
+- 타입: `record`
+- 필드:
+  - `eventId`: `UUID`
+  - `quantity`: `int`
+
+### CartOrderRequest
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/CartOrderRequest.java`
+- 타입: `record`
+- 필드:
+  - `cartItemIds`: `List<UUID>`
+
+### OrderListRequest
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/OrderListRequest.java`
+- 타입: `record`
+- 필드:
+  - `page`: `int`
+  - `size`: `int`
+  - `status`: `String`
+
+### OrderRequest
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/OrderRequest.java`
+- 타입: `record`
+- 필드:
+  - `cartItemEventIds`: `List<String>`
+
+### SellerEventParticipantListRequest
+- 파일: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/SellerEventParticipantListRequest.java`
+- 타입: `record`
+- 필드:
+  - `page`: `Integer`
+  - `size`: `Integer`
+  - `keyword`: `String`
+
+### TicketListRequest
+- 파일: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/TicketListRequest.java`
+- 타입: `record`
+- 필드:
+  - `page`: `int`
+  - `size`: `int`
+
+### TicketRequest
+- 파일: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/TicketRequest.java`
+- 타입: `record`
+- 필드:
+  - `orderId`: `Long`
+
+## Response DTO
+
+### CartClearResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartClearResponse.java`
+- 타입: `record`
+- 필드:
+  - `message`: `String`
+
+### CartItemDeleteResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDeleteResponse.java`
+- 타입: `record`
+- 필드:
+  - `message`: `String`
+
+### CartItemDetail
+- 파일: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDetail.java`
+- 타입: `record`
+- 필드:
+  - `cartItemId`: `UUID`
+  - `eventId`: `UUID`
+  - `eventTitle`: `String`
+  - `price`: `int`
+  - `quantity`: `int`
+
+### CartItemQuantityResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemQuantityResponse.java`
+- 타입: `record`
+- 필드:
+  - `cartItemId`: `String`
+  - `quantity`: `int`
+
+### CartItemResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemResponse.java`
+- 타입: `record`
+- 필드:
+  - `cartId`: `String`
+  - `items`: `List<CartItemDetail>`
+  - `totalAmount`: `long`
+
+### CartResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartResponse.java`
+- 타입: `record`
+- 필드:
+  - `cartId`: `String`
+  - `items`: `List<CartItemDetail>`
+  - `totalAmount`: `int`
+
+### InternalOrderInfoResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderInfoResponse.java`
+- 타입: `record`
+- 필드:
+  - `id`: `UUID`
+  - `userId`: `UUID`
+  - `orderNumber`: `String`
+  - `paymentMethod`: `String`
+  - `totalAmount`: `Integer`
+  - `status`: `String`
+  - `orderedAt`: `String`
+
+### InternalOrderItemResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderItemResponse.java`
+- 타입: `record`
+- 필드:
+  - `id`: `Long`
+  - `orderItemId`: `UUID`
+  - `orderId`: `Long`
+  - `userId`: `UUID`
+  - `eventId`: `UUID`
+  - `price`: `int`
+  - `quantity`: `int`
+  - `subtotalAmount`: `int`
+  - `createdAt`: `LocalDateTime`
+  - `updatedAt`: `LocalDateTime`
+
+### InternalOrderItemsResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderItemsResponse.java`
+- 타입: `record`
+- 필드:
+  - `eventId`: `Long`
+  - `orders`: `List<InternalOrderItemsResponse.OrderItems>`
+
+### InternalSettlementDataResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalSettlementDataResponse.java`
+- 타입: `record`
+- 필드:
+  - `sellerId`: `UUID`
+  - `periodStart`: `String`
+  - `periodEnd`: `String`
+  - `eventSettlements`: `List<EventSettlements>`
+
+### OrderCancelResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderCancelResponse.java`
+- 타입: `record`
+- 필드:
+  - `orderId`: `String`
+  - `status`: `String`
+  - `cancelledAt`: `String`
+
+### OrderDetailItemResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailItemResponse.java`
+- 타입: `record`
+- 필드:
+  - `eventId`: `UUID`
+  - `eventTitle`: `String`
+  - `quantity`: `int`
+  - `price`: `int`
+
+### OrderDetailResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailResponse.java`
+- 타입: `record`
+- 필드:
+  - `orderId`: `UUID`
+  - `status`: `OrderStatus`
+  - `totalAmount`: `int`
+  - `orderItems`: `List<OrderDetailItemResponse>`
+  - `paymentMethod`: `PaymentMethod`
+  - `createdAt`: `LocalDateTime`
+
+### OrderItemsResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderItemsResponse.java`
+- 타입: `record`
+- 필드:
+  - `eventId`: `UUID`
+  - `eventTitle`: `String`
+  - `quantity`: `int`
+  - `price`: `int`
+
+### OrderListResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderListResponse.java`
+- 타입: `record`
+- 필드:
+  - `orders`: `List<OrderSummary>`
+  - `totalPages`: `int`
+  - `totalElements`: `long`
+
+### OrderResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderResponse.java`
+- 타입: `record`
+- 필드:
+  - `orderId`: `UUID`
+  - `totalAmount`: `Long`
+  - `orderStatus`: `OrderStatus`
+  - `orderItems`: `List<OrderItemsResponse>`
+  - `createdAt`: `LocalDateTime`
+
+### OrderSummary
+- 파일: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderSummary.java`
+- 타입: `record`
+- 필드:
+  - `orderId`: `UUID`
+  - `totalAmount`: `int`
+  - `status`: `OrderStatus`
+  - `createdAt`: `LocalDateTime`
+
+### SellerEventParticipantListResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantListResponse.java`
+- 타입: `record`
+- 필드:
+  - `sellerEventParticipantListResponse`: `List<SellerEventParticipantResponse>`
+  - `page`: `int`
+  - `size`: `int`
+  - `totalElements`: `long`
+  - `totalPages`: `int`
+
+### SellerEventParticipantResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantResponse.java`
+- 타입: `record`
+- 필드:
+  - `ticketId`: `String`
+  - `orderId`: `String`
+  - `userId`: `String`
+  - `email`: `String`
+  - `purchasedAt`: `String`
+  - `orderNumber`: `String`
+
+### TicketDetailResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketDetailResponse.java`
+- 타입: `record`
+- 필드:
+  - `ticketId`: `UUID`
+  - `eventId`: `UUID`
+  - `eventTitle`: `String`
+  - `eventDateTime`: `String`
+  - `status`: `String`
+  - `issuedAt`: `String`
+
+### TicketListResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketListResponse.java`
+- 타입: `record`
+- 필드:
+  - `totalPages`: `int`
+  - `totalElements`: `Long`
+  - `tickets`: `List<TicketDetailResponse>`
+
+### TicketResponse
+- 파일: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketResponse.java`
+- 타입: `record`
+- 필드:
+  - `orderItemId`: `Long`
+  - `totalCount`: `Integer`
+  - `tickets`: `List<TicketInfo>`

--- a/docs/service-status.json
+++ b/docs/service-status.json
@@ -1,0 +1,41 @@
+{
+  "module": "commerce",
+  "services": [
+    {
+      "service": "CartService",
+      "methods": [
+        {"name": "findByUserId", "status": "implemented", "summary": "사용자 장바구니 존재 여부 조회"},
+        {"name": "save", "status": "implemented", "summary": "구매 가능 검증 후 장바구니 아이템 생성/증가"},
+        {"name": "getCart", "status": "implemented", "summary": "장바구니/아이템 조회 및 응답 변환"},
+        {"name": "clearCart", "status": "implemented", "summary": "장바구니 전체 비우기"},
+        {"name": "updateTicket", "status": "implemented", "summary": "장바구니 아이템 수량 증감 처리"},
+        {"name": "deleteTicket", "status": "implemented", "summary": "장바구니 아이템 단건 삭제"}
+      ]
+    },
+    {
+      "service": "OrderService",
+      "methods": [
+        {"name": "createOrderByCart", "status": "implemented", "summary": "주문 생성 + 재고 선차감/실패 보상"},
+        {"name": "getOrderList", "status": "implemented", "summary": "주문 목록 페이징 조회"},
+        {"name": "getOrderDetail", "status": "implemented", "summary": "주문 상세 조회"},
+        {"name": "cancelOrder", "status": "implemented", "summary": "결제 전 주문 취소 + 재고 복구"},
+        {"name": "getOrderInfo", "status": "implemented", "summary": "내부 결제용 주문 단건 조회"},
+        {"name": "getOrderListForSettlement", "status": "implemented", "summary": "내부 정산용 주문 항목 조회"},
+        {"name": "completeOrder", "status": "implemented", "summary": "결제 완료 처리 및 티켓 발급"},
+        {"name": "failOrder", "status": "implemented", "summary": "결제 실패 상태 반영"},
+        {"name": "getSettelmentData", "status": "implemented", "summary": "판매자 기간 정산 데이터 집계"},
+        {"name": "getOrderItemByTicketId", "status": "implemented", "summary": "티켓 기준 주문 항목 조회"},
+        {"name": "completeRefund", "status": "implemented", "summary": "환불 완료 상태 반영 + 금액/재고 보정"}
+      ]
+    },
+    {
+      "service": "TicketService",
+      "methods": [
+        {"name": "getTicketList", "status": "implemented", "summary": "내 티켓 목록 조회"},
+        {"name": "getTicketDetail", "status": "implemented", "summary": "티켓 상세 조회"},
+        {"name": "createTicket", "status": "implemented", "summary": "주문 항목 수량 기반 티켓 발급"},
+        {"name": "getParticipantList", "status": "implemented", "summary": "판매자 이벤트 참가자 조회"}
+      ]
+    }
+  ]
+}

--- a/docs/service-status.md
+++ b/docs/service-status.md
@@ -1,0 +1,28 @@
+# Commerce 서비스 구현 현황 (메서드 단위)
+
+## CartService
+- `findByUserId`: 사용자 장바구니 존재 여부를 조회합니다.
+- `save`: 이벤트 구매 가능 여부 검증 후 장바구니 아이템을 생성/증가시킵니다.
+- `getCart`: 장바구니와 아이템 목록을 조회해 응답 DTO로 반환합니다.
+- `clearCart`: 장바구니 아이템을 전체 삭제합니다.
+- `updateTicket`: 장바구니 아이템 수량 변경 및 재검증을 수행합니다.
+- `deleteTicket`: 특정 장바구니 아이템을 삭제합니다.
+
+## OrderService
+- `createOrderByCart`: 장바구니 아이템으로 주문 생성, 재고 선차감 및 실패 시 원복을 처리합니다.
+- `getOrderList`: 사용자 주문 목록을 상태/페이지 조건으로 조회합니다.
+- `getOrderDetail`: 주문 상세와 이벤트 제목 정보를 결합해 반환합니다.
+- `cancelOrder`: 결제 전 주문을 취소하고 재고를 복구합니다.
+- `getOrderInfo`: 내부용 주문 단건 정보를 반환합니다.
+- `getOrderListForSettlement`: 정산용 주문 항목 목록을 반환합니다.
+- `completeOrder`: 결제 완료 상태 전이 후 티켓 발급을 수행합니다.
+- `failOrder`: 결제 실패 상태로 주문 상태를 전이합니다.
+- `getSettelmentData`: 판매자/기간 기준 정산 집계 데이터를 계산합니다.
+- `getOrderItemByTicketId`: 티켓 기준 주문 항목 상세를 조회합니다.
+- `completeRefund`: 티켓 환불 완료 처리와 주문 금액/재고 보정을 수행합니다.
+
+## TicketService
+- `getTicketList`: 사용자 티켓 목록을 이벤트 정보와 결합해 페이징 반환합니다.
+- `getTicketDetail`: 티켓 단건과 이벤트 정보를 결합해 상세를 반환합니다.
+- `createTicket`: 주문 항목 수량만큼 티켓을 생성/저장합니다.
+- `getParticipantList`: 판매자 이벤트 참가자 목록을 주문/회원 정보와 조합해 반환합니다.


### PR DESCRIPTION
### Motivation
- Commerce 모듈의 API 엔드포인트, presentation DTO 스펙 및 서비스 구현 현황을 중앙화된 문서로 정리해 온보딩과 인터서비스 연동을 용이하게 하기 위해 작성했습니다.
- 현재 코드베이스에 구현된 Controller/DTO/Service 계약을 빠르게 파악할 수 있는 기초 자료가 필요했습니다.

### Description
- 컨트롤러 매핑을 기반으로 외부/내부 API 목록을 추출해 `docs/api-overview.md` 와 `docs/api-overview.json` 을 추가했습니다.
- `presentation/dto` 하위의 request/response DTO를 스캔해 필드 목록을 포함한 `docs/dto-overview.md` 와 `docs/dto-overview.json` 을 생성했습니다.
- Cart/Order/Ticket 서비스의 메서드별 구현 현황을 한 줄 요약으로 정리해 `docs/service-status.md` 와 `docs/service-status.json` 을 추가했습니다.
- 문서는 Controller 코드와 DTO 선언을 분석해 생성했으며 미구현(주석 처리)된 내부 API 경로는 `notImplemented` 항목으로 표기했습니다.

### Testing
- JSON 유효성 검사를 위해 `python -m json.tool docs/api-overview.json` 를 실행했고 성공했습니다.
- JSON 유효성 검사를 위해 `python -m json.tool docs/dto-overview.json` 를 실행했고 성공했습니다.
- JSON 유효성 검사를 위해 `python -m json.tool docs/service-status.json` 를 실행했고 성공했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e224372c8330a5ad792e150d64d5)