### PR TITLE
[admin] chore: 인프라 설정

### DIFF
--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -41,6 +41,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
 }
 
 tasks.named('test') {

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -12,3 +12,21 @@ springdoc:
     path: /swagger-ui.html
   api-docs:
     path: /v3/api-docs
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: never
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+
+logging:
+  file:
+    name: ./spring-logs/admin/admin.log


### PR DESCRIPTION
## 변경 내용
- admin서비스에 모니터링 인프라 설정 추가

## 변경 사항
- `build.gradle`에 의존성 추가
  - `spring-boot-starter-actuator`
  - `micrometer-registry-prometheus`
  - `loki-logback-appender:1.5.2`
- `application.yml` 설정 추가
  - Actuator endpoints 노출: `health`, `prometheus`
  - Prometheus 메트릭 export 활성화
  - 로그 파일 경로 설정: `./spring-logs/admin/admin.log`

## 기타 사항
- Prometheus, Grafana, Loki 연동을 위한 사전 설정입니다.
