### PR TITLE
[Member] fix: internal tech-stacks 경로 UUID 변환 오류 수정

### DIFF
--- a/member/src/main/java/com/devticket/member/application/InternalMemberService.java
+++ b/member/src/main/java/com/devticket/member/application/InternalMemberService.java
@@ -5,9 +5,11 @@ import com.devticket.member.presentation.domain.MemberErrorCode;
 import com.devticket.member.presentation.domain.SellerApplicationDecision;
 import com.devticket.member.presentation.domain.UserRole;
 import com.devticket.member.presentation.domain.model.SellerApplication;
+import com.devticket.member.presentation.domain.model.TechStack;
 import com.devticket.member.presentation.domain.model.User;
 import com.devticket.member.presentation.domain.model.UserProfile;
 import com.devticket.member.presentation.domain.repository.SellerApplicationRepository;
+import com.devticket.member.presentation.domain.repository.TechStackRepository;
 import com.devticket.member.presentation.domain.repository.UserProfileRepository;
 import com.devticket.member.presentation.domain.repository.UserRepository;
 import com.devticket.member.presentation.dto.internal.request.InternalDecideSellerApplicationRequest;
@@ -17,6 +19,7 @@ import com.devticket.member.presentation.dto.internal.response.InternalMemberRol
 import com.devticket.member.presentation.dto.internal.response.InternalMemberStatusResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalSellerApplicationResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalSellerInfoResponse;
+import com.devticket.member.presentation.dto.internal.response.InternalTechStackListResponse;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,6 +35,7 @@ public class InternalMemberService {
     private final UserRepository userRepository;
     private final UserProfileRepository userProfileRepository;
     private final SellerApplicationRepository sellerApplicationRepository;
+    private final TechStackRepository techStackRepository;
 
     public InternalMemberInfoResponse getMemberInfo(UUID userId) {
         User user = findUserByUuidOrThrow(userId);
@@ -96,5 +100,10 @@ public class InternalMemberService {
         return userRepository.findByRole(UserRole.SELLER).stream()
             .map(User::getUserId)
             .toList();
+    }
+
+    public InternalTechStackListResponse getAllTechStacks() {
+        List<TechStack> stacks = techStackRepository.findAll();
+        return InternalTechStackListResponse.from(stacks);
     }
 }

--- a/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
+++ b/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
@@ -8,6 +8,7 @@ import com.devticket.member.presentation.dto.internal.response.InternalMemberRol
 import com.devticket.member.presentation.dto.internal.response.InternalMemberStatusResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalSellerApplicationResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalSellerInfoResponse;
+import com.devticket.member.presentation.dto.internal.response.InternalTechStackListResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalUpdateStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -31,6 +32,48 @@ import org.springframework.web.bind.annotation.RestController;
 public class InternalMemberController {
 
     private final InternalMemberService internalMemberService;
+
+    // 판매자 등록 신청자 리스트
+    @Operation(summary = "판매자 신청 목록 조회", description = "내부 서비스용 — 판매자 신청 목록 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/seller-applications")
+    public ResponseEntity<List<InternalSellerApplicationResponse>> getSellerApplications(){
+        List<InternalSellerApplicationResponse> response = internalMemberService.getSellerApplications();
+        return ResponseEntity.ok(response);
+    }
+
+    // 판매자 승인 결정
+    @Operation(summary = "판매자 신청 승인/반려", description = "내부 서비스용 — 판매자 신청 승인/반려")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "처리 성공"),
+        @ApiResponse(responseCode = "404", description = "신청 없음")
+    })
+    @PatchMapping("/seller-applications/{applicationId}")
+    public ResponseEntity<InternalDecideSellerApplicationResponse> decideSellerApplication(
+        @PathVariable UUID applicationId,
+        @RequestBody InternalDecideSellerApplicationRequest request
+    ){
+        InternalDecideSellerApplicationResponse response=internalMemberService.decideSellerApplication(applicationId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "판매자 ID 목록 조회", description = "내부 서비스용 — 전체 판매자 ID 목록 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/sellers")
+    public ResponseEntity<List<UUID>> getSellerId(){
+        List<UUID> response = internalMemberService.getSellerIds();
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "기술 스택 목록 조회", description = "내부 서비스용 — 전체 기술 스택 목록 조회")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/tech-stacks")
+    public ResponseEntity<InternalTechStackListResponse> getTechStacks() {
+        InternalTechStackListResponse response = internalMemberService.getAllTechStacks();
+        return ResponseEntity.ok(response);
+    }
 
     @Operation(summary = "유저 기본 정보 조회", description = "내부 서비스용 — 유저 ID로 기본 정보 조회")
     @ApiResponses({
@@ -89,36 +132,4 @@ public class InternalMemberController {
 //    public ResponseEntity<InternalUpdateStatusResponse> updateMemberStatus(){
 //
 //    }
-
-    // 판매자 등록 신청자 리스트
-    @Operation(summary = "판매자 신청 목록 조회", description = "내부 서비스용 — 판매자 신청 목록 조회")
-    @ApiResponse(responseCode = "200", description = "조회 성공")
-    @GetMapping("/seller-applications")
-    public ResponseEntity<List<InternalSellerApplicationResponse>> getSellerApplications(){
-        List<InternalSellerApplicationResponse> response = internalMemberService.getSellerApplications();
-        return ResponseEntity.ok(response);
-    }
-
-    // 판매자 승인 결정
-    @Operation(summary = "판매자 신청 승인/반려", description = "내부 서비스용 — 판매자 신청 승인/반려")
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "처리 성공"),
-        @ApiResponse(responseCode = "404", description = "신청 없음")
-    })
-    @PatchMapping("/seller-applications/{applicationId}")
-    public ResponseEntity<InternalDecideSellerApplicationResponse> decideSellerApplication(
-        @PathVariable UUID applicationId,
-        @RequestBody InternalDecideSellerApplicationRequest request
-    ){
-        InternalDecideSellerApplicationResponse response=internalMemberService.decideSellerApplication(applicationId, request);
-        return ResponseEntity.ok(response);
-    }
-
-    @Operation(summary = "판매자 ID 목록 조회", description = "내부 서비스용 — 전체 판매자 ID 목록 조회")
-    @ApiResponse(responseCode = "200", description = "조회 성공")
-    @GetMapping("/sellers")
-    public ResponseEntity<List<UUID>> getSellerId(){
-        List<UUID> response = internalMemberService.getSellerIds();
-        return ResponseEntity.ok(response);
-    }
 }

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalTechStackListResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalTechStackListResponse.java
@@ -1,0 +1,4 @@
+package com.devticket.member.presentation.dto.internal.response;
+
+public class InternalTechStackListResponse {
+}

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalTechStackListResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalTechStackListResponse.java
@@ -1,4 +1,17 @@
 package com.devticket.member.presentation.dto.internal.response;
 
-public class InternalTechStackListResponse {
+import com.devticket.member.presentation.domain.model.TechStack;
+import java.util.List;
+
+public record InternalTechStackListResponse(
+    List<TechStackItem> techStacks
+) {
+    public record TechStackItem(Long techStackId, String name) {}
+
+    public static InternalTechStackListResponse from(List<TechStack> stacks) {
+        List<TechStackItem> items = stacks.stream()
+            .map(s -> new TechStackItem(s.getId(), s.getName()))
+            .toList();
+        return new InternalTechStackListResponse(items);
+    }
 }


### PR DESCRIPTION
## 개요
`/internal/members/tech-stacks` 요청 시 발생하던 UUID 변환 오류를 수정합니다.

## 원인
`InternalMemberController`에서 `/{userId}` 경로 변수 매핑이 정적 경로(`/tech-stacks`, `/seller-applications`, `/sellers`)보다 먼저 선언되어, Spring이 `tech-stacks` 문자열을 UUID로 변환하려다 실패.

## 변경 사항
- `InternalMemberController` 메서드 순서 재정렬: 정적 경로를 `/{userId}` 패턴보다 먼저 배치
- `InternalTechStackListResponse` DTO 구현 완성 (record 타입 + `from()` 팩토리 메서드)
- `InternalMemberService`에 `getAllTechStacks()` 메서드 추가

## 테스트
- [ ] `GET /internal/members/tech-stacks` → 200 OK + 기술 스택 목록 반환 확인
- [ ] `GET /internal/members/{uuid}` → 기존 동작 정상 확인
- [ ] `GET /internal/members/seller-applications` → 정상 동작 확인

Closes #366 
