### PR TITLE
[Event] feat: Admin페이지 연결

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventInternalService.java
+++ b/event/src/main/java/com/devticket/event/application/EventInternalService.java
@@ -52,14 +52,20 @@ public class EventInternalService {
         UUID sellerId,
         Pageable pageable
     ) {
-        Page<InternalAdminEventResponse> page = eventRepository
-            .searchEvents(keyword, status, sellerId, pageable)
-            .map(event -> {
-                String sellerNickname = memberClient.getNickname(event.getSellerId());
-                return InternalAdminEventResponse.of(event, sellerNickname);
-            });
+        Page<Event> page = eventRepository.searchEvents(keyword, status, sellerId, pageable);
 
-        return InternalPagedEventResponse.from(page);
+        List<UUID> sellerIds = page.getContent().stream()
+            .map(Event::getSellerId)
+            .distinct()
+            .toList();
+
+        Map<UUID, String> nicknameMap = memberClient.getNicknames(sellerIds);
+
+        return InternalPagedEventResponse.from(
+            page.map(event -> InternalAdminEventResponse.of(
+                event, nicknameMap.getOrDefault(event.getSellerId(), "")
+            ))
+        );
     }
 
     /**

--- a/event/src/main/java/com/devticket/event/application/EventInternalService.java
+++ b/event/src/main/java/com/devticket/event/application/EventInternalService.java
@@ -4,12 +4,15 @@ import com.devticket.event.common.exception.BusinessException;
 import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.domain.exception.EventErrorCode;
 import com.devticket.event.domain.model.Event;
+import com.devticket.event.infrastructure.client.MemberClient;
 import com.devticket.event.infrastructure.persistence.EventRepository;
 import com.devticket.event.infrastructure.search.EventDocument;
 import com.devticket.event.infrastructure.search.EventSearchRepository;
+import com.devticket.event.presentation.dto.internal.InternalAdminEventResponse;
 import com.devticket.event.presentation.dto.internal.InternalBulkEventInfoResponse;
 import com.devticket.event.presentation.dto.internal.InternalBulkStockAdjustmentRequest;
 import com.devticket.event.presentation.dto.internal.InternalEventInfoResponse;
+import com.devticket.event.presentation.dto.internal.InternalPagedEventResponse;
 import com.devticket.event.presentation.dto.internal.InternalPurchaseValidationResponse;
 import com.devticket.event.presentation.dto.internal.InternalSellerEventsResponse;
 import com.devticket.event.presentation.dto.internal.InternalStockAdjustmentResponse;
@@ -27,6 +30,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +43,24 @@ public class EventInternalService {
 
     private final EventRepository eventRepository;
     private final EventSearchRepository eventSearchRepository;
+    private final MemberClient memberClient;
+
+    @Transactional(readOnly = true)
+    public InternalPagedEventResponse searchEvents(
+        String keyword,
+        EventStatus status,
+        UUID sellerId,
+        Pageable pageable
+    ) {
+        Page<InternalAdminEventResponse> page = eventRepository
+            .searchEvents(keyword, status, sellerId, pageable)
+            .map(event -> {
+                String sellerNickname = memberClient.getNickname(event.getSellerId());
+                return InternalAdminEventResponse.of(event, sellerNickname);
+            });
+
+        return InternalPagedEventResponse.from(page);
+    }
 
     /**
      * API 1: 단건 이벤트 정보 조회

--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -65,8 +65,7 @@ public class EventService {
             throw new BusinessException(EventErrorCode.INVALID_EVENT_DATE);
         }
 
-        LocalDateTime deadline = request.saleStartAt().minusDays(3);
-        if (LocalDateTime.now().isAfter(deadline)) {
+        if (request.saleStartAt().isBefore(LocalDateTime.now())) {
             throw new BusinessException(EventErrorCode.REGISTRATION_TIME_EXCEEDED);
         }
 

--- a/event/src/main/java/com/devticket/event/domain/exception/EventErrorCode.java
+++ b/event/src/main/java/com/devticket/event/domain/exception/EventErrorCode.java
@@ -16,7 +16,7 @@ public enum EventErrorCode implements ErrorCode {
     OUT_OF_STOCK(409, "EVENT_006", "티켓 잔여 수량이 부족합니다."),
     CANNOT_CHANGE_STATUS(400, "EVENT_007", "변경할 수 없는 이벤트 상태입니다."),
     UNAUTHORIZED_SELLER(403, "EVENT_008", "해당 이벤트에 대한 권한이 없습니다."),
-    REGISTRATION_TIME_EXCEEDED(400, "EVENT_005", "이벤트는 판매 시작일 기준 3일 전까지 등록 가능합니다."),
+    REGISTRATION_TIME_EXCEEDED(400, "EVENT_005", "판매 시작일은 현재 시간 이후여야 합니다"),
     INVALID_SALE_PERIOD(400, "EVENT_014", "판매 시작 시각은 판매 종료 시각 이전이어야 합니다."),
     INVALID_EVENT_DATE(400, "EVENT_015", "판매 종료 시각은 행사 일시 이전이어야 합니다."),
     MAX_QUANTITY_EXCEEDED(400, "EVENT_016", "인당 최대 구매 수량은 총 수량을 초과할 수 없습니다."),

--- a/event/src/main/java/com/devticket/event/infrastructure/client/MemberClient.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/MemberClient.java
@@ -3,8 +3,11 @@ package com.devticket.event.infrastructure.client;
 import com.devticket.event.infrastructure.client.dto.InternalMemberInfoResponse;
 import com.devticket.event.infrastructure.client.dto.TechStackItem;
 import com.devticket.event.infrastructure.client.dto.TechStackListResponse;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,6 +33,31 @@ public class MemberClient {
             return response != null ? response.nickname() : null;
         } catch (Exception e) {
             return null; // 장애 시 null 허용 (이벤트 상세 자체는 살림)
+        }
+    }
+
+    public Map<UUID, String> getNicknames(List<UUID> sellerIds) {
+        if (sellerIds == null || sellerIds.isEmpty()) {
+            return Map.of();
+        }
+        try {
+            String ids = sellerIds.stream()
+                .map(UUID::toString)
+                .collect(Collectors.joining(","));
+            InternalMemberInfoResponse[] responses = restTemplate.getForObject(
+                memberServiceUrl + "/internal/members/batch?userIds=" + ids,
+                InternalMemberInfoResponse[].class
+            );
+            if (responses == null) return Map.of();
+            return Arrays.stream(responses)
+                .collect(Collectors.toMap(
+                    r -> UUID.fromString(r.userId()),
+                    r -> r.nickname() != null ? r.nickname() : "",
+                    (a, b) -> a
+                ));
+        } catch (Exception e) {
+            log.warn("[배치 닉네임 조회 실패] Member 서비스 호출 오류", e);
+            return Map.of();
         }
     }
 

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
@@ -23,7 +23,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     WHERE (:keyword IS NULL OR e.title LIKE CONCAT('%', :keyword, '%'))
       AND (:status IS NULL OR e.status = :status)
       AND (:sellerId IS NULL OR e.sellerId = :sellerId)
-""")
+    ORDER BY e.createdAt DESC
+    """)
     Page<Event> searchEvents(
         @Param("keyword") String keyword,
         @Param("status") EventStatus status,

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
@@ -7,6 +7,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -15,6 +17,19 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
+
+    @Query("""
+    SELECT e FROM Event e
+    WHERE (:keyword IS NULL OR e.title LIKE CONCAT('%', :keyword, '%'))
+      AND (:status IS NULL OR e.status = :status)
+      AND (:sellerId IS NULL OR e.sellerId = :sellerId)
+""")
+    Page<Event> searchEvents(
+        @Param("keyword") String keyword,
+        @Param("status") EventStatus status,
+        @Param("sellerId") UUID sellerId,
+        Pageable pageable
+    );
 
     // 외부 API
     List<Event> findAllByEventIdIn(List<UUID> eventIds);

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventInternalController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventInternalController.java
@@ -6,6 +6,7 @@ import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.presentation.dto.internal.InternalBulkEventInfoRequest;
 import com.devticket.event.presentation.dto.internal.InternalBulkEventInfoResponse;
 import com.devticket.event.presentation.dto.internal.InternalBulkStockAdjustmentRequest;
+import com.devticket.event.presentation.dto.internal.InternalPagedEventResponse;
 import com.devticket.event.presentation.dto.internal.InternalStockAdjustmentResponse;
 import com.devticket.event.presentation.dto.internal.InternalEventInfoResponse;
 import com.devticket.event.presentation.dto.internal.InternalPurchaseValidationResponse;
@@ -18,6 +19,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -35,6 +37,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class EventInternalController {
 
     private final EventInternalService eventInternalService;
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<InternalPagedEventResponse>> getEvents(
+        @RequestParam(required = false) String keyword,
+        @RequestParam(required = false) EventStatus status,
+        @RequestParam(required = false) UUID sellerId,
+        Pageable pageable
+    ) {
+        return ResponseEntity.ok(SuccessResponse.success(
+            eventInternalService.searchEvents(keyword, status, sellerId, pageable)
+        ));
+    }
 
     /**
      * API 1: 단건 이벤트 정보 조회

--- a/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalAdminEventResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalAdminEventResponse.java
@@ -1,0 +1,27 @@
+package com.devticket.event.presentation.dto.internal;
+
+import com.devticket.event.domain.model.Event;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record InternalAdminEventResponse(
+    UUID eventId,
+    String title,
+    String sellerNickname,
+    String status,
+    LocalDateTime eventDateTime,
+    Integer totalQuantity,
+    Integer remainingQuantity
+) {
+    public static InternalAdminEventResponse of(Event event, String sellerNickname) {
+        return new InternalAdminEventResponse(
+            event.getEventId(),
+            event.getTitle(),
+            sellerNickname,
+            event.getStatus().name(),
+            event.getEventDateTime(),
+            event.getTotalQuantity(),
+            event.getRemainingQuantity()
+        );
+    }
+}

--- a/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalPagedEventResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalPagedEventResponse.java
@@ -1,0 +1,22 @@
+package com.devticket.event.presentation.dto.internal;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record InternalPagedEventResponse(
+    List<InternalAdminEventResponse> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages
+) {
+    public static InternalPagedEventResponse from(Page<InternalAdminEventResponse> page) {
+        return new InternalPagedEventResponse(
+            page.getContent(),
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages()
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용
- Event 서비스의 내부 관리자용 API를 추가해 Admin 백오피스 연동을 진행했습니다.
- 관리자 이벤트 목록 조회 API를 페이징 + 조건 검색(keyword/status/sellerId) 기반으로 구현했습니다.
- 이벤트 목록 조회 시 판매자 닉네임을 배치 조회해 매핑하는 방식으로 개선했습니다.
- 이벤트 등록 시 “판매 시작일 3일 전 제한” 로직을 제거하고, 판매 시작일이 현재 시각 이후인지 검증하도록 변경했습니다.
- 관련 에러 메시지를 변경된 검증 로직에 맞게 조정했습니다.

## 변경 사항
- `EventInternalService`
  - `searchEvents(...)` 추가 (조건 검색 + pageable)
  - sellerId 목록 추출 후 `MemberClient`를 통해 닉네임 맵 구성
- `EventInternalController`
  - 내부 관리자용 이벤트 목록 조회 `GET` 엔드포인트 추가
- `EventRepository`
  - 조건 검색용 `searchEvents(...)` 쿼리 메서드 추가
- `MemberClient`
  - 판매자 닉네임 조회 연동 코드 추가
- DTO 추가
  - `InternalAdminEventResponse`
  - `InternalPagedEventResponse`
- `EventService`, `EventErrorCode`
  - 판매 시작일 검증/메시지 수정

## 테스트
- [ ] 단위 테스트 통과  
  - GitHub Checks: `CI - Event Service / build-and-test` failed (Apr 14, 2026, exit code 1)
- [ ] 통합 테스트 통과 (해당 시)

## 관련 문서
- API 문서 링크: 없음 (PR 본문/변경 파일 내 별도 링크 확인 불가)
- ERD 변경 여부: 없음 (DB 스키마 변경 파일 확인 불가)