### PR TITLE
[Gateway] chore: 인프라 설정

### DIFF
--- a/apigateway/build.gradle
+++ b/apigateway/build.gradle
@@ -55,6 +55,10 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webflux-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/apigateway/src/main/resources/application.yml
+++ b/apigateway/src/main/resources/application.yml
@@ -54,11 +54,15 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, prometheus
       base-path: /actuator
   endpoint:
     health:
       show-details: never
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 # Swagger
 springdoc:
@@ -92,4 +96,6 @@ gateway:
         refill-tokens: 10
         refill-duration: 1s
 
-
+logging:
+  file:
+    name: ./spring-logs/gateway/gateway.log


### PR DESCRIPTION
## 변경 내용
- gateway서비스에 모니터링 인프라 설정 추가

## 변경 사항
- `build.gradle`에 의존성 추가
  - `spring-boot-starter-actuator`
  - `micrometer-registry-prometheus`
  - `loki-logback-appender:1.5.2`
- `application.yml` 설정 추가
  - Actuator endpoints 노출: `health`, `prometheus`
  - Prometheus 메트릭 export 활성화
  - 로그 파일 경로 설정: `./spring-logs/gateway/gateway.log`

## 기타 사항
- Prometheus, Grafana, Loki 연동을 위한 사전 설정입니다.
