### PR TITLE
[member] feat: Admin페이지 연결

### DIFF
--- a/member/src/main/java/com/devticket/member/application/InternalMemberService.java
+++ b/member/src/main/java/com/devticket/member/application/InternalMemberService.java
@@ -4,6 +4,7 @@ import com.devticket.member.common.exception.BusinessException;
 import com.devticket.member.presentation.domain.MemberErrorCode;
 import com.devticket.member.presentation.domain.SellerApplicationDecision;
 import com.devticket.member.presentation.domain.UserRole;
+import com.devticket.member.presentation.domain.UserStatus;
 import com.devticket.member.presentation.domain.model.SellerApplication;
 import com.devticket.member.presentation.domain.model.TechStack;
 import com.devticket.member.presentation.domain.model.User;
@@ -13,17 +14,23 @@ import com.devticket.member.presentation.domain.repository.TechStackRepository;
 import com.devticket.member.presentation.domain.repository.UserProfileRepository;
 import com.devticket.member.presentation.domain.repository.UserRepository;
 import com.devticket.member.presentation.dto.internal.request.InternalDecideSellerApplicationRequest;
+import com.devticket.member.presentation.dto.internal.request.InternalUpdateUserRoleRequest;
+import com.devticket.member.presentation.dto.internal.request.InternalUpdateUserStatusRequest;
 import com.devticket.member.presentation.dto.internal.response.InternalDecideSellerApplicationResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberInfoResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberRoleResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberStatusResponse;
+import com.devticket.member.presentation.dto.internal.response.InternalPagedMemberResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalSellerApplicationResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalSellerInfoResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalTechStackListResponse;
+import com.devticket.member.presentation.dto.internal.response.InternalUpdateRoleResponse;
+import com.devticket.member.presentation.dto.internal.response.InternalUpdateStatusResponse;
 import java.util.List;
-import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +50,45 @@ public class InternalMemberService {
             .map(UserProfile::getNickname)
             .orElse(null);
         return InternalMemberInfoResponse.from(user, nickname);
+    }
+
+    // 관리자 회원 목록 조회 (paged)
+    public InternalPagedMemberResponse searchMembers(
+        UserRole role, UserStatus status, String keyword, Pageable pageable
+    ) {
+        Page<InternalMemberInfoResponse> page = userRepository
+            .searchMembers(role, status, keyword, pageable)
+            .map(user -> {
+                String nickname = userProfileRepository.findByUserId(user.getId())
+                    .map(UserProfile::getNickname)
+                    .orElse("");  // FE가 nickname.charAt(0) 호출 → null 금지
+                return InternalMemberInfoResponse.from(user, nickname);
+            });
+        return InternalPagedMemberResponse.from(page);
+    }
+
+    // 관리자 회원 상태 변경
+    @Transactional
+    public InternalUpdateStatusResponse updateMemberStatus(
+        UUID userId, InternalUpdateUserStatusRequest request
+    ) {
+        User user = findUserByUuidOrThrow(userId);
+        switch (request.status()) {
+            case ACTIVE -> user.reactivate();
+            case SUSPENDED -> user.suspend();
+            case WITHDRAWN -> user.withdraw();
+        }
+        return InternalUpdateStatusResponse.from(user);
+    }
+
+    // 관리자 회원 권한 변경
+    @Transactional
+    public InternalUpdateRoleResponse updateMemberRole(
+        UUID userId, InternalUpdateUserRoleRequest request
+    ) {
+        User user = findUserByUuidOrThrow(userId);
+        user.changeRole(request.role());
+        return InternalUpdateRoleResponse.from(user);
     }
 
     public InternalMemberStatusResponse getMemberStatus(UUID userId) {

--- a/member/src/main/java/com/devticket/member/application/InternalMemberService.java
+++ b/member/src/main/java/com/devticket/member/application/InternalMemberService.java
@@ -27,6 +27,7 @@ import com.devticket.member.presentation.dto.internal.response.InternalTechStack
 import com.devticket.member.presentation.dto.internal.response.InternalUpdateRoleResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalUpdateStatusResponse;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.data.domain.Pageable;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -84,6 +85,21 @@ public class InternalMemberService {
         User user = findUserByUuidOrThrow(userId);
         user.changeRole(request.role());
         return InternalUpdateRoleResponse.from(user);
+    }
+
+    public List<InternalMemberInfoResponse> getMemberInfoBatch(List<UUID> userIds) {
+        return userIds.stream()
+            .distinct()
+            .map(userId -> userRepository.findByUserId(userId)
+                .map(user -> {
+                    String nickname = userProfileRepository.findByUserId(user.getId())
+                        .map(UserProfile::getNickname)
+                        .orElse("");
+                    return InternalMemberInfoResponse.from(user, nickname);
+                })
+                .orElse(null))
+            .filter(Objects::nonNull)
+            .toList();
     }
 
     public InternalMemberStatusResponse getMemberStatus(UUID userId) {

--- a/member/src/main/java/com/devticket/member/application/InternalMemberService.java
+++ b/member/src/main/java/com/devticket/member/application/InternalMemberService.java
@@ -57,13 +57,8 @@ public class InternalMemberService {
         UserRole role, UserStatus status, String keyword, Pageable pageable
     ) {
         Page<InternalMemberInfoResponse> page = userRepository
-            .searchMembers(role, status, keyword, pageable)
-            .map(user -> {
-                String nickname = userProfileRepository.findByUserId(user.getId())
-                    .map(UserProfile::getNickname)
-                    .orElse("");  // FE가 nickname.charAt(0) 호출 → null 금지
-                return InternalMemberInfoResponse.from(user, nickname);
-            });
+            .searchMembersWithNickname(role, status, keyword, pageable)
+            .map(row -> InternalMemberInfoResponse.from((User) row[0], (String) row[1]));
         return InternalPagedMemberResponse.from(page);
     }
 

--- a/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
+++ b/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
@@ -180,7 +180,7 @@ public class InternalMemberController {
         @ApiResponse(responseCode = "200", description = "조회 성공"),
         @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 파라미터")
     })
-    @GetMapping("/internal/members/batch")
+    @GetMapping("/batch")
     public ResponseEntity<List<InternalMemberInfoResponse>> getMemberInfoBatch(
         @Parameter(description = "조회할 회원 UUID 목록", example = "uuid1,uuid2,uuid3")
         @RequestParam List<UUID> userIds

--- a/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
+++ b/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
@@ -17,6 +17,7 @@ import com.devticket.member.presentation.dto.internal.response.InternalTechStack
 import com.devticket.member.presentation.dto.internal.response.InternalUpdateRoleResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalUpdateStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -172,5 +173,18 @@ public class InternalMemberController {
         @Valid @RequestBody InternalUpdateUserRoleRequest request
     ) {
         return ResponseEntity.ok(internalMemberService.updateMemberRole(userId, request));
+    }
+
+    @Operation(summary = "배치 회원 정보 조회", description = "내부 서비스용 — 여러 회원의 정보를 한 번에 조회")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 파라미터")
+    })
+    @GetMapping("/internal/members/batch")
+    public ResponseEntity<List<InternalMemberInfoResponse>> getMemberInfoBatch(
+        @Parameter(description = "조회할 회원 UUID 목록", example = "uuid1,uuid2,uuid3")
+        @RequestParam List<UUID> userIds
+    ) {
+        return ResponseEntity.ok(internalMemberService.getMemberInfoBatch(userIds));
     }
 }

--- a/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
+++ b/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
@@ -1,28 +1,39 @@
 package com.devticket.member.presentation.controller;
 
 import com.devticket.member.application.InternalMemberService;
+import com.devticket.member.presentation.domain.UserRole;
+import com.devticket.member.presentation.domain.UserStatus;
 import com.devticket.member.presentation.dto.internal.request.InternalDecideSellerApplicationRequest;
+import com.devticket.member.presentation.dto.internal.request.InternalUpdateUserRoleRequest;
+import com.devticket.member.presentation.dto.internal.request.InternalUpdateUserStatusRequest;
 import com.devticket.member.presentation.dto.internal.response.InternalDecideSellerApplicationResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberInfoResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberRoleResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberStatusResponse;
+import com.devticket.member.presentation.dto.internal.response.InternalPagedMemberResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalSellerApplicationResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalSellerInfoResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalTechStackListResponse;
+import com.devticket.member.presentation.dto.internal.response.InternalUpdateRoleResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalUpdateStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Internal - Member", description = "내부 서비스 연동 API (JWT 검증 없음)")
@@ -123,13 +134,43 @@ public class InternalMemberController {
         return ResponseEntity.ok(response);
     }
 
-//    @Operation(summary = "회원 상태 변경", description = "내부 서비스용 — 어드민의 회원 상태 변경")
-//    @ApiResponses({
-//        @ApiResponse(responseCode = "200", description = "변경 성공"),
-//        @ApiResponse(responseCode = "404", description = "회원 없음")
-//    })
-//    @PatchMapping("/{userId}/status")
-//    public ResponseEntity<InternalUpdateStatusResponse> updateMemberStatus(){
-//
-//    }
+    @Operation(summary = "관리자 회원 목록 조회",
+        description = "내부 서비스용 — 관리자 백오피스 회원 목록 조회 (role/status/keyword 필터 + 페이징)")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping
+    public ResponseEntity<InternalPagedMemberResponse> searchMembers(
+        @RequestParam(required = false) UserRole role,
+        @RequestParam(required = false) UserStatus status,
+        @RequestParam(required = false) String keyword,
+        @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(internalMemberService.searchMembers(role, status, keyword, pageable));
+    }
+
+    @Operation(summary = "관리자 회원 상태 변경", description = "내부 서비스용 — 관리자의 회원 제재/해제")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "변경 성공"),
+        @ApiResponse(responseCode = "403", description = "탈퇴된 계정 재활성화 시도 (MEMBER_008)"),
+        @ApiResponse(responseCode = "404", description = "회원 없음 (MEMBER_009)")
+    })
+    @PatchMapping("/{userId}/status")
+    public ResponseEntity<InternalUpdateStatusResponse> updateMemberStatus(
+        @PathVariable UUID userId,
+        @Valid @RequestBody InternalUpdateUserStatusRequest request
+    ) {
+        return ResponseEntity.ok(internalMemberService.updateMemberStatus(userId, request));
+    }
+
+    @Operation(summary = "관리자 회원 권한 변경", description = "내부 서비스용 — 관리자의 회원 권한 변경")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "변경 성공"),
+        @ApiResponse(responseCode = "404", description = "회원 없음 (MEMBER_009)")
+    })
+    @PatchMapping("/{userId}/role")
+    public ResponseEntity<InternalUpdateRoleResponse> updateMemberRole(
+        @PathVariable UUID userId,
+        @Valid @RequestBody InternalUpdateUserRoleRequest request
+    ) {
+        return ResponseEntity.ok(internalMemberService.updateMemberRole(userId, request));
+    }
 }

--- a/member/src/main/java/com/devticket/member/presentation/domain/model/User.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/model/User.java
@@ -84,6 +84,14 @@ public class User {
         this.createdAt = LocalDateTime.now();
     }
 
+    public void reactivate() {
+        if (this.status == UserStatus.WITHDRAWN) {
+            throw new BusinessException(MemberErrorCode.ACCOUNT_WITHDRAWN);
+        }
+        this.status = UserStatus.ACTIVE;
+        this.updatedAt = LocalDateTime.now();
+    }
+
     public void suspend() {
         if (this.status == UserStatus.WITHDRAWN) {
             throw new BusinessException(MemberErrorCode.ACCOUNT_WITHDRAWN);

--- a/member/src/main/java/com/devticket/member/presentation/domain/repository/UserRepository.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/repository/UserRepository.java
@@ -21,25 +21,25 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query(
         value = """
-        SELECT u FROM User u
-        LEFT JOIN UserProfile p ON p.userId = u.id
-        WHERE (:role IS NULL OR u.role = :role)
-          AND (:status IS NULL OR u.status = :status)
-          AND (:keyword IS NULL OR :keyword = ''
-               OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
-               OR LOWER(p.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
-    """,
+    SELECT u, COALESCE(p.nickname, '') FROM User u
+    LEFT JOIN UserProfile p ON p.userId = u.id
+    WHERE (:role IS NULL OR u.role = :role)
+      AND (:status IS NULL OR u.status = :status)
+      AND (:keyword IS NULL OR :keyword = ''
+           OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
+           OR LOWER(p.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
+""",
         countQuery = """
-        SELECT COUNT(u) FROM User u
-        LEFT JOIN UserProfile p ON p.userId = u.id
-        WHERE (:role IS NULL OR u.role = :role)
-          AND (:status IS NULL OR u.status = :status)
-          AND (:keyword IS NULL OR :keyword = ''
-               OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
-               OR LOWER(p.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
-    """
+    SELECT COUNT(u) FROM User u
+    LEFT JOIN UserProfile p ON p.userId = u.id
+    WHERE (:role IS NULL OR u.role = :role)
+      AND (:status IS NULL OR u.status = :status)
+      AND (:keyword IS NULL OR :keyword = ''
+           OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
+           OR LOWER(p.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
+"""
     )
-    Page<User> searchMembers(
+    Page<Object[]> searchMembersWithNickname(
         @Param("role") UserRole role,
         @Param("status") UserStatus status,
         @Param("keyword") String keyword,

--- a/member/src/main/java/com/devticket/member/presentation/domain/repository/UserRepository.java
+++ b/member/src/main/java/com/devticket/member/presentation/domain/repository/UserRepository.java
@@ -2,11 +2,16 @@ package com.devticket.member.presentation.domain.repository;
 
 import com.devticket.member.presentation.domain.ProviderType;
 import com.devticket.member.presentation.domain.UserRole;
+import com.devticket.member.presentation.domain.UserStatus;
 import com.devticket.member.presentation.domain.model.User;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -14,7 +19,32 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUserId(UUID userId);
 
-    Optional<User> findSellerById(Long id);
+    @Query(
+        value = """
+        SELECT u FROM User u
+        LEFT JOIN UserProfile p ON p.userId = u.id
+        WHERE (:role IS NULL OR u.role = :role)
+          AND (:status IS NULL OR u.status = :status)
+          AND (:keyword IS NULL OR :keyword = ''
+               OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
+               OR LOWER(p.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
+    """,
+        countQuery = """
+        SELECT COUNT(u) FROM User u
+        LEFT JOIN UserProfile p ON p.userId = u.id
+        WHERE (:role IS NULL OR u.role = :role)
+          AND (:status IS NULL OR u.status = :status)
+          AND (:keyword IS NULL OR :keyword = ''
+               OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
+               OR LOWER(p.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
+    """
+    )
+    Page<User> searchMembers(
+        @Param("role") UserRole role,
+        @Param("status") UserStatus status,
+        @Param("keyword") String keyword,
+        Pageable pageable
+    );
 
     boolean existsByEmail(String email);
 

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/request/InternalUpdateUserRoleRequest.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/request/InternalUpdateUserRoleRequest.java
@@ -1,0 +1,8 @@
+package com.devticket.member.presentation.dto.internal.request;
+
+import com.devticket.member.presentation.domain.UserRole;
+import jakarta.validation.constraints.NotNull;
+
+public record InternalUpdateUserRoleRequest(
+    @NotNull UserRole role
+) {}

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/request/InternalUpdateUserStatusRequest.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/request/InternalUpdateUserStatusRequest.java
@@ -1,0 +1,8 @@
+package com.devticket.member.presentation.dto.internal.request;
+
+import com.devticket.member.presentation.domain.UserStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record InternalUpdateUserStatusRequest(
+    @NotNull UserStatus status
+) {}

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalMemberInfoResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalMemberInfoResponse.java
@@ -1,6 +1,7 @@
 package com.devticket.member.presentation.dto.internal.response;
 
 import com.devticket.member.presentation.domain.model.User;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record InternalMemberInfoResponse(
@@ -9,9 +10,10 @@ public record InternalMemberInfoResponse(
     String nickname,
     String role,
     String status,
-    String providerType
+    String providerType,
+    LocalDateTime createdAt,
+    LocalDateTime withdrawnAt
 ) {
-
     public static InternalMemberInfoResponse from(User user, String nickname) {
         return new InternalMemberInfoResponse(
             user.getUserId(),
@@ -19,7 +21,9 @@ public record InternalMemberInfoResponse(
             nickname,
             user.getRole().name(),
             user.getStatus().name(),
-            user.getProviderType().name()
+            user.getProviderType().name(),
+            user.getCreatedAt(),
+            user.getWithdrawnAt()
         );
     }
 }

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalPagedMemberResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalPagedMemberResponse.java
@@ -1,0 +1,22 @@
+package com.devticket.member.presentation.dto.internal.response;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record InternalPagedMemberResponse(
+    List<InternalMemberInfoResponse> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages
+) {
+    public static InternalPagedMemberResponse from(Page<InternalMemberInfoResponse> page) {
+        return new InternalPagedMemberResponse(
+            page.getContent(),
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages()
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용
- Member 서비스의 내부 관리자용 API를 확장해 Admin 백오피스 연동 기능을 추가했습니다.
- 관리자 회원 목록 조회 API를 페이징 기반으로 구현했습니다. (role/status/keyword + pageable)
- 관리자 회원 상태 변경 및 권한 변경 API를 내부용으로 정리했습니다.
- 배치 회원 조회 Internal API를 추가/보완했습니다.
- 회원 목록 조회 시 닉네임 조회 로직을 쿼리 기반으로 정리하여 N+1 문제를 개선했습니다.

## 변경 사항
- `InternalMemberService`  
  - 관리자 회원 목록 조회(`searchMembers`) 추가  
  - 관리자 회원 상태/권한 변경 로직 추가  
  - 배치 회원 조회(`getMemberInfoBatch`) 보완
- `InternalMemberController`  
  - 관리자 목록 조회, 상태 변경, 권한 변경 엔드포인트 추가/정리
- `User`  
  - 상태 전이 메서드(`reactivate`, `suspend` 등) 보완
- `UserRepository`  
  - `searchMembersWithNickname(...)` 쿼리 추가 (이메일/닉네임 키워드 검색 + 페이징)
- DTO 추가
  - `InternalUpdateUserRoleRequest`
  - `InternalUpdateUserStatusRequest`
  - `InternalMemberInfoResponse`
  - `InternalPagedMemberResponse`

## 테스트
- [x] 단위 테스트 통과  
  - GitHub Checks: `CI - Member Service / build-and-test` succeeded (Apr 15, 2026)
- [ ] 통합 테스트 통과 (해당 시)

## 관련 문서
- API 문서 링크: 없음 (PR 본문/변경 파일 내 별도 링크 확인 불가)
- ERD 변경 여부: 없음 (DB 스키마 변경 파일 확인 불가)