### PR TITLE
[Event] feat: Elasticsearch 기반 이벤트 검색 Document 모델 구현 및 설정

### DIFF
--- a/event/build.gradle
+++ b/event/build.gradle
@@ -53,6 +53,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
+
+    // ES
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
 }
 
 tasks.named('test') {

--- a/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
@@ -1,24 +1,24 @@
 package com.devticket.event.infrastructure.search;
 
-import com.devticket.event.domain.model.Event;
-import com.devticket.event.domain.model.EventImage;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
+import com.devticket.event.domain.model.Event;
+import com.devticket.event.domain.model.EventImage;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Document(indexName = "event")
 public class EventDocument {
 
@@ -64,10 +64,29 @@ public class EventDocument {
     @Field(type = FieldType.Nested)
     private List<TechStackDocument> techStacks;
 
+    @Builder
+    private EventDocument(String id, String title, String description, String location,
+        String category, String status, String sellerId, Integer price,
+        LocalDateTime eventDateTime, LocalDateTime saleStartAt, LocalDateTime saleEndAt,
+        LocalDateTime createdAt, String thumbnailUrl, List<TechStackDocument> techStacks) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.location = location;
+        this.category = category;
+        this.status = status;
+        this.sellerId = sellerId;
+        this.price = price;
+        this.eventDateTime = eventDateTime;
+        this.saleStartAt = saleStartAt;
+        this.saleEndAt = saleEndAt;
+        this.createdAt = createdAt;
+        this.thumbnailUrl = thumbnailUrl;
+        this.techStacks = techStacks;
+    }
+
     @Getter
     @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
     public static class TechStackDocument {
 
         @Field(type = FieldType.Long)
@@ -75,6 +94,12 @@ public class EventDocument {
 
         @Field(type = FieldType.Keyword)
         private String techStackName;
+
+        @Builder
+        private TechStackDocument(Long techStackId, String techStackName) {
+            this.techStackId = techStackId;
+            this.techStackName = techStackName;
+        }
     }
 
     public static EventDocument from(Event event) {

--- a/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
@@ -5,9 +5,10 @@ import com.devticket.event.domain.model.EventImage;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
@@ -15,8 +16,9 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
 @Getter
-@Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Document(indexName = "event")
 public class EventDocument {
 
@@ -63,8 +65,9 @@ public class EventDocument {
     private List<TechStackDocument> techStacks;
 
     @Getter
-    @Setter
     @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     public static class TechStackDocument {
 
         @Field(type = FieldType.Long)
@@ -81,29 +84,27 @@ public class EventDocument {
             .orElse(null);
 
         List<TechStackDocument> techStacks = event.getEventTechStacks().stream()
-            .map(ts -> {
-                TechStackDocument doc = new TechStackDocument();
-                doc.setTechStackId(ts.getTechStackId());
-                doc.setTechStackName(ts.getTechStackName());
-                return doc;
-            })
+            .map(ts -> TechStackDocument.builder()
+                .techStackId(ts.getTechStackId())
+                .techStackName(ts.getTechStackName())
+                .build())
             .toList();
 
-        EventDocument doc = new EventDocument();
-        doc.setId(event.getEventId().toString());
-        doc.setTitle(event.getTitle());
-        doc.setDescription(event.getDescription());
-        doc.setLocation(event.getLocation());
-        doc.setCategory(event.getCategory().name());
-        doc.setStatus(event.getStatus().name());
-        doc.setSellerId(event.getSellerId().toString());
-        doc.setPrice(event.getPrice());
-        doc.setEventDateTime(event.getEventDateTime());
-        doc.setSaleStartAt(event.getSaleStartAt());
-        doc.setSaleEndAt(event.getSaleEndAt());
-        doc.setCreatedAt(event.getCreatedAt());
-        doc.setThumbnailUrl(thumbnail);
-        doc.setTechStacks(techStacks);
-        return doc;
+        return EventDocument.builder()
+            .id(event.getEventId().toString())
+            .title(event.getTitle())
+            .description(event.getDescription())
+            .location(event.getLocation())
+            .category(event.getCategory().name())
+            .status(event.getStatus().name())
+            .sellerId(event.getSellerId().toString())
+            .price(event.getPrice())
+            .eventDateTime(event.getEventDateTime())
+            .saleStartAt(event.getSaleStartAt())
+            .saleEndAt(event.getSaleEndAt())
+            .createdAt(event.getCreatedAt())
+            .thumbnailUrl(thumbnail)
+            .techStacks(techStacks)
+            .build();
     }
 }

--- a/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
@@ -1,0 +1,109 @@
+package com.devticket.event.infrastructure.search;
+
+import com.devticket.event.domain.model.Event;
+import com.devticket.event.domain.model.EventImage;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Document(indexName = "event")
+public class EventDocument {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Text)
+    private String title;
+
+    @Field(type = FieldType.Text)
+    private String description;
+
+    @Field(type = FieldType.Keyword)
+    private String location;
+
+    @Field(type = FieldType.Keyword)
+    private String category;
+
+    @Field(type = FieldType.Keyword)
+    private String status;
+
+    @Field(type = FieldType.Keyword)
+    private String sellerId;
+
+    @Field(type = FieldType.Integer)
+    private Integer price;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+    private LocalDateTime eventDateTime;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+    private LocalDateTime saleStartAt;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+    private LocalDateTime saleEndAt;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+    private LocalDateTime createdAt;
+
+    @Field(type = FieldType.Keyword)
+    private String thumbnailUrl;
+
+    @Field(type = FieldType.Nested)
+    private List<TechStackDocument> techStacks;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class TechStackDocument {
+
+        @Field(type = FieldType.Long)
+        private Long techStackId;
+
+        @Field(type = FieldType.Keyword)
+        private String techStackName;
+    }
+
+    public static EventDocument from(Event event) {
+        String thumbnail = event.getEventImages().stream()
+            .min(Comparator.comparingInt(EventImage::getSortOrder))
+            .map(EventImage::getImageUrl)
+            .orElse(null);
+
+        List<TechStackDocument> techStacks = event.getEventTechStacks().stream()
+            .map(ts -> {
+                TechStackDocument doc = new TechStackDocument();
+                doc.setTechStackId(ts.getTechStackId());
+                doc.setTechStackName(ts.getTechStackName());
+                return doc;
+            })
+            .toList();
+
+        EventDocument doc = new EventDocument();
+        doc.setId(event.getEventId().toString());
+        doc.setTitle(event.getTitle());
+        doc.setDescription(event.getDescription());
+        doc.setLocation(event.getLocation());
+        doc.setCategory(event.getCategory().name());
+        doc.setStatus(event.getStatus().name());
+        doc.setSellerId(event.getSellerId().toString());
+        doc.setPrice(event.getPrice());
+        doc.setEventDateTime(event.getEventDateTime());
+        doc.setSaleStartAt(event.getSaleStartAt());
+        doc.setSaleEndAt(event.getSaleEndAt());
+        doc.setCreatedAt(event.getCreatedAt());
+        doc.setThumbnailUrl(thumbnail);
+        doc.setTechStacks(techStacks);
+        return doc;
+    }
+}

--- a/event/src/main/resources/application-local.yml
+++ b/event/src/main/resources/application-local.yml
@@ -21,6 +21,10 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
+  elasticsearch:
+    uris: http://localhost:9200
+    connection-timeout: 5s
+    socket-timeout: 30s
 
 service:
   member:


### PR DESCRIPTION
## 관련 이슈
- close #336 

## 작업 내용
- `spring-data-elasticsearch` 의존성 추가
- 로컬 환경 ES 연결 설정 추가 (`application-local.yml`)
- 이벤트 검색용 ES Document 모델 생성 (`EventDocument`)
  - 검색 대상 필드: `title`, `description` (Text)
  - 필터 대상 필드: `category`, `status`, `sellerId` (Keyword)
  - 중첩 구조: `techStacks` (Nested)
  - `EventDocument.from(Event)` 정적 팩토리 메서드로 엔티티 → Document 변환

## 변경 사항
- `build.gradle` — ES 의존성 추가
- `application-local.yml` — ES 연결 설정 추가
- `infrastructure/search/EventDocument.java` — 신규 생성

## 참고 사항
- `EventDocument.id`는 ES `_id` 필드 특성상 String 타입 사용 (내부적으로 `eventId` UUID를 String 변환)
- 한글 형태소 분석(nori)은 추후 필요 시 적용 예정
