### PR TITLE
[Event] fix:기술스택 이름 하드코딩 제거 및 Member 서비스 API 연동

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -10,6 +10,7 @@ import com.devticket.event.domain.model.Event;
 import com.devticket.event.domain.model.EventImage;
 import com.devticket.event.domain.model.EventTechStack;
 import com.devticket.event.infrastructure.client.MemberClient;
+import com.devticket.event.infrastructure.client.dto.TechStackItem;
 import com.devticket.event.infrastructure.persistence.EventRepository;
 import com.devticket.event.infrastructure.search.EventDocument;
 import com.devticket.event.infrastructure.search.EventSearchRepository;
@@ -24,7 +25,6 @@ import com.devticket.event.presentation.dto.SellerEventSummaryResponse;
 import com.devticket.event.presentation.dto.SellerEventUpdateRequest;
 import com.devticket.event.presentation.dto.SellerEventUpdateResponse;
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -94,12 +94,13 @@ public class EventService {
 
         // 4. techStackIds 저장 로직
         if (request.techStackIds() != null && !request.techStackIds().isEmpty()) {
+            Map<Long, String> techStackMap = buildTechStackMap();  // 추가
             for (Long techStackId : request.techStackIds()) {
-                String techStackName = getTechStackName(techStackId);
+                String techStackName = techStackMap.getOrDefault(techStackId, "Unknown");  // 변경
                 EventTechStack techStack = EventTechStack.of(savedEvent, techStackId, techStackName);
                 savedEvent.getEventTechStacks().add(techStack);
             }
-            eventRepository.save(savedEvent);  // EventTechStack 반영을 위해 다시 저장
+            eventRepository.save(savedEvent);
         }
 
         syncToElasticsearch(savedEvent);
@@ -107,22 +108,9 @@ public class EventService {
         return SellerEventCreateResponse.from(savedEvent);
     }
 
-    /**
-     * TechStack ID를 실제 name으로 매핑 (더미 데이터)
-     * 향후 Member 서비스 API 호출로 교체 예정
-     */
-    private String getTechStackName(Long techStackId) {
-        Map<Long, String> TECH_STACK_NAMES = new HashMap<>();
-        TECH_STACK_NAMES.put(1L, "Spring");
-        TECH_STACK_NAMES.put(2L, "React");
-        TECH_STACK_NAMES.put(3L, "Vue");
-        TECH_STACK_NAMES.put(4L, "Django");
-        TECH_STACK_NAMES.put(5L, "FastAPI");
-        TECH_STACK_NAMES.put(6L, "Node.js");
-        TECH_STACK_NAMES.put(7L, "Python");
-        TECH_STACK_NAMES.put(8L, "Kotlin");
-
-        return TECH_STACK_NAMES.getOrDefault(techStackId, "Unknown");
+    private Map<Long, String> buildTechStackMap() {
+        return memberClient.getTechStacks().stream()
+            .collect(Collectors.toMap(TechStackItem::techStackId, TechStackItem::name));
     }
 
     @Transactional(readOnly = true)
@@ -305,9 +293,10 @@ public class EventService {
 
         // TechStack 교체
         event.getEventTechStacks().clear();
+        Map<Long, String> techStackMap = buildTechStackMap();  // 추가
         for (Long techStackId : request.techStackIds()) {
             event.getEventTechStacks().add(
-                EventTechStack.of(event, techStackId, getTechStackName(techStackId)));
+                EventTechStack.of(event, techStackId, techStackMap.getOrDefault(techStackId, "Unknown")));  // 변경
         }
 
         // Image 교체
@@ -369,10 +358,10 @@ public class EventService {
         // 기술스택 필터 (Nested)
         if (request.techStacks() != null && !request.techStacks().isEmpty()) {
             List<Query> techStackShoulds = request.techStacks().stream()
-                .map(techStackId -> Query.of(q -> q
+                .map(name -> Query.of(q -> q
                     .nested(n -> n.path("techStacks")
                         .query(nq -> nq.term(t -> t
-                            .field("techStacks.techStackId").value(techStackId))))))
+                            .field("techStacks.techStackName").value(name))))))
                 .toList();
             boolQuery.filter(Query.of(q -> q
                 .bool(b -> b.should(techStackShoulds).minimumShouldMatch("1"))));

--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -358,10 +358,11 @@ public class EventService {
         // 기술스택 필터 (Nested)
         if (request.techStacks() != null && !request.techStacks().isEmpty()) {
             List<Query> techStackShoulds = request.techStacks().stream()
-                .map(name -> Query.of(q -> q
+                .map(techStackId -> Query.of(q -> q
                     .nested(n -> n.path("techStacks")
                         .query(nq -> nq.term(t -> t
-                            .field("techStacks.techStackName").value(name))))))
+                            .field("techStacks.techStackId")
+                            .value(techStackId))))))
                 .toList();
             boolQuery.filter(Query.of(q -> q
                 .bool(b -> b.should(techStackShoulds).minimumShouldMatch("1"))));

--- a/event/src/main/java/com/devticket/event/domain/enums/EventCategory.java
+++ b/event/src/main/java/com/devticket/event/domain/enums/EventCategory.java
@@ -7,7 +7,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum EventCategory {
     MEETUP("소모임"),
-    CONFERENCE("컨퍼런스");
+    CONFERENCE("컨퍼런스"),
+    HACKATHON("해커톤"),
+    STUDY("스터디"),
+    PROJECT("프로젝트");
 
     private final String description;
 }

--- a/event/src/main/java/com/devticket/event/infrastructure/client/MemberClient.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/MemberClient.java
@@ -37,7 +37,10 @@ public class MemberClient {
         try {
             String url = memberServiceUrl + "/internal/members/tech-stacks";
             TechStackListResponse response = restTemplate.getForObject(url, TechStackListResponse.class);
-            return response != null ? response.techStacks() : List.of();
+            if (response == null) {
+                return List.of();
+            }
+            return response.techStacks() != null ? response.techStacks() : List.of();
         } catch (Exception e) {
             log.warn("[기술스택 조회 실패] Member 서비스 호출 오류", e);
             return List.of();

--- a/event/src/main/java/com/devticket/event/infrastructure/client/MemberClient.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/MemberClient.java
@@ -1,12 +1,17 @@
 package com.devticket.event.infrastructure.client;
 
 import com.devticket.event.infrastructure.client.dto.InternalMemberInfoResponse;
+import com.devticket.event.infrastructure.client.dto.TechStackItem;
+import com.devticket.event.infrastructure.client.dto.TechStackListResponse;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MemberClient {
@@ -25,6 +30,17 @@ public class MemberClient {
             return response != null ? response.nickname() : null;
         } catch (Exception e) {
             return null; // 장애 시 null 허용 (이벤트 상세 자체는 살림)
+        }
+    }
+
+    public List<TechStackItem> getTechStacks() {
+        try {
+            String url = memberServiceUrl + "/internal/members/tech-stacks";
+            TechStackListResponse response = restTemplate.getForObject(url, TechStackListResponse.class);
+            return response != null ? response.techStacks() : List.of();
+        } catch (Exception e) {
+            log.warn("[기술스택 조회 실패] Member 서비스 호출 오류", e);
+            return List.of();
         }
     }
 }

--- a/event/src/main/java/com/devticket/event/infrastructure/client/dto/TechStackItem.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/dto/TechStackItem.java
@@ -1,0 +1,3 @@
+package com.devticket.event.infrastructure.client.dto;
+
+public record TechStackItem(Long techStackId, String name) {}

--- a/event/src/main/java/com/devticket/event/infrastructure/client/dto/TechStackListResponse.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/dto/TechStackListResponse.java
@@ -1,0 +1,5 @@
+package com.devticket.event.infrastructure.client.dto;
+
+import java.util.List;
+
+public record TechStackListResponse(List<TechStackItem> techStacks) {}

--- a/event/src/main/java/com/devticket/event/presentation/dto/EventListRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/EventListRequest.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 public record EventListRequest(
     String keyword,
     EventCategory category,
-    List<Long> techStacks,
+    List<String> techStacks,
     UUID sellerId,
     EventStatus status
 ) {

--- a/event/src/main/java/com/devticket/event/presentation/dto/EventListRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/EventListRequest.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 public record EventListRequest(
     String keyword,
     EventCategory category,
-    List<String> techStacks,
+    List<Long> techStacks,
     UUID sellerId,
     EventStatus status
 ) {


### PR DESCRIPTION
## 개요
이벤트 생성/수정 시 기술스택 이름을 하드코딩에서 Member 서비스 Internal API 동적 조회 방식으로 수정합니다.
또한 기술스택 필터를 ID 기반으로 변경하고, null-safety를 개선합니다.

## 변경 사항

### 버그 수정
- `MemberClient.getTechStacks()` 메서드 개선
  - response 객체뿐만 아니라 response.techStacks()도 null 체크 추가
  - NPE 위험 제거 및 장애 격리 강화

### 기능 개선
- `EventListRequest.techStacks` 타입 변경
  - `List<String>` → `List<Long>` (ID 기반)
  - 생성/수정/검색 로직 통일
  
- `EventService.buildSearchQuery()` 메서드 수정
  - 기술스택 필터: `techStackName` → `techStackId`로 변경
  - Elasticsearch Nested 쿼리를 ID 기반으로 최적화
  - Member API 실패 시에도 "Unknown" 저장된 이벤트 검색 가능

### 기능 추가 (초기 작업)
- `EventService.buildTechStackMap()` 메서드 추가
  - `MemberClient.getTechStacks()` 호출로 기술스택 ID → 이름 매핑
  - 이벤트 생성/수정 시 동적 이름 조회
  
- `MemberClient.getTechStacks()` 추가
  - `GET /internal/members/tech-stacks` Internal API 호출
  - 실패 시 빈 리스트 반환으로 장애 격리

- `EventCategory` enum 확장
  - HACKATHON, STUDY, PROJECT 카테고리 추가
  
- `EventListRequest` DTO 추가
  - keyword/category/techStacks/sellerId/status 필터 지원
  
- `TechStackItem`, `TechStackListResponse` client DTO 추가 (event 모듈)

## 관련 이슈
closes #368
