### PR TITLE
[AI] chore: Elasticsearch 연동 및 인덱스 생성

### DIFF
--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'gradle' # 의존성 다운로드 캐싱 (빌드 속도 최적화)
 
       - name: 3. Grant execute permission for gradlew
-        run: chmod +x admin/gradlew
+        run: chmod +x ai/gradlew
 
       - name: 4. Gradle Test
         run: cd ai && ./gradlew test

--- a/ai/src/main/java/org/example/ai/domain/model/UserVector.java
+++ b/ai/src/main/java/org/example/ai/domain/model/UserVector.java
@@ -41,7 +41,7 @@ public class UserVector {
     private float recentWeightSum;
     // ===================================== //
 
-    // ============ 부정 신호 벡터 ============ //
+    // ============ 부정 신호 vector ============ //
     @Field(type = FieldType.Dense_Vector)
     private float[] negativeVector;
 

--- a/ai/src/main/java/org/example/ai/domain/model/UserVector.java
+++ b/ai/src/main/java/org/example/ai/domain/model/UserVector.java
@@ -1,0 +1,59 @@
+package org.example.ai.domain.model;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+
+@Getter
+@Builder
+@Document(indexName = "user-index")
+public class UserVector {
+
+    @Id
+    private String id;
+
+    // ============ 장기 취향 벡터 ============ //
+    @Field(type = FieldType.Dense_Vector)
+    private float[] preferenceVector;
+
+    @Field(type = FieldType.Float)
+    private float preferenceWeightSum;
+    // ===================================== //
+
+    // ============ 구매 의도 벡터 ============ //
+    @Field(type = FieldType.Dense_Vector)
+    private float cartVector;
+
+    @Field(type = FieldType.Float)
+    private float cartWeightSum;
+    // ===================================== //
+
+    // ============ 최근 관심 벡터 ============ //
+    @Field(type = FieldType.Dense_Vector)
+    private float[] recentVector;
+
+    @Field(type = FieldType.Float)
+    private float recentWeightSum;
+    // ===================================== //
+
+    // ============ 부정 신호 벡터 ============ //
+    @Field(type = FieldType.Dense_Vector)
+    private float[] negativeVector;
+
+    @Field(type = FieldType.Float)
+    private float negativeWeightSum;
+    // ===================================== //
+
+    // vector 갱신 시각
+    @Field(type = FieldType.Date)
+    private String updatedAt;
+
+
+
+}
+

--- a/ai/src/main/java/org/example/ai/domain/model/UserVector.java
+++ b/ai/src/main/java/org/example/ai/domain/model/UserVector.java
@@ -27,7 +27,7 @@ public class UserVector {
 
     // ============ 구매 의도 벡터 ============ //
     @Field(type = FieldType.Dense_Vector)
-    private float cartVector;
+    private float[] cartVector;
 
     @Field(type = FieldType.Float)
     private float cartWeightSum;

--- a/ai/src/main/java/org/example/ai/infrastructure/config/ElasticsearchConfig.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/config/ElasticsearchConfig.java
@@ -1,0 +1,21 @@
+package org.example.ai.infrastructure.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+@Configuration
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+
+
+    @Value("${spring.elasticsearch.uris}")
+    private String uri;
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+            .connectedTo(uri.replace("https://", "").replace("http://", ""))
+            .build();
+    }
+}

--- a/ai/src/main/java/org/example/ai/infrastructure/config/ElasticsearchConfig.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/config/ElasticsearchConfig.java
@@ -16,6 +16,7 @@ public class ElasticsearchConfig extends ElasticsearchConfiguration {
     public ClientConfiguration clientConfiguration() {
         return ClientConfiguration.builder()
             .connectedTo(uri.replace("https://", "").replace("http://", ""))
+            .usingSsl()
             .build();
     }
 }

--- a/ai/src/main/resources/application-test.yml
+++ b/ai/src/main/resources/application-test.yml
@@ -2,3 +2,7 @@ jwt:
   secret-key: test-jwt-secret-key
   access-token-ttl: 1800000
   refresh-token-ttl: 604800000
+
+spring:
+  elasticsearch:
+    uris: http://localhost:9200


### PR DESCRIPTION
## 관련 이슈
- close #342

## 작업 내용
- ElasticsearchConfig 빈 설정
- UserVector 도메인 모델 생성 (user-index 매핑)

## 변경 사항
- infrastructure/config/ElasticsearchConfig.java
- domain/model/UserVector.java

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 참고 사항
- user-index 매핑 @Field(type = FieldType.Dense_Vector) 사용