### PR TITLE
[Event] chore: 인프라 설정

### DIFF
--- a/event/build.gradle
+++ b/event/build.gradle
@@ -49,6 +49,10 @@ dependencies {
     annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:7.1:jpa'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
 }
 
 tasks.named('test') {

--- a/event/src/main/resources/application.yml
+++ b/event/src/main/resources/application.yml
@@ -12,3 +12,21 @@ springdoc:
     path: /swagger-ui.html
   api-docs:
     path: /v1/api-docs
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: never
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+
+logging:
+  file:
+    name: ./spring-logs/event/event.log


### PR DESCRIPTION
## 변경 내용
- Event 서비스에 모니터링 인프라 설정 추가

## 변경 사항
- `build.gradle`에 의존성 추가
  - `spring-boot-starter-actuator`
  - `micrometer-registry-prometheus`
  - `loki-logback-appender:1.5.2`
- `application.yml` 설정 추가
  - Actuator endpoints 노출: `health`, `prometheus`
  - Prometheus 메트릭 export 활성화
  - 로그 파일 경로 설정: `./spring-logs/event/event.log`

## 기타 사항
- Prometheus, Grafana, Loki 연동을 위한 사전 설정입니다.
