### PR TITLE
[AI] feat: Kafka Consumer 기본 설정

### DIFF
--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     // Kafka
     implementation 'org.springframework.boot:spring-boot-starter-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     // Elasticsearch
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'

--- a/ai/src/main/java/org/example/ai/infrastructure/config/KafkaConfig.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,80 @@
+package org.example.ai.infrastructure.config;
+
+
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.example.ai.presentation.dto.req.ActionLogMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JacksonJsonDeserializer;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JacksonJsonSerializer;
+
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ConsumerFactory<String, ActionLogMessage> actionLogMessageConsumerFactory(){
+
+        Map<String, Object> config = new HashMap<>();
+
+        // kafka 브로커 주소
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        // 처음부터 읽기
+        config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        
+        // value 역직렬화
+        JacksonJsonDeserializer<ActionLogMessage> deserializer =
+            new JacksonJsonDeserializer<>(ActionLogMessage.class);
+
+
+        return new DefaultKafkaConsumerFactory<>(
+            config,
+            // key 역직렬화
+            new StringDeserializer(),
+            deserializer
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ActionLogMessage> actionLogKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ActionLogMessage> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(actionLogMessageConsumerFactory());
+        return factory;
+    }
+
+    // =========== 발행 테스트 용 ===========
+    @Bean
+    public ProducerFactory<String, ActionLogMessage> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JacksonJsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, ActionLogMessage> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+    // ================================= //
+
+
+}

--- a/ai/src/main/java/org/example/ai/infrastructure/kafka/ActionLogConsumer.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/kafka/ActionLogConsumer.java
@@ -1,0 +1,34 @@
+package org.example.ai.infrastructure.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.ai.presentation.dto.req.ActionLogMessage;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ActionLogConsumer {
+
+    @KafkaListener(
+        topics = "action.log",
+        groupId = "ai.action-log",
+        containerFactory = "actionLogKafkaListenerContainerFactory"
+    )
+    public void consume(ActionLogMessage message) {
+        log.info("Action Log 수신 - actionType : {}, userId : {}", message.actionType(), message.userId());
+
+        switch (message.actionType()) {
+            case "PURCHASE"     -> log.info("preference_vector 갱신 예정 - eventId: {}", message.eventId());
+            case "CART_ADD"     -> log.info("cart_vector 갱신 예정 - eventId: {}", message.eventId());
+            case "CART_REMOVE"  -> log.info("negative_vector 갱신 예정 - eventId: {}", message.eventId());
+            case "REFUND"       -> log.info("negative_vector 갱신 + preference_vector 역보정 예정 - eventId: {}", message.eventId());
+            case "DETAIL_VIEW"  -> log.info("recent_vector 갱신 예정 - eventId: {}", message.eventId());
+            case "DWELL_TIME"   -> log.info("recent_vector 갱신 예정 - eventId: {}, dwellTime: {}", message.eventId(), message.dwellTimeSeconds());
+            case "VIEW"         -> log.info("recent_vector 갱신 예정 - eventIds: {}", message.eventIds());
+            default             -> log.warn("알 수 없는 actionType: {}", message.actionType());
+        }
+    }
+
+}

--- a/ai/src/main/java/org/example/ai/presentation/dto/controller/KafkaTestController.java
+++ b/ai/src/main/java/org/example/ai/presentation/dto/controller/KafkaTestController.java
@@ -1,0 +1,24 @@
+package org.example.ai.presentation.dto.controller;
+
+import lombok.RequiredArgsConstructor;
+
+import org.example.ai.presentation.dto.req.ActionLogMessage;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test")
+@RequiredArgsConstructor
+public class KafkaTestController {
+
+    private final KafkaTemplate<String, ActionLogMessage> kafkaTemplate;
+
+    @PostMapping("/kafka")
+    public String send(@RequestBody ActionLogMessage message) {
+        kafkaTemplate.send("action.log", message);
+        return "발행 완료";
+    }
+}

--- a/ai/src/main/java/org/example/ai/presentation/dto/req/ActionLogMessage.java
+++ b/ai/src/main/java/org/example/ai/presentation/dto/req/ActionLogMessage.java
@@ -1,0 +1,32 @@
+package org.example.ai.presentation.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record ActionLogMessage(
+    @JsonProperty("userId")
+    String userId,
+
+    @JsonProperty("eventId")
+    String eventId,
+
+    @JsonProperty("eventIds")
+    List<String> eventIds,
+
+    @JsonProperty("actionType")
+    String actionType,
+
+    @JsonProperty("dwellTimeSeconds")
+    Integer dwellTimeSeconds,
+
+    @JsonProperty("quantity")
+    Integer quantity,
+
+    @JsonProperty("totalAmount")
+    Long totalAmount,
+
+    @JsonProperty("timestamp")
+    String timestamp
+) {
+
+}

--- a/ai/src/main/resources/application-test.yml
+++ b/ai/src/main/resources/application-test.yml
@@ -4,5 +4,18 @@ jwt:
   refresh-token-ttl: 604800000
 
 spring:
+  kafka:
+    bootstrap-servers: localhost:9093
+
   elasticsearch:
     uris: http://localhost:9200
+
+openai:
+  api-key: test-api-key
+  embedding:
+    url: https://api.openai.com/v1/embeddings
+    model: text-embedding-3-small
+
+internal:
+  log-service:
+    url: http://localhost:8086


### PR DESCRIPTION
## 관련 이슈
- close #343

## 작업 내용
- KafkaConfig 작성 (ConsumerFactory, ConcurrentKafkaListenerContainerFactory)
- ActionLogMessage DTO 작성 (record)
- ActionLogConsumer 작성 (actionType별 분기 처리)
- KafkaTestController 작성 (테스트용 임시 Producer)
- Swagger를 통한 Kafka 연동 테스트 완료

## 변경 사항
- infrastructure/config/KafkaConfig.java
- infrastructure/kafka/dto/ActionLogMessage.java
- infrastructure/kafka/ActionLogConsumer.java
- presentation/controller/KafkaTestController.java

## 테스트
- [x] Swagger POST /test/kafka → action.log 토픽 발행
- [x] ActionLogConsumer 수신 및 actionType 분기 로그 확인

## 참고 사항
- KafkaTestController는 테스트 전용, 실제 구현 완료 후 삭제 예정
- Consumer가 수신한 메시지는 현재 로그 출력만 (벡터 갱신 로직은 추후 구현)