### PR TITLE
[Payment] Feat/payment deposit

### DIFF
--- a/payment/src/main/java/com/devticket/payment/PaymentApplication.java
+++ b/payment/src/main/java/com/devticket/payment/PaymentApplication.java
@@ -2,8 +2,10 @@ package com.devticket.payment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PaymentApplication {
 
 	public static void main(String[] args) {

--- a/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
@@ -137,6 +137,7 @@ public class PaymentServiceImpl implements PaymentService {
         }
 
         //잔액 차감
+        //TODO : 재시도 로직 추가 OR Atomic Update메서드 사용방식으로 변경하기
         wallet.use(payment.getAmount());
 
         //wallet transaction 생성

--- a/payment/src/main/java/com/devticket/payment/payment/infrastructure/external/PgPaymentClient.java
+++ b/payment/src/main/java/com/devticket/payment/payment/infrastructure/external/PgPaymentClient.java
@@ -10,11 +10,13 @@ import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentCanc
 import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentCancelResponse;
 import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentConfirmRequest;
 import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentConfirmResponse;
+import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentStatusResponse;
 import com.devticket.payment.refund.domain.exception.RefundErrorCode;
 import com.devticket.payment.refund.domain.exception.RefundException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -33,6 +35,7 @@ public class PgPaymentClient {
 
     private static final String CONFIRM_PATH = "/v1/payments/confirm";
     private static final String CANCEL_PATH = "/v1/payments/{paymentKey}/cancel";
+    private static final String STATUS_BY_ORDER_PATH = "/v1/payments/orders/{orderId}";
 
     private final RestClient restClient;
 
@@ -164,6 +167,47 @@ public class PgPaymentClient {
                 e.getResponseBodyAsString()
             );
             throw new PaymentException(PaymentErrorCode.PG_CANCEL_FAILED);
+        }
+    }
+
+    /**
+     * orderId(=chargeId)로 Toss 결제 상태 조회 — 사후 보정 스케줄러용
+     * @return DONE/CANCELED/ABORTED 등 상태가 담긴 응답. 404(Toss 미도달)이면 Optional.empty()
+     */
+    public Optional<TossPaymentStatusResponse> findPaymentByOrderId(String orderId) {
+        try {
+            TossPaymentStatusResponse response = restClient.get()
+                .uri(STATUS_BY_ORDER_PATH, orderId)
+                .retrieve()
+                .onStatus(status -> status == HttpStatus.NOT_FOUND, (req, res) -> {
+                    // Toss에 해당 orderId 결제 없음 → 빈 Optional 반환을 위해 커스텀 예외 사용
+                    throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_REQUEST);
+                })
+                .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+                    throw new PaymentException(PaymentErrorCode.PG_CONFIRM_FAILED);
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+                    throw new PaymentException(PaymentErrorCode.PG_CONFIRM_FAILED);
+                })
+                .body(TossPaymentStatusResponse.class);
+
+            return Optional.ofNullable(response);
+
+        } catch (PaymentException e) {
+            if (e.getErrorCode() == PaymentErrorCode.INVALID_PAYMENT_REQUEST) {
+                // 404 케이스 — Toss에 결제 없음
+                log.warn("[PG] orderId 조회 404 — orderId={}", orderId);
+                return Optional.empty();
+            }
+            throw e;
+
+        } catch (ResourceAccessException e) {
+            log.error("[PG] orderId 조회 타임아웃 — orderId={}, message={}", orderId, e.getMessage());
+            throw new PaymentException(PaymentErrorCode.PG_TIMEOUT);
+
+        } catch (RestClientResponseException e) {
+            log.error("[PG] orderId 조회 실패 — orderId={}, status={}", orderId, e.getStatusCode());
+            throw new PaymentException(PaymentErrorCode.PG_CONFIRM_FAILED);
         }
     }
 

--- a/payment/src/main/java/com/devticket/payment/payment/infrastructure/external/dto/TossPaymentStatusResponse.java
+++ b/payment/src/main/java/com/devticket/payment/payment/infrastructure/external/dto/TossPaymentStatusResponse.java
@@ -1,0 +1,10 @@
+package com.devticket.payment.payment.infrastructure.external.dto;
+
+public record TossPaymentStatusResponse(
+    String paymentKey,
+    String orderId,
+    String status,       // READY | IN_PROGRESS | DONE | CANCELED | ABORTED | EXPIRED 등
+    Integer totalAmount,
+    String approvedAt
+) {
+}

--- a/payment/src/main/java/com/devticket/payment/wallet/application/scheduler/WalletChargeRecoveryScheduler.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/scheduler/WalletChargeRecoveryScheduler.java
@@ -1,0 +1,63 @@
+package com.devticket.payment.wallet.application.scheduler;
+
+import com.devticket.payment.wallet.application.service.WalletService;
+import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * PENDING 상태로 장시간 체류 중인 WalletCharge를 주기적으로 감지하여
+ * Toss 결제 상태를 조회한 뒤 COMPLETED / FAILED 로 보정하는 사후 보정 스케줄러.
+ *
+ * 대상: createdAt 기준 30분 초과 ~ 24시간 이내인 PENDING 건
+ * 원인: 브라우저 종료, 타임아웃, 프론트엔드 런타임 오류 등
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WalletChargeRecoveryScheduler {
+
+    private static final int STALE_THRESHOLD_MINUTES = 30;  // 이 시간 이상 PENDING이면 보정 대상
+    private static final int MAX_RETENTION_HOURS = 24;      // 이 시간 초과 건은 대상에서 제외(별도 처리)
+    private static final int BATCH_SIZE = 100;              // 1회 처리 최대 건수
+
+    private final WalletService walletService;
+    private final WalletChargeRepository walletChargeRepository;
+
+    /**
+     * 10분마다 실행
+     * initialDelay: 서버 기동 직후 즉시 실행 방지.
+     */
+    @Scheduled(fixedDelay = 600_000, initialDelay = 60_000)
+    public void recoverStalePendingCharges() {
+        LocalDateTime before = LocalDateTime.now().minusMinutes(STALE_THRESHOLD_MINUTES);
+        LocalDateTime after = LocalDateTime.now().minusHours(MAX_RETENTION_HOURS);
+
+        // PENDING 상태인 chargeId 목록 반환
+        List<UUID> staleIds = walletChargeRepository.findStalePendingChargeIds(before, after, BATCH_SIZE);
+        if (staleIds.isEmpty()) {
+            return;
+        }
+
+        log.info("[Recovery] 사후 보정 시작 — 대상 {} 건", staleIds.size());
+        int success = 0, skip = 0, fail = 0;
+
+        for (UUID chargeId : staleIds) {
+            try {
+                walletService.recoverStalePendingCharge(chargeId);
+                success++;
+            } catch (Exception e) {
+                // 개별 건 실패는 전체를 멈추지 않음
+                log.error("[Recovery] 처리 중 오류 — chargeId={}, error={}", chargeId, e.getMessage());
+                fail++;
+            }
+        }
+
+        log.info("[Recovery] 사후 보정 완료 — 성공={}, 스킵={}, 실패={}", success, skip, fail);
+    }
+}

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
@@ -29,4 +29,6 @@ public interface WalletService {
     void restoreBalance(UUID userId, int amount, UUID refundId, UUID orderId);
 
     void processBatchRefund(UUID eventId);
+
+    void recoverStalePendingCharge(UUID chargeId);
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
@@ -16,6 +16,8 @@ public interface WalletService {
 
     WalletChargeConfirmResponse confirmCharge(UUID userId, WalletChargeConfirmRequest request);
 
+    void failCharge(UUID userId, String chargeId);
+
     WalletWithdrawResponse withdraw(UUID userId, WalletWithdrawRequest request);
 
     WalletBalanceResponse getBalance(UUID userId);

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -186,7 +186,8 @@ public class WalletServiceImpl implements WalletService {
     @Override
     @Transactional
     public void failCharge(UUID userId, String chargeId) {
-        WalletCharge walletCharge = walletChargeRepository.findByChargeId(parseUUID(chargeId))
+        // 비관적 락: confirmCharge()와 동시 실행 시 상태 역전 방지
+        WalletCharge walletCharge = walletChargeRepository.findByChargeIdForUpdate(parseUUID(chargeId))
             .orElseThrow(() -> new WalletException(WalletErrorCode.CHARGE_NOT_FOUND));
 
         if (!walletCharge.getUserId().equals(userId)) {

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -58,28 +58,41 @@ public class WalletServiceImpl implements WalletService {
     private final CommerceInternalClient commerceInternalClient;
 
     // =====================================================================
-    // 충전 시작
+    // 충전 시작(결제인증에 필요한 WalletCharge생성-chargeId)
     // =====================================================================
 
+    //예치금 충전시 PG사 결제창을 띄우기위한 chargeId와 결제정보 생성.
     @Override
     @Transactional
     public WalletChargeResponse charge(UUID userId, WalletChargeRequest request,
         String idempotencyKey) {
+
+        //멱등성 체크
         Optional<WalletCharge> existing =
             walletChargeRepository.findByUserIdAndIdempotencyKey(userId, idempotencyKey);
         if (existing.isPresent()) {
             return WalletChargeResponse.from(existing.get());
         }
 
-        Wallet wallet = walletRepository.findByUserIdForUpdate(userId)
-            .orElseGet(() -> walletRepository.save(Wallet.create(userId)));
+        //예치금 지갑 조회
+        Wallet wallet = walletRepository.findByUserId(userId)
+            .orElseGet(() -> {
+                    try {
+                        return walletRepository.save(Wallet.create(userId));
+                    } catch (DataIntegrityViolationException e) {
+                        return walletRepository.findByUserId(userId)
+                            .orElseThrow(() -> e);
+                    }
+                });
 
+        //일일 충전 한도 체크
         LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
         int todayTotal = walletChargeRepository.sumTodayChargeAmount(userId, startOfDay);
         if (todayTotal + request.amount() > WalletPolicyConstants.DAILY_CHARGE_LIMIT) {
             throw new WalletException(WalletErrorCode.DAILY_CHARGE_LIMIT_EXCEEDED);
         }
 
+        //WalletCharge생성(PG결제를 위한 chargeId생성됨)
         try {
             WalletCharge walletCharge = WalletCharge.create(
                 wallet.getId(), userId, request.amount(), idempotencyKey);
@@ -96,10 +109,12 @@ public class WalletServiceImpl implements WalletService {
     // 충전 승인
     // =====================================================================
 
+    //PG사 결제창에서 결제인증 완료 후 인증완료된 건에 대한 최종 결제승인 처리진행.
     @Override
     @Transactional
     public WalletChargeConfirmResponse confirmCharge(UUID userId,
         WalletChargeConfirmRequest request) {
+        //WalletCharge : 결제인증된 결제대상의 정보조회
         UUID chargeId = parseUUID(request.chargeId());
         WalletCharge walletCharge = walletChargeRepository.findByChargeId(chargeId)
             .orElseThrow(() -> new WalletException(WalletErrorCode.CHARGE_NOT_FOUND));
@@ -114,6 +129,7 @@ public class WalletServiceImpl implements WalletService {
             throw new WalletException(WalletErrorCode.CHARGE_AMOUNT_MISMATCH);
         }
 
+        //PG사에 최종 결제승인 요청
         PgPaymentConfirmResult pgResult;
         try {
             pgResult = pgPaymentClient.confirm(new PgPaymentConfirmCommand(
@@ -128,12 +144,15 @@ public class WalletServiceImpl implements WalletService {
             );
         }
 
-        Wallet wallet = walletRepository.findByUserIdForUpdate(userId)
+        //Wallet의 잔액에 변경사항 반영(atomic update방식으로 진행)
+        walletCharge.complete(pgResult.paymentKey());
+        walletRepository.chargeBalanceAtomic(userId, walletCharge.getAmount());
+
+        // clearAutomatically = true 로 캐시 초기화됐으므로 최신 잔액을 재조회
+        Wallet wallet = walletRepository.findByUserId(userId)
             .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
 
-        wallet.charge(walletCharge.getAmount());
-        walletCharge.complete(pgResult.paymentKey());
-
+        // WalletTransaction 생성
         String transactionKey = "CHARGE:" + pgResult.paymentKey();
         WalletTransaction walletTransaction = WalletTransaction.createCharge(
             wallet.getId(), userId, transactionKey, walletCharge.getAmount(), wallet.getBalance()
@@ -150,22 +169,48 @@ public class WalletServiceImpl implements WalletService {
     }
 
     // =====================================================================
+    // 충전 실패 처리
+    // =====================================================================
+
+    @Override
+    @Transactional
+    public void failCharge(UUID userId, String chargeId) {
+        WalletCharge walletCharge = walletChargeRepository.findByChargeId(parseUUID(chargeId))
+            .orElseThrow(() -> new WalletException(WalletErrorCode.CHARGE_NOT_FOUND));
+
+        if (!walletCharge.getUserId().equals(userId)) {
+            throw new WalletException(WalletErrorCode.CHARGE_NOT_FOUND);
+        }
+        if (!walletCharge.isPending()) {
+            throw new WalletException(WalletErrorCode.CHARGE_NOT_PENDING);
+        }
+
+        walletCharge.fail();
+        log.info("[WalletCharge] 충전 실패 처리 완료 — chargeId={}", chargeId);
+    }
+
+    // =====================================================================
     // 출금
     // =====================================================================
 
     @Override
     @Transactional
     public WalletWithdrawResponse withdraw(UUID userId, WalletWithdrawRequest request) {
-        Wallet wallet = walletRepository.findByUserIdForUpdate(userId)
-            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
-
-        // 잔액 부족 체크는 Wallet.use() 내부에서도 하지만 WalletException으로 던지기 위해 선행 체크
-        if (wallet.getBalance() < request.amount()) {
+        //atomic update방식으로 balance값 업데이트진행
+        int updated = walletRepository.useBalanceAtomic(userId, request.amount());
+        if (updated == 0) {
+            // 0 rows = 지갑 없음의 경우와  잔액 부족의 경우가 동일한 응답이 반환됨
+            // 지갑 존재 여부로 재구분
+            walletRepository.findByUserId(userId)
+                .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
             throw new WalletException(WalletErrorCode.INSUFFICIENT_BALANCE);
         }
 
-        wallet.use(request.amount()); // Wallet에 withdraw() 없음 — use()로 처리
+        // clearAutomatically = true 로 캐시 초기화됐으므로 최신 잔액을 재조회
+        Wallet wallet = walletRepository.findByUserId(userId)
+            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
 
+        //WalletTransaction 생성
         String transactionKey = "WITHDRAW:" + userId + ":" + UUID.randomUUID();
         WalletTransaction tx = WalletTransaction.createWithdraw(
             wallet.getId(), userId, transactionKey, request.amount(), wallet.getBalance()
@@ -218,20 +263,26 @@ public class WalletServiceImpl implements WalletService {
     public void processWalletPayment(UUID userId, UUID orderId, int amount) {
         String transactionKey = "USE_" + orderId;
 
+        //토스 paymentKey = WalletTransaction의 transactionKey
+        //해당 transactionKey의 유무로 멱등성 체크
         if (walletTransactionRepository.existsByTransactionKey(transactionKey)) {
             log.info("[WalletPayment] 이미 처리된 주문 — orderId={}", orderId);
             return;
         }
 
-        Wallet wallet = walletRepository.findByUserIdForUpdate(userId)
-            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
-
-        if (wallet.getBalance() < amount) {
+        //원자적 업데이트 방식으로 Wallet의 잔액 업데이트
+        int updated = walletRepository.useBalanceAtomic(userId, amount);
+        if (updated == 0) {
+            walletRepository.findByUserId(userId)
+                .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
             throw new WalletException(WalletErrorCode.INSUFFICIENT_BALANCE);
         }
 
-        wallet.use(amount);
+        // clearAutomatically = true 로 캐시 초기화됐으므로 최신 잔액을 재조회
+        Wallet wallet = walletRepository.findByUserId(userId)
+            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
 
+        //WalletTransaction 생성
         WalletTransaction tx = WalletTransaction.createUse(
             wallet.getId(), userId, transactionKey, amount, wallet.getBalance(), orderId
         );
@@ -269,10 +320,15 @@ public class WalletServiceImpl implements WalletService {
             return;
         }
 
-        Wallet wallet = walletRepository.findByUserIdForUpdate(userId)
+        // 지갑이 없으면 생성 후 환불 진행
+        walletRepository.findByUserId(userId)
             .orElseGet(() -> walletRepository.save(Wallet.create(userId)));
 
-        wallet.refund(amount); // Wallet.refund() = balance += amount
+        walletRepository.refundBalanceAtomic(userId, amount);
+
+        // clearAutomatically = true 로 캐시 초기화됐으므로 최신 잔액을 재조회
+        Wallet wallet = walletRepository.findByUserId(userId)
+            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
 
         WalletTransaction tx = WalletTransaction.createRefund(
             wallet.getId(), userId, transactionKey, amount, wallet.getBalance(),

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -4,6 +4,7 @@ import com.devticket.payment.common.messaging.KafkaTopics;
 import com.devticket.payment.common.outbox.OutboxService;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmCommand;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
+import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentStatusResponse;
 import com.devticket.payment.payment.domain.enums.PaymentStatus;
 import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
@@ -114,9 +115,11 @@ public class WalletServiceImpl implements WalletService {
     @Transactional
     public WalletChargeConfirmResponse confirmCharge(UUID userId,
         WalletChargeConfirmRequest request) {
+
         //WalletCharge : 결제인증된 결제대상의 정보조회
+        // 비관적 락: 동시 중복 요청 시 한 건만 진행
         UUID chargeId = parseUUID(request.chargeId());
-        WalletCharge walletCharge = walletChargeRepository.findByChargeId(chargeId)
+        WalletCharge walletCharge = walletChargeRepository.findByChargeIdForUpdate(chargeId)
             .orElseThrow(() -> new WalletException(WalletErrorCode.CHARGE_NOT_FOUND));
 
         if (!walletCharge.getUserId().equals(userId)) {
@@ -137,6 +140,7 @@ public class WalletServiceImpl implements WalletService {
             ));
         } catch (Exception e) {
             log.error("[WalletCharge] PG 승인 실패 — chargeId={}, error={}", chargeId, e.getMessage());
+            //PG결제승인 실패시 기존에 생성된 WalletCharge의 상태값 FAILED로 변경
             walletCharge.fail();
             return WalletChargeConfirmResponse.from(
                 walletCharge.getChargeId().toString(), walletCharge.getAmount(),
@@ -152,8 +156,15 @@ public class WalletServiceImpl implements WalletService {
         Wallet wallet = walletRepository.findByUserId(userId)
             .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
 
-        // WalletTransaction 생성
+        // WalletTransaction 생성 (transactionKey 중복 체크)
         String transactionKey = "CHARGE:" + pgResult.paymentKey();
+        if (walletTransactionRepository.existsByTransactionKey(transactionKey)) {
+            log.warn("[WalletCharge] WalletTransaction 이미 존재 — transactionKey={}", transactionKey);
+            return WalletChargeConfirmResponse.from(
+                walletCharge.getChargeId().toString(), walletCharge.getAmount(),
+                wallet.getBalance(), walletCharge.getStatus().name(), null
+            );
+        }
         WalletTransaction walletTransaction = WalletTransaction.createCharge(
             wallet.getId(), userId, transactionKey, walletCharge.getAmount(), wallet.getBalance()
         );
@@ -399,6 +410,77 @@ public class WalletServiceImpl implements WalletService {
             // log.info("[BatchRefund] 환불 완료 — orderId={}, refundId={}",
             // orderId, refund.getRefundId());
             log.info("[BatchRefund] Refund 모듈 미완성 — 스킵 orderId={}", orderId);
+        }
+    }
+
+    // =====================================================================
+    // 사후 보정 (Self-healing) — 스케줄러에서 개별 건 단위로 호출
+    // =====================================================================
+
+    /**
+     * 스케줄러가 넘겨준 chargeId 한 건을 독립 트랜잭션으로 복구한다.
+     * 비관적 락을 먼저 획득해 분산 환경에서 중복 처리를 방지한다.
+     */
+    @Override
+    @Transactional
+    public void recoverStalePendingCharge(UUID chargeId) {
+        // 비관적 락 획득 — 이미 다른 인스턴스가 처리 중이면 대기 후 isPending() 체크로 조기 종료
+        WalletCharge walletCharge = walletChargeRepository.findByChargeIdForUpdate(chargeId)
+            .orElse(null);
+
+        if (walletCharge == null || !walletCharge.isPending()) {
+            return; // 이미 처리됐거나 찾을 수 없음
+        }
+
+        // Toss에서 실제 결제 상태 조회
+        Optional<TossPaymentStatusResponse> pgStatusOpt;
+        try {
+            pgStatusOpt = pgPaymentClient.findPaymentByOrderId(chargeId.toString());
+        } catch (Exception e) {
+            log.warn("[Recovery] PG 상태 조회 실패 — chargeId={}, 다음 주기에 재시도. error={}",
+                chargeId, e.getMessage());
+            return; // 이번 주기는 스킵, 다음 스케줄에서 재시도
+        }
+
+        if (pgStatusOpt.isEmpty()) {
+            // Toss 404 = 결제 창 진입 전 중단 또는 만료
+            walletCharge.fail();
+            log.info("[Recovery] Toss 미도달(404) — chargeId={} → FAILED", chargeId);
+            return;
+        }
+
+        TossPaymentStatusResponse pgStatus = pgStatusOpt.get();
+
+        if ("DONE".equals(pgStatus.status())) {
+            String transactionKey = "CHARGE:" + pgStatus.paymentKey();
+
+            if (walletTransactionRepository.existsByTransactionKey(transactionKey)) {
+                // WalletTransaction은 이미 생성됐지만 WalletCharge가 미완료 상태인 경우
+                walletCharge.complete(pgStatus.paymentKey());
+                log.info("[Recovery] 거래 기록 중복 확인 — chargeId={} → COMPLETED (잔액 반영 생략)", chargeId);
+                return;
+            }
+
+            // 정상 승인 완료: balance 반영 + WalletTransaction 생성
+            walletCharge.complete(pgStatus.paymentKey());
+            walletRepository.chargeBalanceAtomic(walletCharge.getUserId(), walletCharge.getAmount());
+
+            Wallet wallet = walletRepository.findByUserId(walletCharge.getUserId())
+                .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
+
+            WalletTransaction tx = WalletTransaction.createCharge(
+                wallet.getId(), walletCharge.getUserId(),
+                transactionKey, walletCharge.getAmount(), wallet.getBalance()
+            );
+            walletTransactionRepository.save(tx);
+
+            log.info("[Recovery] PG DONE 감지 — chargeId={}, amount={}, balance={} → COMPLETED",
+                chargeId, walletCharge.getAmount(), wallet.getBalance());
+
+        } else {
+            // CANCELED / ABORTED / EXPIRED / IN_PROGRESS(장시간) 등
+            walletCharge.fail();
+            log.info("[Recovery] PG 상태 '{}' — chargeId={} → FAILED", pgStatus.status(), chargeId);
         }
     }
 

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -75,16 +75,16 @@ public class WalletServiceImpl implements WalletService {
             return WalletChargeResponse.from(existing.get());
         }
 
-        //예치금 지갑 조회
-        Wallet wallet = walletRepository.findByUserId(userId)
-            .orElseGet(() -> {
-                    try {
-                        return walletRepository.save(Wallet.create(userId));
-                    } catch (DataIntegrityViolationException e) {
-                        return walletRepository.findByUserId(userId)
-                            .orElseThrow(() -> e);
-                    }
-                });
+        //예치금 지갑 조회 — 비관적 락으로 한도 체크 구간 직렬화
+        // 동일 사용자의 동시 충전 요청이 같은 todayTotal을 읽고 모두 한도를 통과하는 오류 수정
+        Wallet wallet;
+        try {
+            wallet = walletRepository.findByUserIdForUpdate(userId)
+                .orElseGet(() -> walletRepository.save(Wallet.create(userId)));
+        } catch (DataIntegrityViolationException e) {
+            wallet = walletRepository.findByUserIdForUpdate(userId)
+                .orElseThrow(() -> e);
+        }
 
         //일일 충전 한도 체크
         LocalDateTime startOfDay = LocalDate.now().atStartOfDay();

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/model/Wallet.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/model/Wallet.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -34,6 +35,9 @@ public class Wallet extends BaseEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    @Version
+    private Long version;
 
     /* =======================
         정적 팩토리 메서드

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/repository/WalletChargeRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/repository/WalletChargeRepository.java
@@ -2,6 +2,7 @@ package com.devticket.payment.wallet.domain.repository;
 
 import com.devticket.payment.wallet.domain.model.WalletCharge;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,5 +14,9 @@ public interface WalletChargeRepository {
 
     Optional<WalletCharge> findByChargeId(UUID chargeId);
 
+    Optional<WalletCharge> findByChargeIdForUpdate(UUID chargeId);
+
     int sumTodayChargeAmount(UUID userId, LocalDateTime startOfDay);
+
+    List<UUID> findStalePendingChargeIds(LocalDateTime before, LocalDateTime after, int limit);
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/repository/WalletRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/repository/WalletRepository.java
@@ -11,4 +11,10 @@ public interface WalletRepository {
     Optional<Wallet> findByUserIdForUpdate(UUID userId);
 
     Wallet save(Wallet wallet);
+
+    int chargeBalanceAtomic(UUID userId, int amount);
+
+    int useBalanceAtomic(UUID userId, int amount);
+
+    int refundBalanceAtomic(UUID userId, int amount);
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletChargeJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletChargeJpaRepository.java
@@ -1,10 +1,14 @@
 package com.devticket.payment.wallet.infrastructure.persistence;
 
 import com.devticket.payment.wallet.domain.model.WalletCharge;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,4 +25,20 @@ public interface WalletChargeJpaRepository extends JpaRepository<WalletCharge, L
         + "AND wc.createdAt >= :startOfDay")
     int sumTodayChargeAmount(@Param("userId") UUID userId,
         @Param("startOfDay") LocalDateTime startOfDay);
+
+    // 사후 보정용: 일정 시간 이상 PENDING 상태인 chargeId 목록 조회 (락 없이 ID만)
+    @Query("SELECT wc.chargeId FROM WalletCharge wc "
+        + "WHERE wc.status = com.devticket.payment.wallet.domain.enums.WalletChargeStatus.PENDING "
+        + "AND wc.createdAt < :before "
+        + "AND wc.createdAt >= :after "
+        + "ORDER BY wc.createdAt ASC")
+    List<UUID> findStalePendingChargeIds(
+        @Param("before") LocalDateTime before,
+        @Param("after") LocalDateTime after,
+        Pageable pageable);
+
+    // 사후 보정용: 개별 건 비관적 락 획득 (다른 인스턴스와의 중복 처리 방지)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT wc FROM WalletCharge wc WHERE wc.chargeId = :chargeId")
+    Optional<WalletCharge> findByChargeIdForUpdate(@Param("chargeId") UUID chargeId);
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletChargeRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletChargeRepositoryImpl.java
@@ -3,9 +3,11 @@ package com.devticket.payment.wallet.infrastructure.persistence;
 import com.devticket.payment.wallet.domain.model.WalletCharge;
 import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -32,5 +34,15 @@ public class WalletChargeRepositoryImpl implements WalletChargeRepository {
     @Override
     public int sumTodayChargeAmount(UUID userId, LocalDateTime startOfDay) {
         return walletChargeJpaRepository.sumTodayChargeAmount(userId, startOfDay);
+    }
+
+    @Override
+    public Optional<WalletCharge> findByChargeIdForUpdate(UUID chargeId) {
+        return walletChargeJpaRepository.findByChargeIdForUpdate(chargeId);
+    }
+
+    @Override
+    public List<UUID> findStalePendingChargeIds(LocalDateTime before, LocalDateTime after, int limit) {
+        return walletChargeJpaRepository.findStalePendingChargeIds(before, after, PageRequest.of(0, limit));
     }
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletJpaRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,4 +17,23 @@ public interface WalletJpaRepository extends JpaRepository<Wallet, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT w FROM Wallet w WHERE w.userId = :userId")
     Optional<Wallet> findByUserIdForUpdate(@Param("userId") UUID userId);
+
+    // 충전 (입금)
+    //원자적 업데이트는 JPA의 자동 버전 관리를 타지 않음 -> 수동으로 버전을 올려주기.
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Wallet w SET w.balance = w.balance + :amount, w.version = w.version + 1 " +
+           "WHERE w.userId = :userId")
+    int chargeBalanceAtomic(@Param("userId") UUID userId, @Param("amount") int amount);
+
+    // 사용/출금 (차감) - 잔액 검증 포함
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Wallet w SET w.balance = w.balance - :amount, w.version = w.version + 1 " +
+           "WHERE w.userId = :userId AND w.balance >= :amount")
+    int useBalanceAtomic(@Param("userId") UUID userId, @Param("amount") int amount);
+
+    // 환불 (복구)
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Wallet w SET w.balance = w.balance + :amount, w.version = w.version + 1 " +
+           "WHERE w.userId = :userId")
+    int refundBalanceAtomic(@Param("userId") UUID userId, @Param("amount") int amount);
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletRepositoryImpl.java
@@ -29,4 +29,19 @@ public class WalletRepositoryImpl implements WalletRepository {
     public Wallet save(Wallet wallet) {
         return walletJpaRepository.save(wallet);
     }
+
+    @Override
+    public int chargeBalanceAtomic(UUID userId, int amount) {
+        return walletJpaRepository.chargeBalanceAtomic(userId, amount);
+    }
+
+    @Override
+    public int useBalanceAtomic(UUID userId, int amount) {
+        return walletJpaRepository.useBalanceAtomic(userId, amount);
+    }
+
+    @Override
+    public int refundBalanceAtomic(UUID userId, int amount) {
+        return walletJpaRepository.refundBalanceAtomic(userId, amount);
+    }
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/presentation/controller/WalletController.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/presentation/controller/WalletController.java
@@ -11,16 +11,16 @@ import com.devticket.payment.wallet.presentation.dto.WalletWithdrawRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletWithdrawResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class WalletController {
     private final WalletService walletService;
 
+    //WalletCharge(충전요청서) 생성 : 예치금 충전시 PG결제창 연결을 위한 chargeId생성
     @Operation(summary = "예치금 충전 시작", description = "PG 결제를 통한 예치금 충전을 시작합니다.")
     @ApiResponse(responseCode = "200", description = "예치금 충전 시작 성공")
     @ApiResponse(responseCode = "400", description = "충전 금액이 올바르지 않습니다.")
@@ -44,10 +45,26 @@ public class WalletController {
         @RequestHeader("Idempotency-Key") String idempotencyKey,
         @Valid @RequestBody WalletChargeRequest request) {
 
+        //예치금 충전시 PG사 결제결제인증에 필요한  orderId
         WalletChargeResponse response = walletService.charge(userId, request, idempotencyKey);
         return ResponseEntity.ok(response);
     }
 
+    //WalletCharge 충전 요청 상태를 실패로 처리 (PG 결제창에서 취소/실패 시 클라이언트에서 호출)
+    @Operation(summary = "예치금 충전 실패 처리", description = "PENDING 상태의 충전 요청을 FAILED로 변경합니다.")
+    @ApiResponse(responseCode = "204", description = "충전 실패 처리 성공")
+    @ApiResponse(responseCode = "404", description = "충전 요청을 찾을 수 없습니다.")
+    @ApiResponse(responseCode = "409", description = "대기 상태가 아닌 충전 건입니다.")
+    @PatchMapping("/charge/{chargeId}/fail")
+    public ResponseEntity<Void> failCharge(
+        @RequestHeader("X-User-Id") UUID userId,
+        @PathVariable String chargeId) {
+
+        walletService.failCharge(userId, chargeId);
+        return ResponseEntity.noContent().build();
+    }
+
+    //PG결제인증 완료건에 대해서 최종 결제승인.
     @Operation(summary = "예치금 충전 승인", description = "PG 승인 결과를 바탕으로 예치금 충전을 확정합니다.")
     @ApiResponse(responseCode = "200", description = "예치금 충전 승인 성공")
     @ApiResponse(responseCode = "400", description = "유효하지 않은 승인 요청입니다.")
@@ -97,4 +114,5 @@ public class WalletController {
         WalletWithdrawResponse response = walletService.withdraw(userId, request);
         return ResponseEntity.ok(response);
     }
+
 }

--- a/payment/src/test/java/com/devticket/payment/application/scheduler/WalletChargeRecoverySchedulerTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/scheduler/WalletChargeRecoverySchedulerTest.java
@@ -1,0 +1,140 @@
+package com.devticket.payment.application.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.devticket.payment.wallet.application.scheduler.WalletChargeRecoveryScheduler;
+import com.devticket.payment.wallet.application.service.WalletService;
+import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("사후 보정 스케줄러 (WalletChargeRecoveryScheduler)")
+class WalletChargeRecoverySchedulerTest {
+
+    @Mock private WalletService walletService;
+    @Mock private WalletChargeRepository walletChargeRepository;
+
+    @InjectMocks
+    private WalletChargeRecoveryScheduler scheduler;
+
+    // =====================================================================
+    // 대상 조회
+    // =====================================================================
+
+    @Nested
+    @DisplayName("대상 조회")
+    class FindStaleCharges {
+
+        @Test
+        void 보정_대상_없으면_서비스_호출_없음() {
+            // given
+            given(walletChargeRepository.findStalePendingChargeIds(any(), any(), anyInt()))
+                .willReturn(List.of());
+
+            // when
+            scheduler.recoverStalePendingCharges();
+
+            // then
+            then(walletService).should(never()).recoverStalePendingCharge(any());
+        }
+
+        @Test
+        void 보정_대상_있으면_각_건별_서비스_호출() {
+            // given
+            UUID id1 = UUID.randomUUID();
+            UUID id2 = UUID.randomUUID();
+            UUID id3 = UUID.randomUUID();
+            given(walletChargeRepository.findStalePendingChargeIds(any(), any(), anyInt()))
+                .willReturn(List.of(id1, id2, id3));
+
+            // when
+            scheduler.recoverStalePendingCharges();
+
+            // then: 각 chargeId마다 정확히 1회씩 호출
+            then(walletService).should(times(1)).recoverStalePendingCharge(id1);
+            then(walletService).should(times(1)).recoverStalePendingCharge(id2);
+            then(walletService).should(times(1)).recoverStalePendingCharge(id3);
+        }
+    }
+
+    // =====================================================================
+    // 오류 격리
+    // =====================================================================
+
+    @Nested
+    @DisplayName("오류 격리")
+    class ErrorIsolation {
+
+        @Test
+        void 특정_건_실패해도_나머지_건_계속_처리() {
+            // given: id2 처리 중 예외 발생
+            UUID id1 = UUID.randomUUID();
+            UUID id2 = UUID.randomUUID();
+            UUID id3 = UUID.randomUUID();
+            given(walletChargeRepository.findStalePendingChargeIds(any(), any(), anyInt()))
+                .willReturn(List.of(id1, id2, id3));
+            willThrow(new RuntimeException("PG 오류"))
+                .given(walletService).recoverStalePendingCharge(id2);
+
+            // when: 예외가 스케줄러 밖으로 전파되지 않아야 함
+            scheduler.recoverStalePendingCharges();
+
+            // then: id1, id2, id3 모두 시도됨 (id2는 실패했지만 id3는 계속 처리)
+            then(walletService).should(times(1)).recoverStalePendingCharge(id1);
+            then(walletService).should(times(1)).recoverStalePendingCharge(id2);
+            then(walletService).should(times(1)).recoverStalePendingCharge(id3);
+        }
+
+        @Test
+        void 모든_건_실패해도_스케줄러_예외_미전파() {
+            // given: 전체 실패 케이스
+            UUID id1 = UUID.randomUUID();
+            UUID id2 = UUID.randomUUID();
+            given(walletChargeRepository.findStalePendingChargeIds(any(), any(), anyInt()))
+                .willReturn(List.of(id1, id2));
+            willThrow(new RuntimeException("전체 오류"))
+                .given(walletService).recoverStalePendingCharge(any());
+
+            // when & then: 스케줄러 자체는 예외 없이 정상 종료
+            org.assertj.core.api.Assertions.assertThatCode(scheduler::recoverStalePendingCharges)
+                .doesNotThrowAnyException();
+        }
+    }
+
+    // =====================================================================
+    // 배치 크기 제한
+    // =====================================================================
+
+    @Nested
+    @DisplayName("배치 크기 제한")
+    class BatchLimit {
+
+        @Test
+        void DB_조회시_배치_크기_100_전달() {
+            // given
+            given(walletChargeRepository.findStalePendingChargeIds(any(), any(), anyInt()))
+                .willReturn(List.of());
+
+            // when
+            scheduler.recoverStalePendingCharges();
+
+            // then: limit=100 으로 조회
+            then(walletChargeRepository).should(times(1))
+                .findStalePendingChargeIds(any(), any(), org.mockito.ArgumentMatchers.eq(100));
+        }
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/application/service/PaymentServiceImplTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/PaymentServiceImplTest.java
@@ -59,6 +59,7 @@ public class PaymentServiceImplTest {
     private static final UUID OTHER_USER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
     private static final UUID ORDER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440002");
     private static final UUID EXTERNAL_ORDER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440003");
+    private static final UUID PAYMENT_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440004");
     private static final String PAYMENT_KEY = "toss_pg_key_123";
     private static final String APPROVED_AT = "2024-01-01T00:00:00+09:00";
 
@@ -234,7 +235,7 @@ public class PaymentServiceImplTest {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, PAYMENT_ID, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
@@ -257,7 +258,7 @@ public class PaymentServiceImplTest {
         void 결제_정보_미존재() {
             // given
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, PAYMENT_ID, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.empty());
@@ -277,7 +278,7 @@ public class PaymentServiceImplTest {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, PAYMENT_ID, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
@@ -298,7 +299,7 @@ public class PaymentServiceImplTest {
             Payment payment = createReadyPayment();
             payment.approve(PAYMENT_KEY);
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, PAYMENT_ID, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
@@ -318,7 +319,7 @@ public class PaymentServiceImplTest {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, 99999);
+                PAYMENT_KEY, PAYMENT_ID, EXTERNAL_ORDER_ID, 99999);
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
@@ -338,7 +339,7 @@ public class PaymentServiceImplTest {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, PAYMENT_ID, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
@@ -360,7 +361,7 @@ public class PaymentServiceImplTest {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, PAYMENT_ID, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
@@ -386,7 +387,7 @@ public class PaymentServiceImplTest {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, PAYMENT_ID, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));

--- a/payment/src/test/java/com/devticket/payment/application/service/PaymentServiceImplTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/PaymentServiceImplTest.java
@@ -57,7 +57,8 @@ public class PaymentServiceImplTest {
 
     private static final UUID USER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
     private static final UUID OTHER_USER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
-    private static final String EXTERNAL_ORDER_ID = "order-uuid-123";
+    private static final UUID ORDER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440002");
+    private static final UUID EXTERNAL_ORDER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440003");
     private static final String PAYMENT_KEY = "toss_pg_key_123";
     private static final String APPROVED_AT = "2024-01-01T00:00:00+09:00";
 
@@ -66,7 +67,7 @@ public class PaymentServiceImplTest {
     @BeforeEach
     void setUp() {
         orderInfo = new InternalOrderInfoResponse(
-            123L,
+            ORDER_ID,
             USER_ID,
             "ORD-20250815-001",
             130000,
@@ -82,7 +83,7 @@ public class PaymentServiceImplTest {
     private PgPaymentConfirmResult createPgConfirmResult() {
         return new PgPaymentConfirmResult(
             PAYMENT_KEY,
-            EXTERNAL_ORDER_ID,
+            EXTERNAL_ORDER_ID.toString(),
             "카드",
             "DONE",
             orderInfo.totalAmount(),
@@ -141,7 +142,7 @@ public class PaymentServiceImplTest {
             // given
             PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG);
             InternalOrderInfoResponse paidOrder = new InternalOrderInfoResponse(
-                123L, USER_ID, "ORD-001", 130000, "PAID",
+                ORDER_ID, USER_ID, "ORD-001", 130000, "PAID",
                 LocalDateTime.of(2025, 8, 15, 14, 30).toString()
             );
 
@@ -233,7 +234,7 @@ public class PaymentServiceImplTest {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
@@ -256,7 +257,7 @@ public class PaymentServiceImplTest {
         void 결제_정보_미존재() {
             // given
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.empty());
@@ -276,7 +277,7 @@ public class PaymentServiceImplTest {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
@@ -297,7 +298,7 @@ public class PaymentServiceImplTest {
             Payment payment = createReadyPayment();
             payment.approve(PAYMENT_KEY);
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
@@ -317,7 +318,7 @@ public class PaymentServiceImplTest {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, EXTERNAL_ORDER_ID, 99999);
+                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, 99999);
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
@@ -337,7 +338,7 @@ public class PaymentServiceImplTest {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
@@ -359,7 +360,7 @@ public class PaymentServiceImplTest {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
@@ -385,7 +386,7 @@ public class PaymentServiceImplTest {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+                PAYMENT_KEY, null, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));

--- a/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
@@ -90,7 +90,7 @@ class WalletServiceTest {
             // given
             UUID chargeId = UUID.randomUUID();
             WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(walletCharge));
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
 
             // when
             walletService.failCharge(USER_ID, chargeId.toString());
@@ -103,7 +103,7 @@ class WalletServiceTest {
         void 존재하지_않는_chargeId이면_실패() {
             // given
             UUID chargeId = UUID.randomUUID();
-            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.empty());
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> walletService.failCharge(USER_ID, chargeId.toString()))
@@ -118,7 +118,7 @@ class WalletServiceTest {
             UUID chargeId = UUID.randomUUID();
             UUID otherUserId = UUID.randomUUID();
             WalletCharge walletCharge = pendingCharge(chargeId, otherUserId, 10_000);
-            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(walletCharge));
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
 
             // when & then
             assertThatThrownBy(() -> walletService.failCharge(USER_ID, chargeId.toString()))
@@ -133,7 +133,7 @@ class WalletServiceTest {
             UUID chargeId = UUID.randomUUID();
             WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
             walletCharge.complete("paymentKey-already-done");
-            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(walletCharge));
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
 
             // when & then
             assertThatThrownBy(() -> walletService.failCharge(USER_ID, chargeId.toString()))

--- a/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
@@ -3,6 +3,7 @@ package com.devticket.payment.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -20,9 +21,11 @@ import com.devticket.payment.payment.domain.repository.PaymentRepository;
 import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.wallet.application.service.WalletServiceImpl;
+import com.devticket.payment.wallet.domain.enums.WalletChargeStatus;
 import com.devticket.payment.wallet.domain.exception.WalletErrorCode;
 import com.devticket.payment.wallet.domain.exception.WalletException;
 import com.devticket.payment.wallet.domain.model.Wallet;
+import com.devticket.payment.wallet.domain.model.WalletCharge;
 import com.devticket.payment.wallet.domain.model.WalletTransaction;
 import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
 import com.devticket.payment.wallet.domain.repository.WalletRepository;
@@ -54,21 +57,14 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class WalletServiceTest {
 
-    @Mock
-    private WalletRepository walletRepository;
-    @Mock
-    private WalletTransactionRepository walletTransactionRepository;
-    @Mock
-    private WalletChargeRepository walletChargeRepository;
-    @Mock
-    private PaymentRepository paymentRepository;
+    @Mock private WalletRepository walletRepository;
+    @Mock private WalletTransactionRepository walletTransactionRepository;
+    @Mock private WalletChargeRepository walletChargeRepository;
+    @Mock private PaymentRepository paymentRepository;
     // @Mock private RefundRepository refundRepository; // TODO: Refund 모듈 완성 후 활성화
-    @Mock
-    private PgPaymentClient pgPaymentClient;
-    @Mock
-    private OutboxService outboxService;
-    @Mock
-    private CommerceInternalClient commerceInternalClient;
+    @Mock private PgPaymentClient pgPaymentClient;
+    @Mock private OutboxService outboxService;
+    @Mock private CommerceInternalClient commerceInternalClient;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper()
@@ -81,7 +77,73 @@ class WalletServiceTest {
     private static final UUID USER_ID = UUID.randomUUID();
 
     // =====================================================================
-    // Issue 4: 출금
+    // 충전 실패 처리
+    // =====================================================================
+
+    @Nested
+    @DisplayName("충전 실패 처리 (failCharge)")
+    class FailCharge {
+
+        @Test
+        void 정상_충전_실패_처리() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(walletCharge));
+
+            // when
+            walletService.failCharge(USER_ID, chargeId.toString());
+
+            // then
+            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.FAILED);
+        }
+
+        @Test
+        void 존재하지_않는_chargeId이면_실패() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> walletService.failCharge(USER_ID, chargeId.toString()))
+                .isInstanceOf(WalletException.class)
+                .extracting(e -> ((WalletException) e).getErrorCode())
+                .isEqualTo(WalletErrorCode.CHARGE_NOT_FOUND);
+        }
+
+        @Test
+        void 다른_사용자의_충전_건이면_실패() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            UUID otherUserId = UUID.randomUUID();
+            WalletCharge walletCharge = pendingCharge(chargeId, otherUserId, 10_000);
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(walletCharge));
+
+            // when & then
+            assertThatThrownBy(() -> walletService.failCharge(USER_ID, chargeId.toString()))
+                .isInstanceOf(WalletException.class)
+                .extracting(e -> ((WalletException) e).getErrorCode())
+                .isEqualTo(WalletErrorCode.CHARGE_NOT_FOUND);
+        }
+
+        @Test
+        void PENDING이_아닌_충전_건이면_실패() {
+            // given: 이미 COMPLETED 상태
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
+            walletCharge.complete("paymentKey-already-done");
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(walletCharge));
+
+            // when & then
+            assertThatThrownBy(() -> walletService.failCharge(USER_ID, chargeId.toString()))
+                .isInstanceOf(WalletException.class)
+                .extracting(e -> ((WalletException) e).getErrorCode())
+                .isEqualTo(WalletErrorCode.CHARGE_NOT_PENDING);
+        }
+    }
+
+    // =====================================================================
+    // 출금
     // =====================================================================
 
     @Nested
@@ -90,27 +152,27 @@ class WalletServiceTest {
 
         @Test
         void 정상_출금() {
-            // given
-            Wallet wallet = walletWithBalance(100_000);
-            WalletTransaction tx = WalletTransaction.createWithdraw(
-                1L, USER_ID, "WITHDRAW:key", 30_000, 70_000);
-
-            given(walletRepository.findByUserIdForUpdate(USER_ID)).willReturn(Optional.of(wallet));
-            given(walletTransactionRepository.save(any())).willReturn(tx);
+            // given: atomic update 성공(1 row 업데이트), 재조회 시 차감된 잔액 반환
+            Wallet wallet = walletWithBalance(70_000);
+            given(walletRepository.useBalanceAtomic(USER_ID, 30_000)).willReturn(1);
+            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(wallet));
+            given(walletTransactionRepository.save(any())).willReturn(
+                WalletTransaction.createWithdraw(1L, USER_ID, "WITHDRAW:key", 30_000, 70_000));
 
             // when
             WalletWithdrawResponse response = walletService.withdraw(USER_ID, new WalletWithdrawRequest(30_000));
 
             // then
-            assertThat(wallet.getBalance()).isEqualTo(70_000);
+            assertThat(response).isNotNull();
+            then(walletRepository).should(times(1)).useBalanceAtomic(USER_ID, 30_000);
             then(walletTransactionRepository).should(times(1)).save(any(WalletTransaction.class));
         }
 
         @Test
         void 잔액_부족시_출금_실패() {
-            // given
-            Wallet wallet = walletWithBalance(10_000);
-            given(walletRepository.findByUserIdForUpdate(USER_ID)).willReturn(Optional.of(wallet));
+            // given: atomic update 0 rows(잔액 부족) + 지갑 존재 확인
+            given(walletRepository.useBalanceAtomic(USER_ID, 30_000)).willReturn(0);
+            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(walletWithBalance(10_000)));
 
             // when & then
             assertThatThrownBy(() -> walletService.withdraw(USER_ID, new WalletWithdrawRequest(30_000)))
@@ -123,8 +185,9 @@ class WalletServiceTest {
 
         @Test
         void 지갑이_없으면_출금_실패() {
-            // given
-            given(walletRepository.findByUserIdForUpdate(USER_ID)).willReturn(Optional.empty());
+            // given: atomic update 0 rows + 지갑 자체가 없음
+            given(walletRepository.useBalanceAtomic(USER_ID, 10_000)).willReturn(0);
+            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> walletService.withdraw(USER_ID, new WalletWithdrawRequest(10_000)))
@@ -135,7 +198,7 @@ class WalletServiceTest {
     }
 
     // =====================================================================
-    // Issue 5: 잔액 조회 / 내역 조회
+    // 잔액 조회 / 내역 조회
     // =====================================================================
 
     @Nested
@@ -157,15 +220,18 @@ class WalletServiceTest {
         }
 
         @Test
-        void 지갑이_없으면_잔액_조회_실패() {
-            // given
+        void 지갑이_없으면_신규_생성_후_0원_반환() {
+            // given: 지갑이 없으면 새로 생성하여 0원으로 반환
+            Wallet newWallet = walletWithBalance(0);
             given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
+            given(walletRepository.save(any(Wallet.class))).willReturn(newWallet);
 
-            // when & then
-            assertThatThrownBy(() -> walletService.getBalance(USER_ID))
-                .isInstanceOf(WalletException.class)
-                .extracting(e -> ((WalletException) e).getErrorCode())
-                .isEqualTo(WalletErrorCode.WALLET_NOT_FOUND);
+            // when
+            WalletBalanceResponse response = walletService.getBalance(USER_ID);
+
+            // then
+            assertThat(response.balance()).isEqualTo(0);
+            then(walletRepository).should(times(1)).save(any(Wallet.class));
         }
     }
 
@@ -207,33 +273,33 @@ class WalletServiceTest {
     }
 
     // =====================================================================
-    // Issue 6: 예치금 결제
+    // 예치금 결제
     // =====================================================================
 
     @Nested
     @DisplayName("예치금 결제 (processWalletPayment)")
     class ProcessWalletPayment {
 
-        private static final Long ORDER_ID = 1L;
+        private static final UUID ORDER_ID = UUID.randomUUID();
 
         @Test
         void 정상_예치금_결제() {
-            // given
-            Wallet wallet = walletWithBalance(100_000);
+            // given: atomic update 성공, 재조회 시 차감된 잔액
+            Wallet wallet = walletWithBalance(50_000);
             Payment payment = paymentOf(ORDER_ID, 50_000, PaymentMethod.WALLET, PaymentStatus.READY);
-            WalletTransaction tx = WalletTransaction.createUse(
-                1L, USER_ID, "USE_" + ORDER_ID, 50_000, 50_000, ORDER_ID);
 
             given(walletTransactionRepository.existsByTransactionKey("USE_" + ORDER_ID)).willReturn(false);
-            given(walletRepository.findByUserIdForUpdate(USER_ID)).willReturn(Optional.of(wallet));
-            given(walletTransactionRepository.save(any())).willReturn(tx);
+            given(walletRepository.useBalanceAtomic(USER_ID, 50_000)).willReturn(1);
+            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(wallet));
+            given(walletTransactionRepository.save(any())).willReturn(
+                WalletTransaction.createUse(1L, USER_ID, "USE_" + ORDER_ID, 50_000, 50_000, ORDER_ID));
             given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.of(payment));
 
             // when
             walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000);
 
             // then
-            assertThat(wallet.getBalance()).isEqualTo(50_000);
+            then(walletRepository).should(times(1)).useBalanceAtomic(USER_ID, 50_000);
             then(outboxService).should(times(1)).save(anyString(), anyLong(), eq(KafkaTopics.PAYMENT_COMPLETED), any());
         }
 
@@ -245,18 +311,17 @@ class WalletServiceTest {
             // when
             walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000);
 
-            // then
-            then(walletRepository).should(never()).findByUserIdForUpdate(any());
+            // then: atomic update 및 이벤트 발행 없음
+            then(walletRepository).should(never()).useBalanceAtomic(any(), anyInt());
             then(outboxService).should(never()).save(anyString(), anyLong(), anyString(), any());
         }
 
         @Test
         void 잔액_부족시_결제_실패() {
-            // given
-            Wallet wallet = walletWithBalance(10_000);
-
+            // given: atomic update 0 rows + 지갑 존재
             given(walletTransactionRepository.existsByTransactionKey("USE_" + ORDER_ID)).willReturn(false);
-            given(walletRepository.findByUserIdForUpdate(USER_ID)).willReturn(Optional.of(wallet));
+            given(walletRepository.useBalanceAtomic(USER_ID, 50_000)).willReturn(0);
+            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(walletWithBalance(10_000)));
 
             // when & then
             assertThatThrownBy(() -> walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000))
@@ -269,9 +334,10 @@ class WalletServiceTest {
 
         @Test
         void 지갑이_없으면_결제_실패() {
-            // given
+            // given: atomic update 0 rows + 지갑 없음
             given(walletTransactionRepository.existsByTransactionKey("USE_" + ORDER_ID)).willReturn(false);
-            given(walletRepository.findByUserIdForUpdate(USER_ID)).willReturn(Optional.empty());
+            given(walletRepository.useBalanceAtomic(USER_ID, 50_000)).willReturn(0);
+            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000))
@@ -282,7 +348,7 @@ class WalletServiceTest {
     }
 
     // =====================================================================
-    // Issue 7: 예치금 복구
+    // 예치금 복구
     // =====================================================================
 
     @Nested
@@ -290,25 +356,29 @@ class WalletServiceTest {
     class RestoreBalance {
 
         private static final UUID REFUND_ID = UUID.randomUUID();
-        private static final Long ORDER_ID = 2L;
+        private static final UUID ORDER_ID = UUID.randomUUID();
 
         @Test
         void 정상_예치금_복구() {
             // given
-            Wallet wallet = walletWithBalance(50_000);
             String transactionKey = "REFUND_" + REFUND_ID;
-            WalletTransaction tx = WalletTransaction.createRefund(
-                1L, USER_ID, transactionKey, 30_000, 80_000, ORDER_ID, null);
+            Wallet existingWallet = walletWithBalance(50_000);
+            Wallet updatedWallet = walletWithBalance(80_000);
 
             given(walletTransactionRepository.existsByTransactionKey(transactionKey)).willReturn(false);
-            given(walletRepository.findByUserIdForUpdate(USER_ID)).willReturn(Optional.of(wallet));
-            given(walletTransactionRepository.save(any())).willReturn(tx);
+            // findByUserId: 1번째(존재 확인), 2번째(atomic update 후 최신 잔액 재조회)
+            given(walletRepository.findByUserId(USER_ID))
+                .willReturn(Optional.of(existingWallet))
+                .willReturn(Optional.of(updatedWallet));
+            given(walletRepository.refundBalanceAtomic(USER_ID, 30_000)).willReturn(1);
+            given(walletTransactionRepository.save(any())).willReturn(
+                WalletTransaction.createRefund(1L, USER_ID, transactionKey, 30_000, 80_000, ORDER_ID, null));
 
             // when
             walletService.restoreBalance(USER_ID, 30_000, REFUND_ID, ORDER_ID);
 
             // then
-            assertThat(wallet.getBalance()).isEqualTo(80_000);
+            then(walletRepository).should(times(1)).refundBalanceAtomic(USER_ID, 30_000);
             then(walletTransactionRepository).should(times(1)).save(any(WalletTransaction.class));
         }
 
@@ -321,40 +391,20 @@ class WalletServiceTest {
             // when
             walletService.restoreBalance(USER_ID, 30_000, REFUND_ID, ORDER_ID);
 
-            // then
-            then(walletRepository).should(never()).findByUserIdForUpdate(any());
+            // then: atomic update 없음
+            then(walletRepository).should(never()).refundBalanceAtomic(any(), anyInt());
             then(walletTransactionRepository).should(never()).save(any());
         }
     }
 
     // =====================================================================
-    // Issue 7: 일괄 환불
+    // TODO: 일괄 환불 — Refund 모듈 완성 후 추가
     // =====================================================================
-
-    // TODO: Refund 모듈 완성 후 주석 해제
-    // @Nested
-    // @DisplayName("일괄 환불 (processBatchRefund)")
-    // class ProcessBatchRefund {
-    //
-    //     private static final Long EVENT_ID = 10L;
-    //
-    //     @Test
-    //     void 정상_일괄_환불_WALLET_결제건() { ... }
-    //
-    //     @Test
-    //     void 이미_환불된_주문은_스킵() { ... }
-    //
-    //     @Test
-    //     void 대상_주문이_없으면_아무것도_하지_않음() { ... }
-    // }
 
     // =====================================================================
     // 픽스처 헬퍼
     // =====================================================================
 
-    /**
-     * balance 세팅된 Wallet
-     */
     private Wallet walletWithBalance(int balance) {
         Wallet wallet = Wallet.create(USER_ID);
         ReflectionTestUtils.setField(wallet, "id", 1L);
@@ -362,26 +412,22 @@ class WalletServiceTest {
         return wallet;
     }
 
-    /**
-     * Payment 픽스처 — userId/paymentId는 ReflectionTestUtils로 주입
-     */
-    private Payment paymentOf(Long orderId, int amount, PaymentMethod method, PaymentStatus status) {
+    private WalletCharge pendingCharge(UUID chargeId, UUID userId, int amount) {
+        WalletCharge charge = WalletCharge.create(1L, userId, amount, UUID.randomUUID().toString());
+        ReflectionTestUtils.setField(charge, "chargeId", chargeId);
+        return charge;
+    }
+
+    private Payment paymentOf(UUID orderId, int amount, PaymentMethod method, PaymentStatus status) {
         Payment payment = Payment.create(orderId, USER_ID, method, amount); // 실제 factory 시그니처에 맞게 조정
-        ReflectionTestUtils.setField(payment, "id", orderId);
+        ReflectionTestUtils.setField(payment, "id", 1L);
         ReflectionTestUtils.setField(payment, "paymentId", UUID.randomUUID());
         ReflectionTestUtils.setField(payment, "status", status);
         return payment;
     }
 
-    // TODO: Refund 모듈 완성 후 주석 해제
-    // private Refund refundWithId() {
-    //     Refund refund = Refund.createForBatch(null, 30_000, 100);
-    //     ReflectionTestUtils.setField(refund, "refundId", UUID.randomUUID());
-    //     return refund;
-    // }
-
     private InternalEventOrdersResponse eventOrdersOf(
-        Long eventId, List<InternalEventOrdersResponse.OrderInfo> orders
+        UUID eventId, List<InternalEventOrdersResponse.OrderInfo> orders
     ) {
         InternalEventOrdersResponse res = new InternalEventOrdersResponse();
         ReflectionTestUtils.setField(res, "eventId", eventId);
@@ -390,7 +436,7 @@ class WalletServiceTest {
     }
 
     private InternalEventOrdersResponse.OrderInfo orderInfoOf(
-        Long orderId, String userId, String paymentMethod, int totalAmount, String status
+        UUID orderId, String userId, String paymentMethod, int totalAmount, String status
     ) {
         InternalEventOrdersResponse.OrderInfo info = new InternalEventOrdersResponse.OrderInfo();
         ReflectionTestUtils.setField(info, "orderId", orderId);

--- a/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
@@ -21,6 +21,7 @@ import com.devticket.payment.payment.domain.repository.PaymentRepository;
 import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.wallet.application.service.WalletServiceImpl;
+import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentStatusResponse;
 import com.devticket.payment.wallet.domain.enums.WalletChargeStatus;
 import com.devticket.payment.wallet.domain.exception.WalletErrorCode;
 import com.devticket.payment.wallet.domain.exception.WalletException;
@@ -400,6 +401,160 @@ class WalletServiceTest {
     // =====================================================================
     // TODO: 일괄 환불 — Refund 모듈 완성 후 추가
     // =====================================================================
+
+    // =====================================================================
+    // 사후 보정
+    // =====================================================================
+
+    @Nested
+    @DisplayName("사후 보정 (recoverStalePendingCharge)")
+    class RecoverStalePendingCharge {
+
+        @Test
+        void chargeId_없으면_PG_조회_없이_조기_반환() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.empty());
+
+            // when
+            walletService.recoverStalePendingCharge(chargeId);
+
+            // then: PG 조회 없이 종료
+            then(pgPaymentClient).should(never()).findPaymentByOrderId(any());
+        }
+
+        @Test
+        void 이미_처리된_건은_PG_조회_없이_조기_반환() {
+            // given: COMPLETED 상태
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
+            walletCharge.complete("already-done-key");
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+
+            // when
+            walletService.recoverStalePendingCharge(chargeId);
+
+            // then
+            then(pgPaymentClient).should(never()).findPaymentByOrderId(any());
+        }
+
+        @Test
+        void PG_조회_예외시_상태_변경_없이_스킵() {
+            // given: PG 네트워크 오류 등
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
+                .willThrow(new RuntimeException("PG timeout"));
+
+            // when
+            walletService.recoverStalePendingCharge(chargeId);
+
+            // then: 상태 변경 없음, 다음 주기에 재시도
+            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.PENDING);
+            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
+        }
+
+        @Test
+        void Toss_404_미도달_PENDING_→_FAILED() {
+            // given: Toss에서 해당 orderId 결제 없음 (결제창 진입 전 중단)
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString())).willReturn(Optional.empty());
+
+            // when
+            walletService.recoverStalePendingCharge(chargeId);
+
+            // then
+            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.FAILED);
+            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
+        }
+
+        @Test
+        void PG_DONE_잔액_반영_및_거래기록_생성_후_COMPLETED() {
+            // given: Toss 결제 승인 완료, WalletTransaction 미존재
+            UUID chargeId = UUID.randomUUID();
+            String paymentKey = "pk-recovery-123";
+            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
+            Wallet wallet = walletWithBalance(60_000); // 충전 후 잔액
+
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
+                .willReturn(Optional.of(new TossPaymentStatusResponse(
+                    paymentKey, chargeId.toString(), "DONE", 10_000, "2024-01-01T12:00:00")));
+            given(walletTransactionRepository.existsByTransactionKey("CHARGE:" + paymentKey)).willReturn(false);
+            given(walletRepository.chargeBalanceAtomic(USER_ID, 10_000)).willReturn(1);
+            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(wallet));
+            given(walletTransactionRepository.save(any())).willReturn(
+                WalletTransaction.createCharge(1L, USER_ID, "CHARGE:" + paymentKey, 10_000, 60_000));
+
+            // when
+            walletService.recoverStalePendingCharge(chargeId);
+
+            // then
+            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.COMPLETED);
+            then(walletRepository).should(times(1)).chargeBalanceAtomic(USER_ID, 10_000);
+            then(walletTransactionRepository).should(times(1)).save(any(WalletTransaction.class));
+        }
+
+        @Test
+        void PG_DONE_거래기록_이미_존재_잔액_반영_생략_COMPLETED() {
+            // given: Toss DONE이지만 WalletTransaction이 이미 존재 (부분 실패 후 재시도 케이스)
+            UUID chargeId = UUID.randomUUID();
+            String paymentKey = "pk-already-recorded";
+            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
+
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
+                .willReturn(Optional.of(new TossPaymentStatusResponse(
+                    paymentKey, chargeId.toString(), "DONE", 10_000, "2024-01-01T12:00:00")));
+            given(walletTransactionRepository.existsByTransactionKey("CHARGE:" + paymentKey)).willReturn(true);
+
+            // when
+            walletService.recoverStalePendingCharge(chargeId);
+
+            // then: WalletCharge만 COMPLETED, 잔액 반영 및 거래기록 생성 생략
+            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.COMPLETED);
+            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
+            then(walletTransactionRepository).should(never()).save(any());
+        }
+
+        @Test
+        void PG_CANCELED_PENDING_→_FAILED() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
+                .willReturn(Optional.of(new TossPaymentStatusResponse(
+                    null, chargeId.toString(), "CANCELED", 10_000, null)));
+
+            // when
+            walletService.recoverStalePendingCharge(chargeId);
+
+            // then
+            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.FAILED);
+            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
+        }
+
+        @Test
+        void PG_ABORTED_PENDING_→_FAILED() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
+                .willReturn(Optional.of(new TossPaymentStatusResponse(
+                    null, chargeId.toString(), "ABORTED", 10_000, null)));
+
+            // when
+            walletService.recoverStalePendingCharge(chargeId);
+
+            // then
+            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.FAILED);
+        }
+    }
 
     // =====================================================================
     // 픽스처 헬퍼

--- a/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
@@ -456,7 +456,7 @@ class WalletServiceTest {
         }
 
         @Test
-        void Toss_404_미도달_PENDING_→_FAILED() {
+        void Toss_404_미도달_PENDING_to_FAILED() {
             // given: Toss에서 해당 orderId 결제 없음 (결제창 진입 전 중단)
             UUID chargeId = UUID.randomUUID();
             WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
@@ -521,7 +521,7 @@ class WalletServiceTest {
         }
 
         @Test
-        void PG_CANCELED_PENDING_→_FAILED() {
+        void PG_CANCELED_PENDING_to_FAILED() {
             // given
             UUID chargeId = UUID.randomUUID();
             WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
@@ -539,7 +539,7 @@ class WalletServiceTest {
         }
 
         @Test
-        void PG_ABORTED_PENDING_→_FAILED() {
+        void PG_ABORTED_PENDING_to_FAILED() {
             // given
             UUID chargeId = UUID.randomUUID();
             WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);


### PR DESCRIPTION
## 관련 이슈
- close #349

## 기능 설명
wallet 충전 및 출금에 대한 정합성 적용

**경쟁사례**  :
동일계정으로 여러기기에서 동시접속한 환경에서
예치금 충전/출금, 예치금을 사용한 상품구매/환불, 예치금 잔액 조회의 동시요청

**엔티티** :
Wallet(예치금지갑)
WalletCharge(충전요청서) - 상태값 Pending, Completed, Failed
WalletTransaction(거래기록) - 타입 CHARGE, USE, REFUND, WITHDRAW

**wallet충전 성공흐름** : 
→ front : 예치금 충전요청 
→ back : 예치금 충전요청수신 WalletCharge생성(PG결제창 띄우기위한 chargeId생성)
→ front : 응답데이터 chargeId으로 토스 결제창띄워서 결제인증 절차 진행 
→ front : 토스 결제인증 성공시 반환되는 paymentKey값을 서버에 전달_결제승인 요청하기
→ back : paymentKey로 토스에 결제승인요청 전송 
→ back : 토스 결제승인시 Wallet.balance업데이트
→ back : 토스 결제승인시 WalletTransaction생성

**wallet충전 장애흐름** : ★장애포인트
→ front : 예치금 충전요청 
→ ★ 예치금 충전 중복요청 : WalletCharge테이블의 idempotency_key필드로 멱등성체크
→ back : 예치금 충전요청수신 WalletCharge생성(PG결제창 띄우기위한 chargeId생성)
→ ★  WalletCharge생성 트랜잭션 실패 : 결제실패 응답
→ front : 응답데이터 chargeId으로 토스 결제창띄워서 결제인증 절차 진행 
→ ★  토스 결제인증 실패 : 서버에 WalletCharge상태값 FAILED로 업데이트 요청
→ front : 토스 결제인증 성공시 반환되는 paymentKey값을 서버에 전달_결제승인 요청하기
→ ★ 결제승인 중복요청 : WalletTransaction테이블의 transaction_key필드로 멱등성 체크
→ back : paymentKey로 토스에 결제승인요청 전송 
→ ★ 토스 결제승인 실패시 : WalletCharge상태값 FAILED로 업데이트
→ back : 토스 결제승인시 Wallet.balance업데이트
→ back : 토스 결제승인시 WalletTransaction생성
→ ★ 토스 결제승인시 Wallet.balance업데이트진행시 예치금으로 상품구매/환불과 동시성문제(업데이트 방식을 원자적 업데이트으로 변경)
→ ★'메시지 유실'이나 '프로세스 중단'에 대한 사후 보정(Self-healing) 로직필요
    eg.결제 인증 완료 후, 서버로 승인 요청을 보내기 전 브라우저 종료/앱 강제 종료
    eg.PG승인 요청 후 응답을 받기 직전 타임아웃 또는 서버 재시작
    eg.프론트엔드에서 결제 성공 후 paymentKey를 전송하는 로직에서 런타임 에러 발생

**배치 처리를 통한 사후 정합성 확보 방식**
- 실행 주기 : 매 10분.
- 검토 대상 : 현재 시각 기준 10분 이상 PENDING 상태인 모든  WalletCharge 레코드.
- 처리 절차 :
    1. 외부 PG사 API를 통해 실제 결제 여부 확인.
    2. 결제 완료 건은 즉시 원자적 업데이트(Atomic Update)를 통해 지갑 잔액 반영.
    3. 미결제 건은 유효시간 경과로 간주하여 FAILED처리함으로써 리소스 점유 해제.
  
**Atomic Update방식 체택 이유**
낙관적락 방식으로 처리시 재처리 로직에 spring-retry의존성 추가필요, 
의존성추가 하지 않는 경우 While 루프를 이용한 수동 재시도로직 추가 필요,
의존성 추가 필요없고 구현방식 간단한 Atomic Update방식으로 처리 진행

트랜잭션 A (구매): Wallet 조회 (잔액 10,000, Version 1) - 상품구매 10000원 
트랜잭션 B (충전): Wallet 조회 (잔액 10,000, Version 1) - 충전 5000원 
트랜잭션 B (충전)완료: balance를 15,000으로 바꾸며 Version을 2로 업데이트.
트랜잭션 A (구매)시도: balance를 0으로 바꾸려 함. 
-> Version 1으로 실패로만 처리시 : 예치금 잔액이 충분한데도 구매가 실패함  
-> 구매요청을 @Retryable 으로 재시도 로직 추가필요(spring-retry 의존성추가 필요)
-> Wallet의 balance필드 업데이트로직방식을 Atomic Update(원자적 업데이트) 방식으로 변경

## 변경 사항
- 

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항
API 엔드포인트
- POST /api/wallet/charge : 예치금 충전을 위한 WalletCharge생성_결제인증요청
- POST /api/wallet/charge/confirm : PG결제인증된 건에 대해 결제최종 승인 요청
- PATCH /api/wallet/charge/{chargeId}/fail: 예치금 충전과정에서 실패했을 경우 WalletCharge의 상태값 FAILED로 업데이트
- POST /api/wallet/withdraw : 예치금 출금 요청