### PR TITLE
[AI] feat: Elasticsearch 인덱스 매핑 설정 및 초기화 구현

### DIFF
--- a/ai/src/main/java/org/example/ai/domain/model/UserVector.java
+++ b/ai/src/main/java/org/example/ai/domain/model/UserVector.java
@@ -11,46 +11,37 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 
 @Getter
 @Builder
-@Document(indexName = "user-index")
+@Document(indexName = "user-index", createIndex = false)
 public class UserVector {
 
     @Id
     private String id;
 
     // ============ 장기 취향 벡터 ============ //
-    @Field(type = FieldType.Dense_Vector)
     private float[] preferenceVector;
 
-    @Field(type = FieldType.Float)
     private float preferenceWeightSum;
     // ===================================== //
 
     // ============ 구매 의도 벡터 ============ //
-    @Field(type = FieldType.Dense_Vector)
     private float[] cartVector;
 
-    @Field(type = FieldType.Float)
     private float cartWeightSum;
     // ===================================== //
 
     // ============ 최근 관심 벡터 ============ //
-    @Field(type = FieldType.Dense_Vector)
     private float[] recentVector;
 
-    @Field(type = FieldType.Float)
     private float recentWeightSum;
     // ===================================== //
 
     // ============ 부정 신호 vector ============ //
-    @Field(type = FieldType.Dense_Vector)
     private float[] negativeVector;
 
-    @Field(type = FieldType.Float)
     private float negativeWeightSum;
     // ===================================== //
 
     // vector 갱신 시각
-    @Field(type = FieldType.Date)
     private String updatedAt;
 
 

--- a/ai/src/main/java/org/example/ai/infrastructure/config/ElasticsearchConfig.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/config/ElasticsearchConfig.java
@@ -16,7 +16,6 @@ public class ElasticsearchConfig extends ElasticsearchConfiguration {
     public ClientConfiguration clientConfiguration() {
         return ClientConfiguration.builder()
             .connectedTo(uri.replace("https://", "").replace("http://", ""))
-            .usingSsl()
             .build();
     }
 }

--- a/ai/src/main/java/org/example/ai/infrastructure/config/ElasticsearchIndexInitializer.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/config/ElasticsearchIndexInitializer.java
@@ -1,0 +1,54 @@
+package org.example.ai.infrastructure.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import jakarta.annotation.PostConstruct;
+import java.io.InputStream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ElasticsearchIndexInitializer {
+
+    private final ElasticsearchClient elasticsearchClient;
+
+    @PostConstruct
+    public void init(){
+        createIndexIfNotExists("user-index", "elasticsearch/user-index-mapping.json");
+    }
+
+    private void createIndexIfNotExists(String indexName, String mappingFilePath){
+
+        try{
+            // index가 존재하면 -> 스킵
+            boolean exists = elasticsearchClient.indices()
+                .exists(e -> e.index(indexName))
+                .value();
+
+            if(exists){
+                log.info("[ES] 인덱스 이미 존재 : {}", indexName);
+                return;
+            }
+
+            // JSON 파일 -> 인덱스 생성
+            InputStream mappingStream = new ClassPathResource(mappingFilePath).getInputStream();
+
+            elasticsearchClient.indices().create(c -> c
+                .index(indexName)
+                .withJson(mappingStream)
+            );
+
+            log.info("[ES] 인덱스 생성 완료: {}", indexName);
+
+        } catch (Exception e){
+            log.error("[ES] 인덱스 생성 실패: {}", indexName, e);
+        }
+
+
+
+    }
+
+}

--- a/ai/src/main/resources/elasticsearch/user-index-mapping.json
+++ b/ai/src/main/resources/elasticsearch/user-index-mapping.json
@@ -1,0 +1,44 @@
+{
+  "mappings": {
+    "properties": {
+      "userId": {
+        "type": "keyword"
+      },
+      "preferenceVector": {
+        "type": "dense_vector",
+        "dims": 1536,
+        "index": false
+      },
+      "preferenceWeightSum": {
+        "type": "float"
+      },
+      "recentVector": {
+        "type": "dense_vector",
+        "dims": 1536,
+        "index": false
+      },
+      "recentWeightSum": {
+        "type": "float"
+      },
+      "cartVector": {
+        "type": "dense_vector",
+        "dims": 1536,
+        "index": false
+      },
+      "cartWeightSum": {
+        "type": "float"
+      },
+      "negativeVector": {
+        "type": "dense_vector",
+        "dims": 1536,
+        "index": false
+      },
+      "negativeWeightSum": {
+        "type": "float"
+      },
+      "updatedAt": {
+        "type": "date"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- close #342

## 작업 내용
- user-index-mapping.json 생성 (dense_vector dims/index 명시)
- ElasticsearchIndexInitializer 구현 (@PostConstruct로 앱 시작 시 인덱스 자동 생성)
- UserVector @Field 제거 및 createIndex = false 설정
- ElasticsearchConfig usingSsl() 제거 (HTTP 연결로 수정)

## 변경 사항
- src/main/resources/elasticsearch/user-index-mapping.json (신규)
- infrastructure/config/ElasticsearchIndexInitializer.java (신규)
- infrastructure/config/ElasticsearchConfig.java
- domain/model/UserVector.java

## 테스트
- [x] AI Service 실행 시 user-index 생성 완료 로그 확인
- [x] http://localhost:9200/user-index/_mapping 매핑 구조 확인

## 참고 사항
- @Field 어노테이션 방식은 dims 미설정으로 kNN 검색 시 인덱스 재생성 필요
- JSON 매핑 파일 방식으로 변경하여 초기 스펙 명확화
- event-index는 Event Service 담당, AI Service는 읽기 전용