### PR TITLE
[Front] fix: 이벤트 검색/필터 API 수정 및 기술 스택 동적 조회 전환

### DIFF
--- a/frontend/src/api/auth.api.ts
+++ b/frontend/src/api/auth.api.ts
@@ -60,4 +60,4 @@ export const getSellerApplicationStatus = () =>
 
 // ── 공통 ──────────────────────────────────────────────────────────────────────
 export const getTechStacks = () =>
-  apiClient.get<ApiResponse<TechStackListResponse>>('/tech-stacks');
+  apiClient.get<TechStackListResponse>('/tech-stacks');

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,6 +6,18 @@ export const apiClient: AxiosInstance = axios.create({
   baseURL: "/api",
   timeout: 10_000,
   headers: { 'Content-Type': 'application/json' },
+  paramsSerializer: (params) => {
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null) continue;
+      if (Array.isArray(value)) {
+        value.forEach((v) => searchParams.append(key, String(v)));
+      } else {
+        searchParams.append(key, String(value));
+      }
+    }
+    return searchParams.toString();
+  },
 });
 
 // ── Request: access token 주입 ──────────────────────────────────────────────

--- a/frontend/src/api/events.api.ts
+++ b/frontend/src/api/events.api.ts
@@ -20,7 +20,6 @@ import type {
   SellerEventParticipantListResponse,
   SellerEventRefundListRequest,
   SellerEventRefundListResponse,
-  TechStackListResponse,
 } from "./types";
 
 // ── 공개 이벤트 ────────────────────────────────────────────────────────────────
@@ -87,6 +86,3 @@ export const getSellerEventRefunds = (
     { params },
   );
 
-// 기술스택 목록 동적 조회
-export const getTechStacks = () =>
-  apiClient.get<TechStackListResponse>("/tech-stacks");

--- a/frontend/src/api/events.api.ts
+++ b/frontend/src/api/events.api.ts
@@ -1,50 +1,73 @@
-import { apiClient, ApiResponse } from './client';
+import { apiClient, ApiResponse } from "./client";
 import type {
-  EventListRequest, EventListResponse,
+  EventListRequest,
+  EventListResponse,
   EventDetailResponse,
-  EventSearchRequest, EventSearchResponse,
-  EventFilterRequest, EventFilterResponse,
-  SellerEventCreateRequest, SellerEventCreateResponse,
-  SellerEventListRequest, SellerEventListResponse,
+  EventSearchRequest,
+  EventSearchResponse,
+  EventFilterRequest,
+  EventFilterResponse,
+  SellerEventCreateRequest,
+  SellerEventCreateResponse,
+  SellerEventListRequest,
+  SellerEventListResponse,
   SellerEventDetailResponse,
-  SellerEventUpdateRequest, SellerEventUpdateResponse,
+  SellerEventUpdateRequest,
+  SellerEventUpdateResponse,
   SellerEventStopResponse,
   SellerEventSummaryResponse,
-  SellerEventParticipantListRequest, SellerEventParticipantListResponse,
-  SellerEventRefundListRequest, SellerEventRefundListResponse,
-} from './types';
+  SellerEventParticipantListRequest,
+  SellerEventParticipantListResponse,
+  SellerEventRefundListRequest,
+  SellerEventRefundListResponse,
+  TechStackListResponse,
+} from "./types";
 
 // ── 공개 이벤트 ────────────────────────────────────────────────────────────────
 export const getEvents = (params?: EventListRequest) =>
-  apiClient.get<ApiResponse<EventListResponse>>('/events', { params });
+  apiClient.get<ApiResponse<EventListResponse>>("/events", { params });
 
 export const getEventDetail = (eventId: string) =>
   apiClient.get<ApiResponse<EventDetailResponse>>(`/events/${eventId}`);
 
 export const searchEvents = (params: EventSearchRequest) =>
-  apiClient.get<ApiResponse<EventSearchResponse>>('/events/search', { params });
+  apiClient.get<ApiResponse<EventSearchResponse>>("/events", { params });
 
 export const filterEvents = (params: EventFilterRequest) =>
-  apiClient.get<ApiResponse<EventFilterResponse>>('/events', { params });
+  apiClient.get<ApiResponse<EventFilterResponse>>("/events", { params });
 
 // ── 판매자 이벤트 ──────────────────────────────────────────────────────────────
 export const createSellerEvent = (body: SellerEventCreateRequest) =>
-    apiClient.post<ApiResponse<SellerEventCreateResponse>>('/events', body);
+  apiClient.post<ApiResponse<SellerEventCreateResponse>>("/events", body);
 
 export const getSellerEvents = (params?: SellerEventListRequest) =>
-  apiClient.get<ApiResponse<SellerEventListResponse>>('/seller/events', { params });
+  apiClient.get<ApiResponse<SellerEventListResponse>>("/seller/events", {
+    params,
+  });
 
 export const getSellerEventDetail = (eventId: string) =>
-  apiClient.get<ApiResponse<SellerEventDetailResponse>>(`/seller/events/${eventId}`);
+  apiClient.get<ApiResponse<SellerEventDetailResponse>>(
+    `/seller/events/${eventId}`,
+  );
 
-export const updateSellerEvent = (eventId: string, body: SellerEventUpdateRequest) =>
-  apiClient.patch<ApiResponse<SellerEventUpdateResponse>>(`/seller/events/${eventId}`, body);
+export const updateSellerEvent = (
+  eventId: string,
+  body: SellerEventUpdateRequest,
+) =>
+  apiClient.patch<ApiResponse<SellerEventUpdateResponse>>(
+    `/seller/events/${eventId}`,
+    body,
+  );
 
 export const stopSellerEvent = (eventId: string) =>
-  apiClient.patch<ApiResponse<SellerEventStopResponse>>(`/seller/events/${eventId}/cancel`);
+  apiClient.patch<ApiResponse<SellerEventStopResponse>>(
+    `/seller/events/${eventId}/cancel`,
+  );
 
 export const getSellerEventSummary = (eventId: string) =>
-  apiClient.get<ApiResponse<SellerEventSummaryResponse>>(`/seller/events/${eventId}/statistics`);
+  apiClient.get<ApiResponse<SellerEventSummaryResponse>>(
+    `/seller/events/${eventId}/statistics`,
+  );
 
 export const getSellerEventParticipants = (
   eventId: string,
@@ -63,3 +86,7 @@ export const getSellerEventRefunds = (
     `/seller/events/${eventId}/refunds`,
     { params },
   );
+
+// 기술스택 목록 동적 조회
+export const getTechStacks = () =>
+  apiClient.get<TechStackListResponse>("/tech-stacks");

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -174,7 +174,7 @@ export type EventSearchResponse = EventListResponse;
 
 export interface EventFilterRequest {
   category?: string;
-  techStacks?: string[];
+  techStacks?: number[];
   page?: number;
   size?: number;
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -11,7 +11,7 @@ export interface SignUpRequest {
 }
 export interface SignUpResponse {
   userId: string;
-  accessToken: string;   // 백엔드에서 가입 즉시 토큰 발급
+  accessToken: string; // 백엔드에서 가입 즉시 토큰 발급
   refreshToken: string;
 }
 
@@ -25,7 +25,7 @@ export interface LoginResponse {
 }
 
 export interface SocialSignUpOrLoginRequest {
-  providerType: string;   // "GOOGLE"
+  providerType: string; // "GOOGLE"
   idToken: string;
 }
 export interface SocialSignUpOrLoginResponse {
@@ -57,7 +57,7 @@ export interface WithdrawResponse {
 export interface SignUpProfileRequest {
   nickname: string;
   position: string;
-  techStackIds: number[];           // Long[] — tech stack은 공개 마스터 데이터라 Long 사용
+  techStackIds: number[]; // Long[] — tech stack은 공개 마스터 데이터라 Long 사용
   profileImageUrl: string | null;
   bio: string | null;
 }
@@ -118,7 +118,7 @@ export interface SellerApplicationListResponse {
 
 export interface SellerApplicationStatusResponse {
   applicationId: string;
-  status: 'PENDING' | 'APPROVED' | 'REJECTED';
+  status: "PENDING" | "APPROVED" | "REJECTED";
   createdAt: string;
   reviewedAt?: string;
   rejectionReason?: string;
@@ -133,7 +133,7 @@ export interface EventItem {
   eventId: string;
   title: string;
   category: string;
-  techStacks: TechStackItem[];
+  techStacks: string[];
   price: number;
   eventDateTime: string;
   remainingQuantity: number;
@@ -174,7 +174,7 @@ export type EventSearchResponse = EventListResponse;
 
 export interface EventFilterRequest {
   category?: string;
-  techStack?: string;
+  techStacks?: string[];
   page?: number;
   size?: number;
 }
@@ -182,18 +182,18 @@ export type EventFilterResponse = EventListResponse;
 
 // ── Seller Events ────────────────────────────────────────────────────────────
 export interface SellerEventCreateRequest {
-  title: string
-  description: string
-  category: string
-  techStackIds: number[]
-  price: number
-  totalQuantity: number
-  maxQuantity: number
-  eventDateTime: string
-  saleStartAt: string
-  saleEndAt: string
-  location: string
-  imageUrls?: string[]
+  title: string;
+  description: string;
+  category: string;
+  techStackIds: number[];
+  price: number;
+  totalQuantity: number;
+  maxQuantity: number;
+  eventDateTime: string;
+  saleStartAt: string;
+  saleEndAt: string;
+  location: string;
+  imageUrls?: string[];
 }
 export interface SellerEventCreateResponse {
   eventId: string;
@@ -314,7 +314,7 @@ export interface SellerEventRefundListResponse {
 
 // 장바구니 아이템 상세 (백엔드 CartItemDetail)
 export interface CartItemDetail {
-  cartItemId: string;   // UUID string
+  cartItemId: string; // UUID string
   eventId: string;
   eventTitle: string;
   price: number;
@@ -323,7 +323,7 @@ export interface CartItemDetail {
 
 // POST /cart/items 요청
 export interface CartItemRequest {
-  eventId: string;      // UUID
+  eventId: string; // UUID
   quantity: number;
 }
 
@@ -343,7 +343,7 @@ export interface CartResponse {
 
 // PATCH /cart/items/{cartItemId} 요청
 export interface CartItemQuantityRequest {
-  quantity: number;     // 증감 delta (+1, -1)
+  quantity: number; // 증감 delta (+1, -1)
 }
 
 // PATCH /cart/items/{cartItemId} 응답 (백엔드 CartItemQuantityResponse)
@@ -443,7 +443,7 @@ export interface TicketDetailResponse {
 // ── Payments ─────────────────────────────────────────────────────────────────
 export interface PaymentRequest {
   orderId: string;
-  paymentMethod: 'PG' | 'WALLET';
+  paymentMethod: "PG" | "WALLET";
 }
 export interface PaymentResponse {
   paymentId: string;
@@ -504,7 +504,7 @@ export interface WalletTransactionListRequest {
 export interface WalletTransactionItem {
   transactionId: string;
   transactionKey: string;
-  type: 'CHARGE' | 'USE' | 'REFUND' | 'WITHDRAW';
+  type: "CHARGE" | "USE" | "REFUND" | "WITHDRAW";
   amount: number;
   balanceAfter: number;
   relatedOrderId?: string;
@@ -699,7 +699,7 @@ export interface AdminUserDetailResponse {
 }
 
 export interface UserStatusRequest {
-  status: 'ACTIVE' | 'SUSPENDED';
+  status: "ACTIVE" | "SUSPENDED";
   reason?: string;
 }
 export interface UserStatusResponse {
@@ -708,7 +708,7 @@ export interface UserStatusResponse {
 }
 
 export interface UserRoleRequest {
-  role: 'USER' | 'SELLER' | 'ADMIN';
+  role: "USER" | "SELLER" | "ADMIN";
 }
 export interface UserRoleResponse {
   userId: string;
@@ -732,7 +732,7 @@ export interface SellerApplicationListResponse {
 
 // ── Tech Stack ────────────────────────────────────────────────────────────────
 export interface TechStackItem {
-  techStackId: number;    // Long PK — 공개 마스터 데이터라 UUID 안 씀
+  techStackId: number; // Long PK — 공개 마스터 데이터라 UUID 안 씀
   name: string;
 }
 export interface TechStackListResponse {

--- a/frontend/src/components/EventCard.tsx
+++ b/frontend/src/components/EventCard.tsx
@@ -1,117 +1,179 @@
-import { Link } from 'react-router-dom'
-import type { EventItem } from '../api/types'
-import { EVENT_STATUS } from '../constants'
-import { formatDateTime, formatPrice } from '../utils'
+import { Link } from "react-router-dom";
+import type { EventItem } from "../api/types";
+import { EVENT_STATUS } from "../constants";
+import { formatDateTime, formatPrice } from "../utils";
 
-const ACCENT_COLORS = ['#4F46E5', '#0EA5E9', '#10B981', '#F59E0B', '#8B5CF6', '#EC4899', '#EF4444']
+const ACCENT_COLORS = [
+  "#4F46E5",
+  "#0EA5E9",
+  "#10B981",
+  "#F59E0B",
+  "#8B5CF6",
+  "#EC4899",
+  "#EF4444",
+];
 
 function accentColor(seed: string) {
-  return ACCENT_COLORS[seed.charCodeAt(0) % ACCENT_COLORS.length]
+  return ACCENT_COLORS[seed.charCodeAt(0) % ACCENT_COLORS.length];
 }
 
 interface Props {
-  event: EventItem
+  event: EventItem;
 }
 
 export default function EventCard({ event }: Props) {
-  const status = EVENT_STATUS[event.status as keyof typeof EVENT_STATUS]
-    ?? { label: event.status, badge: 'badge-gray', color: 'var(--text-3)' }
+  const status = EVENT_STATUS[event.status as keyof typeof EVENT_STATUS] ?? {
+    label: event.status,
+    badge: "badge-gray",
+    color: "var(--text-3)",
+  };
 
-  const color = accentColor(event.eventId)
-  const isFree = event.price === 0
-  const isLowStock = event.status === 'ON_SALE' && event.remainingQuantity < 10
+  const color = accentColor(event.eventId);
+  const isFree = event.price === 0;
+  const isLowStock = event.status === "ON_SALE" && event.remainingQuantity < 10;
 
   return (
-    <Link to={`/events/${event.eventId}`} style={{ display: 'block' }}>
+    <Link to={`/events/${event.eventId}`} style={{ display: "block" }}>
       <article
         style={{
-          background: 'var(--surface)',
-          border: '1px solid var(--border)',
-          borderRadius: 'var(--r-lg)',
-          overflow: 'hidden',
-          transition: 'transform 0.18s ease, box-shadow 0.18s ease',
-          cursor: 'pointer',
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--r-lg)",
+          overflow: "hidden",
+          transition: "transform 0.18s ease, box-shadow 0.18s ease",
+          cursor: "pointer",
         }}
-        onMouseEnter={e => {
-          ;(e.currentTarget as HTMLElement).style.transform = 'translateY(-4px)'
-          ;(e.currentTarget as HTMLElement).style.boxShadow = '0 12px 32px rgba(0,0,0,0.12)'
+        onMouseEnter={(e) => {
+          (e.currentTarget as HTMLElement).style.transform = "translateY(-4px)";
+          (e.currentTarget as HTMLElement).style.boxShadow =
+            "0 12px 32px rgba(0,0,0,0.12)";
         }}
-        onMouseLeave={e => {
-          ;(e.currentTarget as HTMLElement).style.transform = 'translateY(0)'
-          ;(e.currentTarget as HTMLElement).style.boxShadow = ''
+        onMouseLeave={(e) => {
+          (e.currentTarget as HTMLElement).style.transform = "translateY(0)";
+          (e.currentTarget as HTMLElement).style.boxShadow = "";
         }}
       >
         {/* Thumbnail */}
-        <div style={{
-          height: 148, position: 'relative', overflow: 'hidden',
-          background: event.thumbnailUrl
-            ? `url(${event.thumbnailUrl}) center/cover`
-            : `linear-gradient(135deg, ${color}18 0%, ${color}38 100%)`,
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-        }}>
+        <div
+          style={{
+            height: 148,
+            position: "relative",
+            overflow: "hidden",
+            background: event.thumbnailUrl
+              ? `url(${event.thumbnailUrl}) center/cover`
+              : `linear-gradient(135deg, ${color}18 0%, ${color}38 100%)`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
           {!event.thumbnailUrl && (
-            <span style={{
-              fontFamily: 'var(--font-mono)', fontSize: 40,
-              color, opacity: 0.35, userSelect: 'none',
-            }}>{'</>'}</span>
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 40,
+                color,
+                opacity: 0.35,
+                userSelect: "none",
+              }}
+            >
+              {"</>"}
+            </span>
           )}
 
           {/* Status badge */}
-          <div style={{ position: 'absolute', top: 10, left: 10 }}>
+          <div style={{ position: "absolute", top: 10, left: 10 }}>
             <span className={`badge ${status.badge}`}>{status.label}</span>
           </div>
 
           {/* Free badge */}
           {isFree && (
-            <div style={{ position: 'absolute', top: 10, right: 10 }}>
+            <div style={{ position: "absolute", top: 10, right: 10 }}>
               <span className="badge badge-brand">무료</span>
             </div>
           )}
 
           {/* Low stock warning */}
           {isLowStock && (
-            <div style={{
-              position: 'absolute', bottom: 8, left: 10,
-              display: 'flex', alignItems: 'center', gap: 4,
-              padding: '2px 8px', borderRadius: 'var(--r-full)',
-              background: 'rgba(239,68,68,0.9)', color: '#fff',
-              fontSize: 11, fontWeight: 600,
-            }}>
+            <div
+              style={{
+                position: "absolute",
+                bottom: 8,
+                left: 10,
+                display: "flex",
+                alignItems: "center",
+                gap: 4,
+                padding: "2px 8px",
+                borderRadius: "var(--r-full)",
+                background: "rgba(239,68,68,0.9)",
+                color: "#fff",
+                fontSize: 11,
+                fontWeight: 600,
+              }}
+            >
               ⚡ 잔여 {event.remainingQuantity}석
             </div>
           )}
         </div>
 
         {/* Body */}
-        <div style={{ padding: '14px 16px 16px' }}>
+        <div style={{ padding: "14px 16px 16px" }}>
           {/* Category */}
-          <div style={{
-            fontSize: 11, fontWeight: 600, color,
-            fontFamily: 'var(--font-mono)', marginBottom: 5,
-            opacity: 0.85,
-          }}>
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              color,
+              fontFamily: "var(--font-mono)",
+              marginBottom: 5,
+              opacity: 0.85,
+            }}
+          >
             {event.category}
           </div>
 
           {/* Title */}
-          <h3 style={{
-            fontSize: 15, fontWeight: 600, color: 'var(--text)',
-            lineHeight: 1.4, marginBottom: 10,
-            overflow: 'hidden', display: '-webkit-box',
-            WebkitLineClamp: 2, WebkitBoxOrient: 'vertical',
-            minHeight: '2.8em',
-          }}>
+          <h3
+            style={{
+              fontSize: 15,
+              fontWeight: 600,
+              color: "var(--text)",
+              lineHeight: 1.4,
+              marginBottom: 10,
+              overflow: "hidden",
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              minHeight: "2.8em",
+            }}
+          >
             {event.title}
           </h3>
 
           {/* Tech stacks */}
           {event.techStacks?.length > 0 && (
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 12 }}>
-              {event.techStacks.slice(0, 3).map(t => (
-                <span key={t} className="tag" style={{ fontSize: 11, padding: '2px 8px' }}>{t}</span>
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 4,
+                marginBottom: 12,
+              }}
+            >
+              {event.techStacks.slice(0, 3).map((t, i) => (
+                <span
+                  key={i}
+                  className="tag"
+                  style={{ fontSize: 11, padding: "2px 8px" }}
+                >
+                  {t}
+                </span>
               ))}
               {event.techStacks.length > 3 && (
-                <span className="tag" style={{ fontSize: 11, padding: '2px 8px' }}>
+                <span
+                  className="tag"
+                  style={{ fontSize: 11, padding: "2px 8px" }}
+                >
                   +{event.techStacks.length - 3}
                 </span>
               )}
@@ -119,23 +181,31 @@ export default function EventCard({ event }: Props) {
           )}
 
           {/* Meta footer */}
-          <div style={{
-            borderTop: '1px solid var(--border)',
-            paddingTop: 10, marginTop: 'auto',
-            display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-          }}>
-            <div style={{ fontSize: 12, color: 'var(--text-3)' }}>
+          <div
+            style={{
+              borderTop: "1px solid var(--border)",
+              paddingTop: 10,
+              marginTop: "auto",
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <div style={{ fontSize: 12, color: "var(--text-3)" }}>
               📅 {formatDateTime(event.eventDateTime)}
             </div>
-            <div style={{
-              fontSize: 15, fontWeight: 700,
-              color: isFree ? 'var(--success)' : 'var(--text)',
-            }}>
+            <div
+              style={{
+                fontSize: 15,
+                fontWeight: 700,
+                color: isFree ? "var(--success)" : "var(--text)",
+              }}
+            >
               {formatPrice(event.price)}
             </div>
           </div>
         </div>
       </article>
     </Link>
-  )
+  );
 }

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,15 +1,15 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef } from "react";
 
 interface UseApiState<T> {
-  data: T | null
-  loading: boolean
-  error: string | null
+  data: T | null;
+  loading: boolean;
+  error: string | null;
 }
 
 interface UseApiOptions {
-  immediate?: boolean   // mount 시 즉시 실행 (default: true)
-  onSuccess?: (data: any) => void
-  onError?: (err: string) => void
+  immediate?: boolean; // mount 시 즉시 실행 (default: true)
+  onSuccess?: (data: any) => void;
+  onError?: (err: string) => void;
 }
 
 /**
@@ -24,44 +24,51 @@ export function useApi<T>(
   apiFn: () => Promise<{ data: { data: T } }>,
   options: UseApiOptions = {},
 ) {
-  const { immediate = true, onSuccess, onError } = options
-  const [state, setState] = useState<UseApiState<T>>({ data: null, loading: immediate, error: null })
-  const mountedRef = useRef(true)
+  const { immediate = true, onSuccess, onError } = options;
+  const [state, setState] = useState<UseApiState<T>>({
+    data: null,
+    loading: immediate,
+    error: null,
+  });
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    mountedRef.current = true
-    return () => { mountedRef.current = false }
-  }, [])
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const execute = useCallback(async () => {
-    setState(s => ({ ...s, loading: true, error: null }))
+    setState((s) => ({ ...s, loading: true, error: null }));
     try {
-      const res = await apiFn()
-      const data = res.data.data
+      const res = await apiFn();
+      const data = res.data.data;
       if (mountedRef.current) {
-        setState({ data, loading: false, error: null })
-        onSuccess?.(data)
+        setState({ data, loading: false, error: null });
+        onSuccess?.(data);
       }
-      return data
+      return data;
     } catch (err: any) {
-      const message = err?.response?.data?.message ?? err?.message ?? '오류가 발생했습니다'
+      const message =
+        err?.response?.data?.message ?? err?.message ?? "오류가 발생했습니다";
       if (mountedRef.current) {
-        setState(s => ({ ...s, loading: false, error: message }))
-        onError?.(message)
+        setState((s) => ({ ...s, loading: false, error: message }));
+        onError?.(message);
       }
-      throw err
+      throw err;
     }
-  }, [apiFn])
+  }, [apiFn]);
 
   useEffect(() => {
-    if (immediate) execute()
-  }, []) // eslint-disable-line
+    if (immediate) execute();
+  }, []); // eslint-disable-line
 
   const setData = useCallback((updater: (prev: T | null) => T) => {
-    setState(s => ({ ...s, data: updater(s.data) }))
-  }, [])
+    setState((s) => ({ ...s, data: updater(s.data) }));
+  }, []);
 
-  return { ...state, execute, setData }
+  return { ...state, execute, setData };
 }
 
 /**
@@ -73,45 +80,65 @@ export function useApi<T>(
  * )
  */
 export function usePagedApi<T>(
-  apiFn: (page: number) => Promise<{ data: { data: { content: T[]; totalPages: number; totalElements: number } } }>,
+  apiFn: (
+    page: number,
+  ) => Promise<{
+    data: { data: { content: T[]; totalPages: number; totalElements: number } };
+  }>,
   initialPage = 0,
 ) {
-  const [page, setPage] = useState(initialPage)
-  const [items, setItems] = useState<T[]>([])
-  const [totalPages, setTotalPages] = useState(0)
-  const [totalElements, setTotalElements] = useState(0)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const mountedRef = useRef(true)
+  const [page, setPage] = useState(initialPage);
+  const [items, setItems] = useState<T[]>([]);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalElements, setTotalElements] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    mountedRef.current = true
-    return () => { mountedRef.current = false }
-  }, [])
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
-  const fetch = useCallback(async (p: number) => {
-    setLoading(true)
-    setError(null)
-    try {
-      const res = await apiFn(p)
-      const { content, totalPages: tp, totalElements: te } = res.data.data
-      if (mountedRef.current) {
-        setItems(content)
-        setTotalPages(tp)
-        setTotalElements(te)
+  const fetch = useCallback(
+    async (p: number) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await apiFn(p);
+        const { content, totalPages: tp, totalElements: te } = res.data.data;
+        if (mountedRef.current) {
+          setItems(content);
+          setTotalPages(tp);
+          setTotalElements(te);
+        }
+      } catch (err: any) {
+        const msg = err?.response?.data?.message ?? "로드 실패";
+        if (mountedRef.current) setError(msg);
+      } finally {
+        if (mountedRef.current) setLoading(false);
       }
-    } catch (err: any) {
-      const msg = err?.response?.data?.message ?? '로드 실패'
-      if (mountedRef.current) setError(msg)
-    } finally {
-      if (mountedRef.current) setLoading(false)
-    }
-  }, [apiFn])
+    },
+    [apiFn],
+  );
 
-  useEffect(() => { fetch(page) }, [page])
+  useEffect(() => {
+    fetch(page);
+  }, [page, fetch]);
 
-  const changePage = useCallback((p: number) => setPage(p), [])
-  const refresh = useCallback(() => fetch(page), [fetch, page])
+  const changePage = useCallback((p: number) => setPage(p), []);
+  const refresh = useCallback(() => fetch(page), [fetch, page]);
 
-  return { items, page, totalPages, totalElements, loading, error, changePage, refresh }
+  return {
+    items,
+    page,
+    totalPages,
+    totalElements,
+    loading,
+    error,
+    changePage,
+    refresh,
+  };
 }

--- a/frontend/src/pages/EventList.tsx
+++ b/frontend/src/pages/EventList.tsx
@@ -24,7 +24,7 @@ const CATEGORY_MAP: Record<string, string> = {
 export default function EventList() {
   const [keyword, setKeyword] = useState("");
   const [category, setCategory] = useState("전체");
-  const [selectedStack, setSelectedStack] = useState("");
+  const [selectedStackId, setSelectedStackId] = useState<number | null>(null);
   const [techStacks, setTechStacks] = useState<
     { techStackId: number; name: string }[]
   >([]);
@@ -40,17 +40,17 @@ export default function EventList() {
       if (debouncedKeyword) {
         return searchEvents({ keyword: debouncedKeyword, page, size: 12 });
       }
-      if (category !== "전체" || selectedStack) {
+      if (category !== "전체" || selectedStackId) {
         return filterEvents({
           category: category !== "전체" ? CATEGORY_MAP[category] : undefined,
-          techStacks: selectedStack ? [selectedStack] : undefined, // 이름 그대로 전달
+          techStacks: selectedStackId ? [selectedStackId] : undefined,
           page,
           size: 12,
         });
       }
       return getEvents({ page, size: 12 });
     },
-    [debouncedKeyword, category, selectedStack],
+    [debouncedKeyword, category, selectedStackId],
   );
 
   const { items, page, totalPages, totalElements, loading, changePage } =
@@ -59,10 +59,10 @@ export default function EventList() {
   const reset = () => {
     setKeyword("");
     setCategory("전체");
-    setSelectedStack("");
+    setSelectedStackId(null);
   };
 
-  const hasFilter = category !== "전체" || selectedStack || keyword;
+  const hasFilter = category !== "전체" || selectedStackId || keyword;
 
   return (
     <div className="container" style={{ paddingTop: 44, paddingBottom: 72 }}>
@@ -213,31 +213,31 @@ export default function EventList() {
       >
         {techStacks.map((stack) => (
           <button
-            key={stack.techStackId} // stack → stack.techStackId
+            key={stack.techStackId}
             onClick={() => {
-              setSelectedStack((s) => (s === stack.name ? "" : stack.name)); // stack → stack.name
+              setSelectedStackId((id) => (id === stack.techStackId ? null : stack.techStackId));
               changePage(0);
             }}
             className="tag"
             style={{
               cursor: "pointer",
               background:
-                selectedStack === stack.name
+                selectedStackId === stack.techStackId
                   ? "var(--brand-light)"
-                  : "var(--surface-2)", // stack → stack.name
+                  : "var(--surface-2)",
               color:
-                selectedStack === stack.name ? "var(--brand)" : "var(--text-2)",
-              border: `1px solid ${selectedStack === stack.name ? "var(--brand-muted)" : "var(--border)"}`,
+                selectedStackId === stack.techStackId ? "var(--brand)" : "var(--text-2)",
+              border: `1px solid ${selectedStackId === stack.techStackId ? "var(--brand-muted)" : "var(--border)"}`,
               transition: "all 0.12s",
             }}
           >
             {stack.name}
-          </button> // stack → stack.name
+          </button>
         ))}
       </div>
 
       {/* Active filter chips */}
-      {(keyword || selectedStack) && (
+      {(keyword || selectedStackId) && (
         <div
           style={{
             display: "flex",
@@ -254,10 +254,10 @@ export default function EventList() {
               onRemove={() => setKeyword("")}
             />
           )}
-          {selectedStack && (
+          {selectedStackId && (
             <ActiveChip
-              label={selectedStack}
-              onRemove={() => setSelectedStack("")}
+              label={techStacks.find((s) => s.techStackId === selectedStackId)?.name ?? ""}
+              onRemove={() => setSelectedStackId(null)}
             />
           )}
         </div>

--- a/frontend/src/pages/EventList.tsx
+++ b/frontend/src/pages/EventList.tsx
@@ -3,8 +3,8 @@ import {
   getEvents,
   searchEvents,
   filterEvents,
-  getTechStacks,
 } from "../api/events.api";
+import { getTechStacks } from "../api/auth.api";
 import type { EventItem } from "../api/types";
 import EventCard from "../components/EventCard";
 import Pagination from "../components/Pagination";

--- a/frontend/src/pages/EventList.tsx
+++ b/frontend/src/pages/EventList.tsx
@@ -1,135 +1,265 @@
-import { useCallback, useState } from 'react'
-import { getEvents, searchEvents, filterEvents } from '../api/events.api'
-import type { EventItem } from '../api/types'
-import EventCard from '../components/EventCard'
-import Pagination from '../components/Pagination'
-import { usePagedApi } from '../hooks/useApi'
-import { useDebounce } from '../hooks/useDebounce'
+import { useCallback, useState, useEffect } from "react";
+import {
+  getEvents,
+  searchEvents,
+  filterEvents,
+  getTechStacks,
+} from "../api/events.api";
+import type { EventItem } from "../api/types";
+import EventCard from "../components/EventCard";
+import Pagination from "../components/Pagination";
+import { usePagedApi } from "../hooks/useApi";
+import { useDebounce } from "../hooks/useDebounce";
 
-const CATEGORIES = ['전체', '컨퍼런스', '밋업', '해커톤', '스터디', '세미나', '워크샵']
-const TECH_STACKS = [
-  'Java', 'Spring Boot', 'Kotlin', 'JavaScript', 'TypeScript',
-  'React', 'Vue.js', 'Node.js', 'Python', 'FastAPI',
-  'Go', 'Rust', 'Docker', 'Kubernetes', 'AWS',
-]
+const CATEGORIES = ["전체", "컨퍼런스", "밋업", "해커톤", "스터디", "프로젝트"];
+
+const CATEGORY_MAP: Record<string, string> = {
+  컨퍼런스: "CONFERENCE",
+  밋업: "MEETUP",
+  해커톤: "HACKATHON",
+  스터디: "STUDY",
+  프로젝트: "PROJECT",
+};
 
 export default function EventList() {
-  const [keyword, setKeyword] = useState('')
-  const [category, setCategory] = useState('전체')
-  const [selectedStack, setSelectedStack] = useState('')
+  const [keyword, setKeyword] = useState("");
+  const [category, setCategory] = useState("전체");
+  const [selectedStack, setSelectedStack] = useState("");
+  const [techStacks, setTechStacks] = useState<
+    { techStackId: number; name: string }[]
+  >([]);
 
-  const debouncedKeyword = useDebounce(keyword, 350)
+  useEffect(() => {
+    getTechStacks().then((res) => setTechStacks(res.data.techStacks));
+  }, []);
+
+  const debouncedKeyword = useDebounce(keyword, 350);
 
   const apiFn = useCallback(
     (page: number) => {
       if (debouncedKeyword) {
-        return searchEvents({ keyword: debouncedKeyword, page, size: 12 })
+        return searchEvents({ keyword: debouncedKeyword, page, size: 12 });
       }
-      if (category !== '전체' || selectedStack) {
+      if (category !== "전체" || selectedStack) {
         return filterEvents({
-          category: category !== '전체' ? category : undefined,
-          techStack: selectedStack || undefined,
-          page, size: 12,
-        })
+          category: category !== "전체" ? CATEGORY_MAP[category] : undefined,
+          techStacks: selectedStack ? [selectedStack] : undefined, // 이름 그대로 전달
+          page,
+          size: 12,
+        });
       }
-      return getEvents({ page, size: 12 })
+      return getEvents({ page, size: 12 });
     },
     [debouncedKeyword, category, selectedStack],
-  )
+  );
 
-  const { items, page, totalPages, totalElements, loading, changePage } = usePagedApi<EventItem>(apiFn)
+  const { items, page, totalPages, totalElements, loading, changePage } =
+    usePagedApi<EventItem>(apiFn);
 
   const reset = () => {
-    setKeyword('')
-    setCategory('전체')
-    setSelectedStack('')
-  }
+    setKeyword("");
+    setCategory("전체");
+    setSelectedStack("");
+  };
 
-  const hasFilter = category !== '전체' || selectedStack || keyword
+  const hasFilter = category !== "전체" || selectedStack || keyword;
 
   return (
     <div className="container" style={{ paddingTop: 44, paddingBottom: 72 }}>
-
       {/* Hero */}
-      <div style={{ textAlign: 'center', marginBottom: 44 }}>
-        <div style={{
-          display: 'inline-flex', alignItems: 'center', gap: 6,
-          padding: '4px 14px', borderRadius: 'var(--r-full)',
-          background: 'var(--brand-light)', color: 'var(--brand)',
-          fontSize: 12, fontWeight: 600, marginBottom: 16,
-          fontFamily: 'var(--font-mono)', letterSpacing: '0.02em',
-        }}>
+      <div style={{ textAlign: "center", marginBottom: 44 }}>
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "4px 14px",
+            borderRadius: "var(--r-full)",
+            background: "var(--brand-light)",
+            color: "var(--brand)",
+            fontSize: 12,
+            fontWeight: 600,
+            marginBottom: 16,
+            fontFamily: "var(--font-mono)",
+            letterSpacing: "0.02em",
+          }}
+        >
           ✦ 개발자를 위한 이벤트 플랫폼
         </div>
-        <h1 style={{ fontSize: 34, fontWeight: 800, color: 'var(--text)', marginBottom: 10, letterSpacing: '-0.02em' }}>
+        <h1
+          style={{
+            fontSize: 34,
+            fontWeight: 800,
+            color: "var(--text)",
+            marginBottom: 10,
+            letterSpacing: "-0.02em",
+          }}
+        >
           다음 컨퍼런스를 찾아보세요
         </h1>
-        <p style={{ fontSize: 16, color: 'var(--text-3)' }}>
+        <p style={{ fontSize: 16, color: "var(--text-3)" }}>
           {!loading && totalElements > 0
             ? `${totalElements.toLocaleString()}개의 이벤트가 기다리고 있습니다`
-            : '관심 기술 스택의 밋업 · 컨퍼런스를 찾아보세요'}
+            : "관심 기술 스택의 밋업 · 컨퍼런스를 찾아보세요"}
         </p>
       </div>
 
       {/* Search */}
-      <div style={{ display: 'flex', gap: 8, maxWidth: 560, margin: '0 auto 32px' }}>
-        <div className="search-bar" style={{ flex: 1, position: 'relative' }}>
-          <svg className="search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          maxWidth: 560,
+          margin: "0 auto 32px",
+        }}
+      >
+        <div className="search-bar" style={{ flex: 1, position: "relative" }}>
+          <svg
+            className="search-icon"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.35-4.35" />
           </svg>
           <input
             className="search-input"
             placeholder="이벤트명, 기술 스택 검색..."
             value={keyword}
-            onChange={e => { setKeyword(e.target.value); changePage(0) }}
+            onChange={(e) => {
+              setKeyword(e.target.value);
+              changePage(0);
+            }}
           />
           {keyword && (
-            <button onClick={() => { setKeyword(''); changePage(0) }} style={{
-              position: 'absolute', right: 10, top: '50%', transform: 'translateY(-50%)',
-              background: 'none', border: 'none', cursor: 'pointer',
-              color: 'var(--text-4)', fontSize: 16, padding: 4, lineHeight: 1,
-            }}>✕</button>
+            <button
+              onClick={() => {
+                setKeyword("");
+                changePage(0);
+              }}
+              style={{
+                position: "absolute",
+                right: 10,
+                top: "50%",
+                transform: "translateY(-50%)",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                color: "var(--text-4)",
+                fontSize: 16,
+                padding: 4,
+                lineHeight: 1,
+              }}
+            >
+              ✕
+            </button>
           )}
         </div>
         {hasFilter && (
-          <button className="btn btn-secondary" onClick={reset}>초기화</button>
+          <button className="btn btn-secondary" onClick={reset}>
+            초기화
+          </button>
         )}
       </div>
 
       {/* Category chips */}
-      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 10, justifyContent: 'center' }}>
-        {CATEGORIES.map(cat => (
-          <button key={cat} onClick={() => { setCategory(cat); changePage(0) }} style={{
-            padding: '6px 16px', borderRadius: 'var(--r-full)', fontSize: 13,
-            fontWeight: category === cat ? 600 : 400,
-            border: `1.5px solid ${category === cat ? 'var(--brand)' : 'var(--border)'}`,
-            background: category === cat ? 'var(--brand-light)' : 'var(--surface)',
-            color: category === cat ? 'var(--brand)' : 'var(--text-2)',
-            cursor: 'pointer', transition: 'all 0.12s',
-          }}>{cat}</button>
+      <div
+        style={{
+          display: "flex",
+          gap: 6,
+          flexWrap: "wrap",
+          marginBottom: 10,
+          justifyContent: "center",
+        }}
+      >
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => {
+              setCategory(cat);
+              changePage(0);
+            }}
+            style={{
+              padding: "6px 16px",
+              borderRadius: "var(--r-full)",
+              fontSize: 13,
+              fontWeight: category === cat ? 600 : 400,
+              border: `1.5px solid ${category === cat ? "var(--brand)" : "var(--border)"}`,
+              background:
+                category === cat ? "var(--brand-light)" : "var(--surface)",
+              color: category === cat ? "var(--brand)" : "var(--text-2)",
+              cursor: "pointer",
+              transition: "all 0.12s",
+            }}
+          >
+            {cat}
+          </button>
         ))}
       </div>
 
       {/* Tech stack chips */}
-      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', justifyContent: 'center', marginBottom: 36 }}>
-        {TECH_STACKS.map(stack => (
-          <button key={stack} onClick={() => { setSelectedStack(s => s === stack ? '' : stack); changePage(0) }}
-            className="tag" style={{
-              cursor: 'pointer',
-              background: selectedStack === stack ? 'var(--brand-light)' : 'var(--surface-2)',
-              color: selectedStack === stack ? 'var(--brand)' : 'var(--text-2)',
-              border: `1px solid ${selectedStack === stack ? 'var(--brand-muted)' : 'var(--border)'}`,
-              transition: 'all 0.12s',
-            }}>{stack}</button>
+      <div
+        style={{
+          display: "flex",
+          gap: 6,
+          flexWrap: "wrap",
+          justifyContent: "center",
+          marginBottom: 36,
+        }}
+      >
+        {techStacks.map((stack) => (
+          <button
+            key={stack.techStackId} // stack → stack.techStackId
+            onClick={() => {
+              setSelectedStack((s) => (s === stack.name ? "" : stack.name)); // stack → stack.name
+              changePage(0);
+            }}
+            className="tag"
+            style={{
+              cursor: "pointer",
+              background:
+                selectedStack === stack.name
+                  ? "var(--brand-light)"
+                  : "var(--surface-2)", // stack → stack.name
+              color:
+                selectedStack === stack.name ? "var(--brand)" : "var(--text-2)",
+              border: `1px solid ${selectedStack === stack.name ? "var(--brand-muted)" : "var(--border)"}`,
+              transition: "all 0.12s",
+            }}
+          >
+            {stack.name}
+          </button> // stack → stack.name
         ))}
       </div>
 
       {/* Active filter chips */}
       {(keyword || selectedStack) && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 20, flexWrap: 'wrap' }}>
-          <span style={{ fontSize: 13, color: 'var(--text-3)' }}>필터:</span>
-          {keyword && <ActiveChip label={`"${keyword}"`} onRemove={() => setKeyword('')} />}
-          {selectedStack && <ActiveChip label={selectedStack} onRemove={() => setSelectedStack('')} />}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            marginBottom: 20,
+            flexWrap: "wrap",
+          }}
+        >
+          <span style={{ fontSize: 13, color: "var(--text-3)" }}>필터:</span>
+          {keyword && (
+            <ActiveChip
+              label={`"${keyword}"`}
+              onRemove={() => setKeyword("")}
+            />
+          )}
+          {selectedStack && (
+            <ActiveChip
+              label={selectedStack}
+              onRemove={() => setSelectedStack("")}
+            />
+          )}
         </div>
       )}
 
@@ -141,65 +271,143 @@ export default function EventList() {
           <div className="empty-icon">🔍</div>
           <div className="empty-title">이벤트가 없습니다</div>
           <div className="empty-desc">다른 조건으로 검색해보세요</div>
-          <button className="btn btn-secondary" style={{ marginTop: 8 }} onClick={reset}>전체 보기</button>
+          <button
+            className="btn btn-secondary"
+            style={{ marginTop: 8 }}
+            onClick={reset}
+          >
+            전체 보기
+          </button>
         </div>
       ) : (
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
-          gap: 20,
-        }}>
-          {items.map(event => <EventCard key={event.eventId} event={event} />)}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+            gap: 20,
+          }}
+        >
+          {items.map((event) => (
+            <EventCard key={event.eventId} event={event} />
+          ))}
         </div>
       )}
 
       <Pagination page={page} totalPages={totalPages} onChange={changePage} />
     </div>
-  )
+  );
 }
 
-function ActiveChip({ label, onRemove }: { label: string; onRemove: () => void }) {
+function ActiveChip({
+  label,
+  onRemove,
+}: {
+  label: string;
+  onRemove: () => void;
+}) {
   return (
-    <span style={{
-      display: 'inline-flex', alignItems: 'center', gap: 6,
-      padding: '3px 10px', background: 'var(--brand-light)',
-      color: 'var(--brand)', borderRadius: 'var(--r-full)',
-      fontSize: 13, fontWeight: 500,
-    }}>
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        padding: "3px 10px",
+        background: "var(--brand-light)",
+        color: "var(--brand)",
+        borderRadius: "var(--r-full)",
+        fontSize: 13,
+        fontWeight: 500,
+      }}
+    >
       {label}
-      <button onClick={onRemove} style={{
-        background: 'none', border: 'none', cursor: 'pointer',
-        color: 'var(--brand)', lineHeight: 1, padding: 0, fontSize: 14,
-      }}>✕</button>
+      <button
+        onClick={onRemove}
+        style={{
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          color: "var(--brand)",
+          lineHeight: 1,
+          padding: 0,
+          fontSize: 14,
+        }}
+      >
+        ✕
+      </button>
     </span>
-  )
+  );
 }
 
 function SkeletonGrid() {
   return (
     <>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 20 }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+          gap: 20,
+        }}
+      >
         {Array.from({ length: 8 }).map((_, i) => (
-          <div key={i} style={{
-            height: 280, borderRadius: 'var(--r-lg)',
-            background: 'var(--surface)', border: '1px solid var(--border)',
-            overflow: 'hidden', position: 'relative',
-          }}>
-            <div style={{ height: 140, background: 'var(--surface-2)' }} />
-            <div style={{ padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 10 }}>
-              <div style={{ height: 10, width: '40%', background: 'var(--surface-3)', borderRadius: 4 }} />
-              <div style={{ height: 14, width: '85%', background: 'var(--surface-3)', borderRadius: 4 }} />
-              <div style={{ height: 14, width: '65%', background: 'var(--surface-3)', borderRadius: 4 }} />
+          <div
+            key={i}
+            style={{
+              height: 280,
+              borderRadius: "var(--r-lg)",
+              background: "var(--surface)",
+              border: "1px solid var(--border)",
+              overflow: "hidden",
+              position: "relative",
+            }}
+          >
+            <div style={{ height: 140, background: "var(--surface-2)" }} />
+            <div
+              style={{
+                padding: "14px 16px",
+                display: "flex",
+                flexDirection: "column",
+                gap: 10,
+              }}
+            >
+              <div
+                style={{
+                  height: 10,
+                  width: "40%",
+                  background: "var(--surface-3)",
+                  borderRadius: 4,
+                }}
+              />
+              <div
+                style={{
+                  height: 14,
+                  width: "85%",
+                  background: "var(--surface-3)",
+                  borderRadius: 4,
+                }}
+              />
+              <div
+                style={{
+                  height: 14,
+                  width: "65%",
+                  background: "var(--surface-3)",
+                  borderRadius: 4,
+                }}
+              />
             </div>
-            <div style={{
-              position: 'absolute', inset: 0,
-              background: 'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.5) 50%, transparent 100%)',
-              backgroundSize: '200% 100%', animation: 'shimmer 1.5s infinite',
-            }} />
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                background:
+                  "linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.5) 50%, transparent 100%)",
+                backgroundSize: "200% 100%",
+                animation: "shimmer 1.5s infinite",
+              }}
+            />
           </div>
         ))}
       </div>
       <style>{`@keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }`}</style>
     </>
-  )
+  );
 }

--- a/frontend/src/pages/seller/SellerEventCreate.tsx
+++ b/frontend/src/pages/seller/SellerEventCreate.tsx
@@ -4,8 +4,8 @@ import {
   createSellerEvent,
   getSellerEventDetail,
   updateSellerEvent,
-  getTechStacks,
 } from "../../api/events.api";
+import { getTechStacks } from "../../api/auth.api";
 import { useToast } from "../../contexts/ToastContext";
 
 const CATEGORIES = [

--- a/frontend/src/pages/seller/SellerEventCreate.tsx
+++ b/frontend/src/pages/seller/SellerEventCreate.tsx
@@ -1,241 +1,411 @@
-import { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
-import { createSellerEvent, getSellerEventDetail, updateSellerEvent } from '../../api/events.api'
-import { useToast } from '../../contexts/ToastContext'
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  createSellerEvent,
+  getSellerEventDetail,
+  updateSellerEvent,
+  getTechStacks,
+} from "../../api/events.api";
+import { useToast } from "../../contexts/ToastContext";
 
 const CATEGORIES = [
-  { value: 'CONFERENCE', label: '컨퍼런스' },
-  { value: 'MEETUP', label: '밋업' },
-]
-const TECH_STACKS = ['Java', 'Spring Boot', 'Kotlin', 'JavaScript', 'TypeScript', 'React', 'Vue.js', 'Node.js', 'Python', 'FastAPI', 'Go', 'Rust', 'Docker', 'Kubernetes', 'AWS', 'MySQL', 'PostgreSQL', 'Redis', 'Kafka']
-const TECH_STACK_MAP: Record<string, number> = {
-  'Java': 1, 'Spring Boot': 2, 'Kotlin': 3, 'JavaScript': 4, 'TypeScript': 5,
-  'React': 6, 'Vue.js': 7, 'Node.js': 8, 'Python': 9, 'FastAPI': 10,
-  'Go': 11, 'Rust': 12, 'Docker': 13, 'Kubernetes': 14, 'AWS': 15,
-  'MySQL': 16, 'PostgreSQL': 17, 'Redis': 18, 'Kafka': 19,
-}
+  { value: "CONFERENCE", label: "컨퍼런스" },
+  { value: "MEETUP", label: "밋업" },
+  { value: "HACKATHON", label: "해커톤" },
+  { value: "STUDY", label: "스터디" },
+  { value: "PROJECT", label: "프로젝트" },
+];
 
 interface EventForm {
-  title: string
-  description: string
-  category: string
-  techStacks: string[]
-  price: string
-  totalQuantity: string
-  maxQuantityPerUser: string
-  eventDateTime: string
-  saleStartAt: string
-  saleEndAt: string
-  location: string
-  imageUrls: string
+  title: string;
+  description: string;
+  category: string;
+  techStacks: string[];
+  price: string;
+  totalQuantity: string;
+  maxQuantityPerUser: string;
+  eventDateTime: string;
+  saleStartAt: string;
+  saleEndAt: string;
+  location: string;
+  imageUrls: string;
 }
 
 const EMPTY_FORM: EventForm = {
-  title: '', description: '', category: '',
-  techStacks: [], price: '', totalQuantity: '',
-  maxQuantityPerUser: '1', eventDateTime: '',
-  saleStartAt: '', saleEndAt: '', location: '', imageUrls: '',
-}
+  title: "",
+  description: "",
+  category: "",
+  techStacks: [],
+  price: "",
+  totalQuantity: "",
+  maxQuantityPerUser: "1",
+  eventDateTime: "",
+  saleStartAt: "",
+  saleEndAt: "",
+  location: "",
+  imageUrls: "",
+};
 
-function EventForm({ initialData, onSubmit, submitLabel }: {
-  initialData: EventForm
-  onSubmit: (data: EventForm) => Promise<void>
-  submitLabel: string
+function EventForm({
+  initialData,
+  onSubmit,
+  submitLabel,
+  techStackOptions,
+}: {
+  initialData: EventForm;
+  onSubmit: (data: EventForm) => Promise<void>;
+  submitLabel: string;
+  techStackOptions: { techStackId: number; name: string }[];
 }) {
-  const [form, setForm] = useState<EventForm>(initialData)
-  const [errors, setErrors] = useState<Record<string, string>>({})
-  const [loading, setLoading] = useState(false)
+  const [form, setForm] = useState<EventForm>(initialData);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
 
   const toggleStack = (s: string) =>
-      setForm(f => ({
-        ...f,
-        techStacks: f.techStacks.includes(s) ? f.techStacks.filter(t => t !== s) : [...f.techStacks, s],
-      }))
+    setForm((f) => ({
+      ...f,
+      techStacks: f.techStacks.includes(s)
+        ? f.techStacks.filter((t) => t !== s)
+        : [...f.techStacks, s],
+    }));
 
   const validate = () => {
-    const e: Record<string, string> = {}
-    if (!form.title) e.title = '이벤트명을 입력하세요'
-    if (!form.category) e.category = '카테고리를 선택하세요'
-    if (!form.description) e.description = '상세 설명을 입력하세요'
-    if (!form.eventDateTime) e.eventDateTime = '행사 일시를 선택하세요'
-    if (!form.saleStartAt) e.saleStartAt = '판매 시작일을 선택하세요'
-    if (!form.saleEndAt) e.saleEndAt = '판매 종료일을 선택하세요'
-    if (!form.location) e.location = '장소를 입력하세요'
-    if (!form.totalQuantity || parseInt(form.totalQuantity) < 5) e.totalQuantity = '수량을 5명 이상 입력하세요'
-    if (form.techStacks.length === 0) e.techStacks = '기술 스택을 1개 이상 선택하세요'
+    const e: Record<string, string> = {};
+    if (!form.title) e.title = "이벤트명을 입력하세요";
+    if (!form.category) e.category = "카테고리를 선택하세요";
+    if (!form.description) e.description = "상세 설명을 입력하세요";
+    if (!form.eventDateTime) e.eventDateTime = "행사 일시를 선택하세요";
+    if (!form.saleStartAt) e.saleStartAt = "판매 시작일을 선택하세요";
+    if (!form.saleEndAt) e.saleEndAt = "판매 종료일을 선택하세요";
+    if (!form.location) e.location = "장소를 입력하세요";
+    if (!form.totalQuantity || parseInt(form.totalQuantity) < 5)
+      e.totalQuantity = "수량을 5명 이상 입력하세요";
+    if (form.techStacks.length === 0)
+      e.techStacks = "기술 스택을 1개 이상 선택하세요";
     if (form.saleStartAt && form.saleEndAt) {
       if (new Date(form.saleStartAt) >= new Date(form.saleEndAt))
-        e.saleEndAt = '판매 종료일은 판매 시작일 이후여야 합니다'
+        e.saleEndAt = "판매 종료일은 판매 시작일 이후여야 합니다";
     }
     if (form.saleEndAt && form.eventDateTime) {
       if (new Date(form.saleEndAt) >= new Date(form.eventDateTime))
-        e.saleEndAt = '판매 종료일은 행사 일시 이전이어야 합니다'
+        e.saleEndAt = "판매 종료일은 행사 일시 이전이어야 합니다";
     }
     if (form.saleStartAt) {
-      const minStart = new Date()
-      minStart.setDate(minStart.getDate() + 3)
+      const minStart = new Date();
+      minStart.setDate(minStart.getDate() + 3);
       if (new Date(form.saleStartAt) < minStart)
-        e.saleStartAt = '판매 시작일은 오늘로부터 3일 이후여야 합니다'
+        e.saleStartAt = "판매 시작일은 오늘로부터 3일 이후여야 합니다";
     }
 
-    setErrors(e)
-    return Object.keys(e).length === 0
-    setErrors(e)
-    return Object.keys(e).length === 0
-  }
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!validate()) return
-    setLoading(true)
+    e.preventDefault();
+    if (!validate()) return;
+    setLoading(true);
     try {
-      await onSubmit(form)
+      await onSubmit(form);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
   return (
-      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
-        {/* 기본 정보 */}
-        <Section title="기본 정보">
+    <form
+      onSubmit={handleSubmit}
+      style={{ display: "flex", flexDirection: "column", gap: 20 }}
+    >
+      {/* 기본 정보 */}
+      <Section title="기본 정보">
+        <div className="form-group">
+          <label className="form-label">이벤트명 *</label>
+          <input
+            className="form-input"
+            placeholder="Spring Boot 심화 밋업"
+            value={form.title}
+            onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+            style={errors.title ? { borderColor: "var(--danger)" } : {}}
+          />
+          {errors.title && <span className="form-error">{errors.title}</span>}
+        </div>
+
+        <div
+          style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}
+        >
           <div className="form-group">
-            <label className="form-label">이벤트명 *</label>
-            <input className="form-input" placeholder="Spring Boot 심화 밋업"
-                   value={form.title} onChange={e => setForm(f => ({ ...f, title: e.target.value }))}
-                   style={errors.title ? { borderColor: 'var(--danger)' } : {}} />
-            {errors.title && <span className="form-error">{errors.title}</span>}
+            <label className="form-label">카테고리 *</label>
+            <select
+              className="form-input form-select"
+              value={form.category}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, category: e.target.value }))
+              }
+              style={errors.category ? { borderColor: "var(--danger)" } : {}}
+            >
+              <option value="">선택</option>
+              {CATEGORIES.map((c) => (
+                <option key={c.value} value={c.value}>
+                  {c.label}
+                </option>
+              ))}
+            </select>
+            {errors.category && (
+              <span className="form-error">{errors.category}</span>
+            )}
           </div>
-
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
-            <div className="form-group">
-              <label className="form-label">카테고리 *</label>
-              <select className="form-input form-select" value={form.category}
-                      onChange={e => setForm(f => ({ ...f, category: e.target.value }))}
-                      style={errors.category ? { borderColor: 'var(--danger)' } : {}}>
-                <option value="">선택</option>
-                {CATEGORIES.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
-              </select>
-              {errors.category && <span className="form-error">{errors.category}</span>}
-            </div>
-            <div className="form-group">
-              <label className="form-label">장소 *</label>
-              <input className="form-input" placeholder="서울 강남구 / 온라인"
-                     value={form.location} onChange={e => setForm(f => ({ ...f, location: e.target.value }))}
-                     style={errors.location ? { borderColor: 'var(--danger)' } : {}} />
-              {errors.location && <span className="form-error">{errors.location}</span>}
-            </div>
-          </div>
-
           <div className="form-group">
-            <label className="form-label">행사 일시 *</label>
-            <input className="form-input" type="datetime-local"
-                   value={form.eventDateTime} onChange={e => setForm(f => ({ ...f, eventDateTime: e.target.value }))}
-                   style={errors.eventDateTime ? { borderColor: 'var(--danger)' } : {}} />
-            {errors.eventDateTime && <span className="form-error">{errors.eventDateTime}</span>}
+            <label className="form-label">장소 *</label>
+            <input
+              className="form-input"
+              placeholder="서울 강남구 / 온라인"
+              value={form.location}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, location: e.target.value }))
+              }
+              style={errors.location ? { borderColor: "var(--danger)" } : {}}
+            />
+            {errors.location && (
+              <span className="form-error">{errors.location}</span>
+            )}
           </div>
+        </div>
 
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
-            <div className="form-group">
-              <label className="form-label">판매 시작일 *</label>
-              <input className="form-input" type="datetime-local"
-                     value={form.saleStartAt} onChange={e => setForm(f => ({ ...f, saleStartAt: e.target.value }))}
-                     style={errors.saleStartAt ? { borderColor: 'var(--danger)' } : {}} />
-              {errors.saleStartAt && <span className="form-error">{errors.saleStartAt}</span>}
-            </div>
-            <div className="form-group">
-              <label className="form-label">판매 종료일 *</label>
-              <input className="form-input" type="datetime-local"
-                     value={form.saleEndAt} onChange={e => setForm(f => ({ ...f, saleEndAt: e.target.value }))}
-                     style={errors.saleEndAt ? { borderColor: 'var(--danger)' } : {}} />
-              {errors.saleEndAt && <span className="form-error">{errors.saleEndAt}</span>}
-            </div>
-          </div>
-
-          <div className="form-group">
-            <label className="form-label">상세 설명 *</label>
-            <textarea className="form-textarea" rows={5} placeholder="이벤트에 대한 자세한 설명을 입력하세요"
-                      value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
-                      style={errors.description ? { borderColor: 'var(--danger)' } : {}} />
-            {errors.description && <span className="form-error">{errors.description}</span>}
-          </div>
-
-          <div className="form-group">
-            <label className="form-label">이미지 URL</label>
-            <input className="form-input" placeholder="https://example.com/image.jpg"
-                   value={form.imageUrls} onChange={e => setForm(f => ({ ...f, imageUrls: e.target.value }))} />
-            <span style={{ fontSize: 12, color: 'var(--text-4)' }}>최대 2장, 쉼표로 구분</span>
-          </div>
-        </Section>
-
-        {/* 티켓 설정 */}
-        <Section title="티켓 설정">
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 14 }}>
-            <div className="form-group">
-              <label className="form-label">티켓 가격 (원)</label>
-              <input className="form-input" type="number" min="0" placeholder="0 = 무료"
-                     value={form.price} onChange={e => setForm(f => ({ ...f, price: e.target.value }))} />
-              <span style={{ fontSize: 12, color: 'var(--text-4)' }}>0 입력 시 무료</span>
-            </div>
-            <div className="form-group">
-              <label className="form-label">총 수량 *</label>
-              <input className="form-input" type="number" min="5" placeholder="100"
-                     value={form.totalQuantity} onChange={e => setForm(f => ({ ...f, totalQuantity: e.target.value }))}
-                     style={errors.totalQuantity ? { borderColor: 'var(--danger)' } : {}} />
-              {errors.totalQuantity && <span className="form-error">{errors.totalQuantity}</span>}
-            </div>
-            <div className="form-group">
-              <label className="form-label">1인 최대 구매</label>
-              <input className="form-input" type="number" min="1" max="10"
-                     value={form.maxQuantityPerUser} onChange={e => setForm(f => ({ ...f, maxQuantityPerUser: e.target.value }))} />
-            </div>
-          </div>
-        </Section>
-
-        {/* 기술 스택 */}
-        <Section title="관련 기술 스택 *">
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-            {TECH_STACKS.map(stack => (
-                <button key={stack} type="button" onClick={() => toggleStack(stack)} className="tag" style={{
-                  cursor: 'pointer',
-                  background: form.techStacks.includes(stack) ? 'var(--brand-light)' : 'var(--surface-2)',
-                  color: form.techStacks.includes(stack) ? 'var(--brand)' : 'var(--text-2)',
-                  border: `1px solid ${form.techStacks.includes(stack) ? 'var(--brand-muted)' : 'var(--border)'}`,
-                }}>{stack}</button>
-            ))}
-          </div>
-          {errors.techStacks && <span className="form-error">{errors.techStacks}</span>}
-          {form.techStacks.length > 0 && (
-              <div style={{ fontSize: 12, color: 'var(--text-3)' }}>{form.techStacks.length}개 선택됨</div>
+        <div className="form-group">
+          <label className="form-label">행사 일시 *</label>
+          <input
+            className="form-input"
+            type="datetime-local"
+            value={form.eventDateTime}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, eventDateTime: e.target.value }))
+            }
+            style={errors.eventDateTime ? { borderColor: "var(--danger)" } : {}}
+          />
+          {errors.eventDateTime && (
+            <span className="form-error">{errors.eventDateTime}</span>
           )}
-        </Section>
+        </div>
 
-        <button type="submit" className="btn btn-primary btn-lg btn-full" disabled={loading}>
-          {loading ? '처리 중...' : submitLabel}
-        </button>
-      </form>
-  )
+        <div
+          style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}
+        >
+          <div className="form-group">
+            <label className="form-label">판매 시작일 *</label>
+            <input
+              className="form-input"
+              type="datetime-local"
+              value={form.saleStartAt}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, saleStartAt: e.target.value }))
+              }
+              style={errors.saleStartAt ? { borderColor: "var(--danger)" } : {}}
+            />
+            {errors.saleStartAt && (
+              <span className="form-error">{errors.saleStartAt}</span>
+            )}
+          </div>
+          <div className="form-group">
+            <label className="form-label">판매 종료일 *</label>
+            <input
+              className="form-input"
+              type="datetime-local"
+              value={form.saleEndAt}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, saleEndAt: e.target.value }))
+              }
+              style={errors.saleEndAt ? { borderColor: "var(--danger)" } : {}}
+            />
+            {errors.saleEndAt && (
+              <span className="form-error">{errors.saleEndAt}</span>
+            )}
+          </div>
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">상세 설명 *</label>
+          <textarea
+            className="form-textarea"
+            rows={5}
+            placeholder="이벤트에 대한 자세한 설명을 입력하세요"
+            value={form.description}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, description: e.target.value }))
+            }
+            style={errors.description ? { borderColor: "var(--danger)" } : {}}
+          />
+          {errors.description && (
+            <span className="form-error">{errors.description}</span>
+          )}
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">이미지 URL</label>
+          <input
+            className="form-input"
+            placeholder="https://example.com/image.jpg"
+            value={form.imageUrls}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, imageUrls: e.target.value }))
+            }
+          />
+          <span style={{ fontSize: 12, color: "var(--text-4)" }}>
+            최대 2장, 쉼표로 구분
+          </span>
+        </div>
+      </Section>
+
+      {/* 티켓 설정 */}
+      <Section title="티켓 설정">
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr 1fr",
+            gap: 14,
+          }}
+        >
+          <div className="form-group">
+            <label className="form-label">티켓 가격 (원)</label>
+            <input
+              className="form-input"
+              type="number"
+              min="0"
+              placeholder="0 = 무료"
+              value={form.price}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, price: e.target.value }))
+              }
+            />
+            <span style={{ fontSize: 12, color: "var(--text-4)" }}>
+              0 입력 시 무료
+            </span>
+          </div>
+          <div className="form-group">
+            <label className="form-label">총 수량 *</label>
+            <input
+              className="form-input"
+              type="number"
+              min="5"
+              placeholder="100"
+              value={form.totalQuantity}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, totalQuantity: e.target.value }))
+              }
+              style={
+                errors.totalQuantity ? { borderColor: "var(--danger)" } : {}
+              }
+            />
+            {errors.totalQuantity && (
+              <span className="form-error">{errors.totalQuantity}</span>
+            )}
+          </div>
+          <div className="form-group">
+            <label className="form-label">1인 최대 구매</label>
+            <input
+              className="form-input"
+              type="number"
+              min="1"
+              max="10"
+              value={form.maxQuantityPerUser}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, maxQuantityPerUser: e.target.value }))
+              }
+            />
+          </div>
+        </div>
+      </Section>
+
+      {/* 기술 스택 */}
+      <Section title="관련 기술 스택 *">
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {techStackOptions.map((stack) => (
+            <button
+              key={stack.techStackId}
+              type="button"
+              onClick={() => toggleStack(stack.name)}
+              className="tag"
+              style={{
+                cursor: "pointer",
+                background: form.techStacks.includes(stack.name)
+                  ? "var(--brand-light)"
+                  : "var(--surface-2)",
+                color: form.techStacks.includes(stack.name)
+                  ? "var(--brand)"
+                  : "var(--text-2)",
+                border: `1px solid ${form.techStacks.includes(stack.name) ? "var(--brand-muted)" : "var(--border)"}`,
+              }}
+            >
+              {stack.name}
+            </button>
+          ))}
+        </div>
+        {errors.techStacks && (
+          <span className="form-error">{errors.techStacks}</span>
+        )}
+        {form.techStacks.length > 0 && (
+          <div style={{ fontSize: 12, color: "var(--text-3)" }}>
+            {form.techStacks.length}개 선택됨
+          </div>
+        )}
+      </Section>
+
+      <button
+        type="submit"
+        className="btn btn-primary btn-lg btn-full"
+        disabled={loading}
+      >
+        {loading ? "처리 중..." : submitLabel}
+      </button>
+    </form>
+  );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
-      <div className="card" style={{ padding: '24px' }}>
-        <h2 style={{ fontSize: 15, fontWeight: 600, marginBottom: 18, color: 'var(--text)' }}>{title}</h2>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>{children}</div>
+    <div className="card" style={{ padding: "24px" }}>
+      <h2
+        style={{
+          fontSize: 15,
+          fontWeight: 600,
+          marginBottom: 18,
+          color: "var(--text)",
+        }}
+      >
+        {title}
+      </h2>
+      <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+        {children}
       </div>
-  )
+    </div>
+  );
 }
 
 export default function SellerEventCreate() {
-  const { toast } = useToast()
-  const navigate = useNavigate()
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const [techStackOptions, setTechStackOptions] = useState<
+    { techStackId: number; name: string }[]
+  >([]);
+
+  useEffect(() => {
+    getTechStacks().then((res) => setTechStackOptions(res.data.techStacks));
+  }, []);
 
   const handleSubmit = async (form: EventForm) => {
     const res = await createSellerEvent({
       title: form.title,
       description: form.description,
       category: form.category,
-      techStackIds: form.techStacks.map(s => TECH_STACK_MAP[s]).filter(Boolean),
+      techStackIds: form.techStacks
+        .map((s) => techStackOptions.find((t) => t.name === s)?.techStackId)
+        .filter((id): id is number => id !== undefined),
       price: parseInt(form.price) || 0,
       totalQuantity: parseInt(form.totalQuantity),
       maxQuantity: parseInt(form.maxQuantityPerUser) || 1,
@@ -243,48 +413,75 @@ export default function SellerEventCreate() {
       saleStartAt: form.saleStartAt,
       saleEndAt: form.saleEndAt,
       location: form.location,
-      imageUrls: form.imageUrls ? form.imageUrls.split(',').map(s => s.trim()).filter(Boolean) : undefined,
-    })
-    toast('이벤트가 등록되었습니다!', 'success')
-    navigate(`/seller/events/${res.data.data.eventId}`)
-  }
+      imageUrls: form.imageUrls
+        ? form.imageUrls
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : undefined,
+    });
+    toast("이벤트가 등록되었습니다!", "success");
+    navigate(`/seller/events/${res.data.data.eventId}`);
+  };
 
   return (
-      <div style={{ padding: '32px 36px', maxWidth: 720 }}>
-        <div style={{ marginBottom: 28 }}>
-          <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 4 }}>이벤트 등록</h1>
-          <p style={{ fontSize: 14, color: 'var(--text-3)' }}>새로운 이벤트를 등록하세요</p>
-        </div>
-        <EventForm initialData={EMPTY_FORM} onSubmit={handleSubmit} submitLabel="이벤트 등록하기" />
+    <div style={{ padding: "32px 36px", maxWidth: 720 }}>
+      <div style={{ marginBottom: 28 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 4 }}>
+          이벤트 등록
+        </h1>
+        <p style={{ fontSize: 14, color: "var(--text-3)" }}>
+          새로운 이벤트를 등록하세요
+        </p>
       </div>
-  )
+      <EventForm
+        initialData={EMPTY_FORM}
+        onSubmit={handleSubmit}
+        submitLabel="이벤트 등록하기"
+        techStackOptions={techStackOptions}
+      />
+    </div>
+  );
 }
 
 export function SellerEventEdit() {
-  const { id } = useParams<{ id: string }>()
-  const { toast } = useToast()
-  const navigate = useNavigate()
-  const [initial, setInitial] = useState<EventForm | null>(null)
+  const { id } = useParams<{ id: string }>();
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const [initial, setInitial] = useState<EventForm | null>(null);
+  const [techStackOptions, setTechStackOptions] = useState<
+    { techStackId: number; name: string }[]
+  >([]);
 
   useEffect(() => {
-    if (!id) return
-    getSellerEventDetail(id).then(res => {
-      const d = res.data.data
-      setInitial({
-        title: d.title, description: d.description, category: d.category,
-        techStacks: d.techStacks.map((t: any) => t.name),
-        price: String(d.price),
-        totalQuantity: String(d.totalQuantity),
-        maxQuantityPerUser: String(d.maxQuantityPerUser),
-        eventDateTime: d.eventDateTime.slice(0, 16),
-        saleStartAt: '', saleEndAt: '',
-        location: d.location, imageUrls: '',
+    getTechStacks().then((res) => setTechStackOptions(res.data.techStacks));
+  }, []);
+
+  useEffect(() => {
+    if (!id) return;
+    getSellerEventDetail(id)
+      .then((res) => {
+        const d = res.data.data;
+        setInitial({
+          title: d.title,
+          description: d.description,
+          category: d.category,
+          techStacks: d.techStacks.map((t: any) => t.name),
+          price: String(d.price),
+          totalQuantity: String(d.totalQuantity),
+          maxQuantityPerUser: String(d.maxQuantityPerUser),
+          eventDateTime: d.eventDateTime.slice(0, 16),
+          saleStartAt: "",
+          saleEndAt: "",
+          location: d.location,
+          imageUrls: "",
+        });
       })
-    }).catch(() => toast('이벤트 로드 실패', 'error'))
-  }, [id])
+      .catch(() => toast("이벤트 로드 실패", "error"));
+  }, [id]);
 
   const handleSubmit = async (form: EventForm) => {
-    if (!id) return
+    if (!id) return;
     await updateSellerEvent(id, {
       title: form.title,
       description: form.description,
@@ -295,20 +492,39 @@ export function SellerEventEdit() {
       saleStartAt: form.saleStartAt,
       saleEndAt: form.saleEndAt,
       location: form.location,
-      imageUrls: form.imageUrls ? form.imageUrls.split(',').map(s => s.trim()).filter(Boolean) : undefined,
-    })
-    toast('이벤트가 수정되었습니다', 'success')
-    navigate(`/seller/events/${id}`)
-  }
+      imageUrls: form.imageUrls
+        ? form.imageUrls
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : undefined,
+    });
+    toast("이벤트가 수정되었습니다", "success");
+    navigate(`/seller/events/${id}`);
+  };
 
-  if (!initial) return <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 100 }}><div className="spinner" /></div>
+  if (!initial)
+    return (
+      <div
+        style={{ display: "flex", justifyContent: "center", paddingTop: 100 }}
+      >
+        <div className="spinner" />
+      </div>
+    );
 
   return (
-      <div style={{ padding: '32px 36px', maxWidth: 720 }}>
-        <div style={{ marginBottom: 28 }}>
-          <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 4 }}>이벤트 수정</h1>
-        </div>
-        <EventForm initialData={initial} onSubmit={handleSubmit} submitLabel="수정 저장" />
+    <div style={{ padding: "32px 36px", maxWidth: 720 }}>
+      <div style={{ marginBottom: 28 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 4 }}>
+          이벤트 수정
+        </h1>
       </div>
-  )
+      <EventForm
+        initialData={initial}
+        onSubmit={handleSubmit}
+        submitLabel="수정 저장"
+        techStackOptions={techStackOptions}
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
## 🛠 작업 내용
- getTechStacks API 중복 제거 및 응답 타입 일관성 확보
- 기술스택 필터를 이름 기반에서 ID 기반으로 변경하여 백엔드 스펙 정렬
- axios paramsSerializer 추가로 배열 파라미터 직렬화 방식 수정 (URL: key=val1&key=val2)
- SellerEventCreate 및 EventList에서 기술스택 동적 조회 적용

## 📝 변경 사항
- **API 레이어**: auth.api.ts에 getTechStacks 통합, events.api.ts에서 중복 제거
- **타입 정의**: EventFilterRequest.techStacks를 string[] → number[]로 변경
- **이벤트 목록 필터**: selectedStack(이름) → selectedStackId(ID) 기반 필터링
- **판매자 이벤트 폼**: getTechStacks를 auth.api.ts에서 import하여 기술스택 동적 로드
- **HTTP 클라이언트**: axios paramsSerializer 커스터마이징
