### PR TITLE
[Settlement] chore: 인프라 설정

### DIFF
--- a/settlement/build.gradle
+++ b/settlement/build.gradle
@@ -36,6 +36,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
 }
 
 tasks.named('test') {

--- a/settlement/src/main/resources/application.yml
+++ b/settlement/src/main/resources/application.yml
@@ -12,3 +12,21 @@ springdoc:
     path: /swagger-ui.html
   api-docs:
     path: /v3/api-docs
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: never
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+
+logging:
+  file:
+    name: ./spring-logs/settlement/settlement.log


### PR DESCRIPTION
## 변경 내용
- settlement서비스에 모니터링 인프라 설정 추가

## 변경 사항
- `build.gradle`에 의존성 추가
  - `spring-boot-starter-actuator`
  - `micrometer-registry-prometheus`
  - `loki-logback-appender:1.5.2`
- `application.yml` 설정 추가
  - Actuator endpoints 노출: `health`, `prometheus`
  - Prometheus 메트릭 export 활성화
  - 로그 파일 경로 설정: `./spring-logs/settlement/settlement.log`

## 기타 사항
- Prometheus, Grafana, Loki 연동을 위한 사전 설정입니다.
