### PR TITLE
[Admin] feat: Admin 서비스 내부 모듈과 연동

### DIFF
--- a/admin/src/main/java/com/devticket/admin/application/service/AdminEventService.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/AdminEventService.java
@@ -1,0 +1,10 @@
+package com.devticket.admin.application.service;
+
+import com.devticket.admin.presentation.dto.req.AdminEventSearchRequest;
+import com.devticket.admin.presentation.dto.res.AdminEventListResponse;
+import java.util.UUID;
+
+public interface AdminEventService {
+    AdminEventListResponse getEventList(AdminEventSearchRequest condition);
+    void forceCancel(UUID adminId, UUID eventId);
+}

--- a/admin/src/main/java/com/devticket/admin/application/service/AdminEventServiceImpl.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/AdminEventServiceImpl.java
@@ -1,0 +1,50 @@
+package com.devticket.admin.application.service;
+
+import com.devticket.admin.domain.model.AdminActionHistory;
+import com.devticket.admin.domain.model.AdminActionType;
+import com.devticket.admin.domain.model.AdminTargetType;
+import com.devticket.admin.domain.repository.AdminActionRepository;
+import com.devticket.admin.infrastructure.external.client.EventInternalClient;
+import com.devticket.admin.infrastructure.external.dto.res.InternalAdminEventPageResponse;
+import com.devticket.admin.presentation.dto.req.AdminEventSearchRequest;
+import com.devticket.admin.presentation.dto.res.AdminEventListResponse;
+import com.devticket.admin.presentation.dto.res.AdminEventResponse;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminEventServiceImpl implements AdminEventService {
+
+    private final EventInternalClient eventInternalClient;
+    private final AdminActionRepository adminActionRepository;   // ← 인터페이스 타입!
+
+    @Override
+    public AdminEventListResponse getEventList(AdminEventSearchRequest condition) {
+        InternalAdminEventPageResponse page = eventInternalClient.getEvents(condition);
+        List<AdminEventResponse> content = page.content().stream()
+            .map(e -> new AdminEventResponse(
+                e.eventId(), e.title(), e.sellerNickname(), e.status(),
+                e.eventDateTime(), e.totalQuantity(), e.remainingQuantity(), e.createdAt()))
+            .toList();
+        return new AdminEventListResponse(content, page.page(), page.size(), page.totalElements(), page.totalPages());
+    }
+
+    @Override
+    @Transactional
+    public void forceCancel(UUID adminId, UUID eventId) {
+        eventInternalClient.forceCancel(eventId);
+        adminActionRepository.save(
+            AdminActionHistory.builder()
+                .adminId(adminId)
+                .targetType(AdminTargetType.EVENT)
+                .targetId(eventId)
+                .actionType(AdminActionType.FORCE_CANCEL_EVENT)   // ← 기존 enum 재사용
+                .build()
+        );
+    }
+}

--- a/admin/src/main/java/com/devticket/admin/application/service/AdminSettlementService.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/AdminSettlementService.java
@@ -1,0 +1,10 @@
+package com.devticket.admin.application.service;
+
+import com.devticket.admin.presentation.dto.req.AdminSettlementSearchRequest;
+import com.devticket.admin.presentation.dto.res.AdminSettelmentListResponse;
+import java.util.UUID;
+
+public interface AdminSettlementService {
+    AdminSettelmentListResponse getSettlementList(AdminSettlementSearchRequest condition);
+    void runSettlement(UUID adminId);
+}

--- a/admin/src/main/java/com/devticket/admin/application/service/AdminSettlementServiceImpl.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/AdminSettlementServiceImpl.java
@@ -32,7 +32,7 @@ public class AdminSettlementServiceImpl implements AdminSettlementService {
                 s.totalSalesAmount(), s.totalRefundAmount(), s.totalFeeAmount(),
                 s.finalSettlementAmount(), s.status(), s.settledAt()))
             .toList();
-        return new AdminSettelmentListResponse(content, page.page(), page.size(), page.totalElements(), page.totalPage());
+        return new AdminSettelmentListResponse(content, page.page(), page.size(), page.totalElements(), page.totalPages());
     }
 
     @Transactional

--- a/admin/src/main/java/com/devticket/admin/application/service/AdminSettlementServiceImpl.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/AdminSettlementServiceImpl.java
@@ -35,16 +35,16 @@ public class AdminSettlementServiceImpl implements AdminSettlementService {
         return new AdminSettelmentListResponse(content, page.page(), page.size(), page.totalElements(), page.totalPage());
     }
 
-    @Override
     @Transactional
     public void runSettlement(UUID adminId) {
-        settlementInternalClient.runSettlement();      // 중복이면 409(SETTLEMENT_002) → 전역 핸들러 변환
+        settlementInternalClient.runSettlement();
+
         adminActionRepository.save(
             AdminActionHistory.builder()
                 .adminId(adminId)
                 .targetType(AdminTargetType.SETTLEMENT)
-                .targetId(adminId)                     // run은 특정 대상이 없으니 논의 필요
-                .actionType(AdminActionType.FORCE_CANCEL_EVENT /* or 신규 RUN_SETTLEMENT */)
+                .targetId(null)                          // 특정 대상 없음
+                .actionType(AdminActionType.RUN_SETTLEMENT)
                 .build()
         );
     }

--- a/admin/src/main/java/com/devticket/admin/application/service/AdminSettlementServiceImpl.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/AdminSettlementServiceImpl.java
@@ -1,0 +1,51 @@
+package com.devticket.admin.application.service;
+
+import com.devticket.admin.domain.model.AdminActionHistory;
+import com.devticket.admin.domain.model.AdminActionType;
+import com.devticket.admin.domain.model.AdminTargetType;
+import com.devticket.admin.domain.repository.AdminActionRepository;
+import com.devticket.admin.infrastructure.external.client.SettlementInternalClient;
+import com.devticket.admin.infrastructure.external.dto.res.InternalSettlementPageResponse;
+import com.devticket.admin.presentation.dto.req.AdminSettlementSearchRequest;
+import com.devticket.admin.presentation.dto.res.AdminSettelmentListResponse;
+import com.devticket.admin.presentation.dto.res.SettlementResponse;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminSettlementServiceImpl implements AdminSettlementService {
+
+    private final SettlementInternalClient settlementInternalClient;
+    private final AdminActionRepository adminActionRepository;
+
+    @Override
+    public AdminSettelmentListResponse getSettlementList(AdminSettlementSearchRequest condition) {
+        InternalSettlementPageResponse page = settlementInternalClient.getSettlements(condition);
+        List<SettlementResponse> content = page.content().stream()
+            .map(s -> new SettlementResponse(
+                s.settlementId(), s.periodStart(), s.periodEnd(),
+                s.totalSalesAmount(), s.totalRefundAmount(), s.totalFeeAmount(),
+                s.finalSettlementAmount(), s.status(), s.settledAt()))
+            .toList();
+        return new AdminSettelmentListResponse(content, page.page(), page.size(), page.totalElements(), page.totalPage());
+    }
+
+    @Override
+    @Transactional
+    public void runSettlement(UUID adminId) {
+        settlementInternalClient.runSettlement();      // 중복이면 409(SETTLEMENT_002) → 전역 핸들러 변환
+        adminActionRepository.save(
+            AdminActionHistory.builder()
+                .adminId(adminId)
+                .targetType(AdminTargetType.SETTLEMENT)
+                .targetId(adminId)                     // run은 특정 대상이 없으니 논의 필요
+                .actionType(AdminActionType.FORCE_CANCEL_EVENT /* or 신규 RUN_SETTLEMENT */)
+                .build()
+        );
+    }
+}

--- a/admin/src/main/java/com/devticket/admin/application/service/AdminUserService.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/AdminUserService.java
@@ -3,13 +3,17 @@ package com.devticket.admin.application.service;
 import com.devticket.admin.presentation.dto.req.UserRoleRequest;
 import com.devticket.admin.presentation.dto.req.UserSearchCondition;
 import com.devticket.admin.presentation.dto.req.UserStatusRequest;
+import com.devticket.admin.presentation.dto.res.AdminUserListResponse;
+import com.devticket.admin.presentation.dto.res.UserDetailResponse;
 import com.devticket.admin.presentation.dto.res.UserListResponse;
 import java.util.List;
 import java.util.UUID;
 
 public interface AdminUserService {
 
-    List<UserListResponse> getMembers(UserSearchCondition condition);
+    AdminUserListResponse getMembers(UserSearchCondition condition);
+
+    UserDetailResponse getUserDetail(UUID userId);
 
     void penalizeUser(UUID adminId, UUID userId, UserStatusRequest request);
 

--- a/admin/src/main/java/com/devticket/admin/application/service/AdminUserServiceImpl.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/AdminUserServiceImpl.java
@@ -13,9 +13,9 @@ import com.devticket.admin.presentation.dto.req.UserStatusRequest;
 import com.devticket.admin.presentation.dto.res.AdminActionHistorySummary;
 import com.devticket.admin.presentation.dto.res.AdminUserListResponse;
 import com.devticket.admin.presentation.dto.res.InternalMemberDetailResponse;
+import com.devticket.admin.presentation.dto.res.InternalMemberPageResponse;
 import com.devticket.admin.presentation.dto.res.UserDetailResponse;
 import com.devticket.admin.presentation.dto.res.UserListItem;
-import com.devticket.admin.presentation.dto.res.UserListResponse;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -34,8 +34,9 @@ public class AdminUserServiceImpl implements AdminUserService {
 
     @Override
     public AdminUserListResponse getMembers(UserSearchCondition condition) {
+        InternalMemberPageResponse page = memberInternalClient.getMembers(condition);
 
-        List<UserListItem> content = memberInternalClient.getMembers(condition).stream()
+        List<UserListItem> content = page.content().stream()
             .map(member -> new UserListItem(
                 member.userId(),
                 member.email(),
@@ -50,10 +51,10 @@ public class AdminUserServiceImpl implements AdminUserService {
 
         return new AdminUserListResponse(
             content,
-            condition.page() == null ? 0 : condition.page(),
-            condition.size() == null ? 50 : condition.size(),
-            content.size(), // 임시
-            1               // 임시
+            page.page(),
+            page.size(),
+            page.totalElements(),
+            page.totalPages()
         );
     }
 

--- a/admin/src/main/java/com/devticket/admin/application/service/AdminUserServiceImpl.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/AdminUserServiceImpl.java
@@ -4,11 +4,17 @@ import com.devticket.admin.domain.model.AdminActionHistory;
 import com.devticket.admin.domain.model.AdminActionType;
 import com.devticket.admin.domain.model.AdminTargetType;
 import com.devticket.admin.domain.model.temporaryEnum.UserStatus;
+import com.devticket.admin.domain.repository.AdminActionRepository;
 import com.devticket.admin.infrastructure.external.client.MemberInternalClient;
 import com.devticket.admin.infrastructure.persistence.repository.AdminActionHistoryRepositoryImpl;
 import com.devticket.admin.presentation.dto.req.UserRoleRequest;
 import com.devticket.admin.presentation.dto.req.UserSearchCondition;
 import com.devticket.admin.presentation.dto.req.UserStatusRequest;
+import com.devticket.admin.presentation.dto.res.AdminActionHistorySummary;
+import com.devticket.admin.presentation.dto.res.AdminUserListResponse;
+import com.devticket.admin.presentation.dto.res.InternalMemberDetailResponse;
+import com.devticket.admin.presentation.dto.res.UserDetailResponse;
+import com.devticket.admin.presentation.dto.res.UserListItem;
 import com.devticket.admin.presentation.dto.res.UserListResponse;
 import java.util.List;
 import java.util.UUID;
@@ -23,24 +29,62 @@ public class AdminUserServiceImpl implements AdminUserService {
 
     private final MemberInternalClient memberInternalClient;
     private final AdminActionHistoryRepositoryImpl adminActionHistoryRepository;
+    private final AdminActionRepository adminActionRepository;
 
 
     @Override
-    public List<UserListResponse> getMembers(UserSearchCondition condition) {
-        return memberInternalClient.getMembers(condition).stream()
-            .map(member -> new UserListResponse(
-                member.id(),
+    public AdminUserListResponse getMembers(UserSearchCondition condition) {
+
+        List<UserListItem> content = memberInternalClient.getMembers(condition).stream()
+            .map(member -> new UserListItem(
+                member.userId(),
                 member.email(),
+                member.nickname(),
                 member.role(),
                 member.status(),
                 member.providerType(),
-                null,
-                null,
-                null
-            )).toList();
+                member.createdAt(),
+                member.withdrawnAt()
+            ))
+            .toList();
+
+        return new AdminUserListResponse(
+            content,
+            condition.page() == null ? 0 : condition.page(),
+            condition.size() == null ? 50 : condition.size(),
+            content.size(), // 임시
+            1               // 임시
+        );
     }
 
     @Override
+    public UserDetailResponse getUserDetail(UUID userId) {
+        InternalMemberDetailResponse member = memberInternalClient.getMember(userId);
+        // 존재하지 않으면 MemberInternalClient에서 4xx 터뜨리고 전역 핸들러가 MEMBER_009로 변환
+
+        List<AdminActionHistorySummary> history =
+            adminActionRepository.findByTarget(AdminTargetType.USER, userId).stream()
+                .map(h -> new AdminActionHistorySummary(
+                    h.getActionType().name(),
+                    h.getAdminId(),
+                    h.getCreatedAt()))
+                .toList();
+
+        return new UserDetailResponse(
+            member.id(),
+            member.email(),
+            member.nickname(),
+            member.role(),
+            member.status(),
+            member.providerType(),
+            member.createdAt(),
+            member.withdrawnAt(),
+            history
+        );
+    }
+
+    @Override
+    @Transactional
     public void penalizeUser(UUID adminId, UUID userId, UserStatusRequest request) {
         memberInternalClient.updateUserStatus(userId, request);
 
@@ -68,6 +112,7 @@ public class AdminUserServiceImpl implements AdminUserService {
     }
 
     @Override
+    @Transactional
     public void updateUserRole(UUID adminId, UUID userId, UserRoleRequest request) {
         memberInternalClient.updateUserRole(userId, request);
 

--- a/admin/src/main/java/com/devticket/admin/domain/model/AdminActionType.java
+++ b/admin/src/main/java/com/devticket/admin/domain/model/AdminActionType.java
@@ -6,5 +6,6 @@ public enum AdminActionType {
     CHANGE_ROLE,
     APPROVE_SELLER,
     REJECT_SELLER,
-    FORCE_CANCEL_EVENT
+    FORCE_CANCEL_EVENT,
+    RUN_SETTLEMENT
 }

--- a/admin/src/main/java/com/devticket/admin/domain/repository/AdminActionRepository.java
+++ b/admin/src/main/java/com/devticket/admin/domain/repository/AdminActionRepository.java
@@ -1,8 +1,11 @@
 package com.devticket.admin.domain.repository;
 
 import com.devticket.admin.domain.model.AdminActionHistory;
+import com.devticket.admin.domain.model.AdminTargetType;
+import java.util.List;
+import java.util.UUID;
 
 public interface AdminActionRepository {
-
     void save(AdminActionHistory adminActionHistory);
+    List<AdminActionHistory> findByTarget(AdminTargetType targetType, UUID targetId);
 }

--- a/admin/src/main/java/com/devticket/admin/infrastructure/config/JpaConfig.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.devticket.admin.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/EventInternalClient.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/EventInternalClient.java
@@ -1,0 +1,10 @@
+package com.devticket.admin.infrastructure.external.client;
+
+import com.devticket.admin.infrastructure.external.dto.res.InternalAdminEventPageResponse;
+import com.devticket.admin.presentation.dto.req.AdminEventSearchRequest;
+import java.util.UUID;
+
+public interface EventInternalClient {
+    InternalAdminEventPageResponse getEvents(AdminEventSearchRequest condition);
+    void forceCancel(UUID eventId);
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/MemberInternalClient.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/MemberInternalClient.java
@@ -2,18 +2,18 @@ package com.devticket.admin.infrastructure.external.client;
 
 import com.devticket.admin.infrastructure.external.dto.req.InternalDecideSellerApplicationRequest;
 import com.devticket.admin.infrastructure.external.dto.res.InternalDecideSellerApplicationResponse;
-import com.devticket.admin.infrastructure.external.dto.res.InternalMemberInfoResponse;
 import com.devticket.admin.infrastructure.external.dto.res.InternalSellerApplicationResponse;
 import com.devticket.admin.presentation.dto.req.UserRoleRequest;
 import com.devticket.admin.presentation.dto.req.UserSearchCondition;
 import com.devticket.admin.presentation.dto.req.UserStatusRequest;
 import com.devticket.admin.presentation.dto.res.InternalMemberDetailResponse;
+import com.devticket.admin.presentation.dto.res.InternalMemberPageResponse;
 import java.util.List;
 import java.util.UUID;
 
 public interface MemberInternalClient {
 
-    List<InternalMemberInfoResponse> getMembers(UserSearchCondition condition);
+    InternalMemberPageResponse getMembers(UserSearchCondition condition);
 
     InternalMemberDetailResponse getMember(UUID userId);
 

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/MemberInternalClient.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/MemberInternalClient.java
@@ -7,12 +7,15 @@ import com.devticket.admin.infrastructure.external.dto.res.InternalSellerApplica
 import com.devticket.admin.presentation.dto.req.UserRoleRequest;
 import com.devticket.admin.presentation.dto.req.UserSearchCondition;
 import com.devticket.admin.presentation.dto.req.UserStatusRequest;
+import com.devticket.admin.presentation.dto.res.InternalMemberDetailResponse;
 import java.util.List;
 import java.util.UUID;
 
 public interface MemberInternalClient {
 
     List<InternalMemberInfoResponse> getMembers(UserSearchCondition condition);
+
+    InternalMemberDetailResponse getMember(UUID userId);
 
     void updateUserStatus(UUID userId, UserStatusRequest request);
 

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImpl.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImpl.java
@@ -1,0 +1,52 @@
+package com.devticket.admin.infrastructure.external.client;
+
+import com.devticket.admin.infrastructure.external.dto.res.InternalAdminEventPageResponse;
+import com.devticket.admin.infrastructure.external.dto.res.InternalResponse;
+import com.devticket.admin.presentation.dto.req.AdminEventSearchRequest;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Primary
+@Component
+@RequiredArgsConstructor
+public class RestClientEventInternalClientImpl implements EventInternalClient {
+
+    private final RestClient restClient;
+
+    @Value("${internal.event-service.url}")
+    private String eventServerUrl;
+
+    @Override
+    public InternalAdminEventPageResponse getEvents(AdminEventSearchRequest condition) {
+        InternalResponse<InternalAdminEventPageResponse> response = restClient.get()
+            .uri(eventServerUrl + "/internal/events?keyword={k}&status={s}&sellerId={sid}&page={p}&size={z}",
+                nvl(condition.keyword()),
+                nvl(condition.status()),
+                nvl(condition.sellerId()),
+                condition.page() == null ? 0 : condition.page(),
+                condition.size() == null ? 20 : condition.size())
+            .retrieve()
+            .body(new org.springframework.core.ParameterizedTypeReference<
+                InternalResponse<InternalAdminEventPageResponse>>() {});
+
+        if (response == null || response.data() == null) {
+            return new InternalAdminEventPageResponse(java.util.List.of(), 0, 20, 0L, 0);
+        }
+
+        return response.data();
+    }
+
+    @Override
+    public void forceCancel(UUID eventId) {
+        restClient.post()
+            .uri(eventServerUrl + "/internal/events/{eventId}/force-cancel", eventId)
+            .retrieve()
+            .toBodilessEntity();
+    }
+
+    private static String nvl(String v) { return v == null ? "" : v; }
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientMemberInternalClientImpl.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientMemberInternalClientImpl.java
@@ -7,7 +7,10 @@ import com.devticket.admin.infrastructure.external.dto.res.InternalSellerApplica
 import com.devticket.admin.presentation.dto.req.UserRoleRequest;
 import com.devticket.admin.presentation.dto.req.UserSearchCondition;
 import com.devticket.admin.presentation.dto.req.UserStatusRequest;
+import com.devticket.admin.presentation.dto.res.InternalMemberDetailResponse;
+import com.devticket.admin.presentation.dto.res.InternalMemberPageResponse;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,26 +32,43 @@ public class RestClientMemberInternalClientImpl implements MemberInternalClient 
 
     @Override
     public List<InternalMemberInfoResponse> getMembers(UserSearchCondition condition) {
-        return List.of(
-            new InternalMemberInfoResponse(
-                "550e8400-e29b-41d4-a716-446655440000",
-                "test@test.com",
-                "SELLER",
-                "ACTIVE",
-                "Google"
-            )
+        InternalMemberPageResponse page = restClient.get()
+            .uri(memberServerUrl + "/internal/members?role={role}&status={status}&keyword={keyword}",
+                condition.role(),
+                condition.status(),
+                condition.keyword())
+            .retrieve()
+            .body(new ParameterizedTypeReference<>() {});
 
-        );
+        return page != null ? page.content() : List.of();
     }
+
 
     @Override
     public void updateUserStatus(UUID userId, UserStatusRequest request) {
-
+        restClient.patch()
+            .uri(memberServerUrl + "/internal/members/{userId}/status", userId)
+            .body(request)
+            .retrieve()
+            .toBodilessEntity();
     }
+
 
     @Override
     public void updateUserRole(UUID userId, UserRoleRequest request) {
+        restClient.patch()
+            .uri(memberServerUrl + "/internal/members/{userId}/role", userId)
+            .body(request)
+            .retrieve()
+            .toBodilessEntity();
+    }
 
+    @Override
+    public InternalMemberDetailResponse getMember(UUID userId) {
+        return restClient.get()
+            .uri(memberServerUrl + "/internal/members/{userId}", userId)
+            .retrieve()
+            .body(InternalMemberDetailResponse.class);
     }
 
     // 판매자 신청 유저 조회

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientMemberInternalClientImpl.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientMemberInternalClientImpl.java
@@ -2,7 +2,6 @@ package com.devticket.admin.infrastructure.external.client;
 
 import com.devticket.admin.infrastructure.external.dto.req.InternalDecideSellerApplicationRequest;
 import com.devticket.admin.infrastructure.external.dto.res.InternalDecideSellerApplicationResponse;
-import com.devticket.admin.infrastructure.external.dto.res.InternalMemberInfoResponse;
 import com.devticket.admin.infrastructure.external.dto.res.InternalSellerApplicationResponse;
 import com.devticket.admin.presentation.dto.req.UserRoleRequest;
 import com.devticket.admin.presentation.dto.req.UserSearchCondition;
@@ -10,7 +9,6 @@ import com.devticket.admin.presentation.dto.req.UserStatusRequest;
 import com.devticket.admin.presentation.dto.res.InternalMemberDetailResponse;
 import com.devticket.admin.presentation.dto.res.InternalMemberPageResponse;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,16 +29,15 @@ public class RestClientMemberInternalClientImpl implements MemberInternalClient 
     private String memberServerUrl;
 
     @Override
-    public List<InternalMemberInfoResponse> getMembers(UserSearchCondition condition) {
+    public InternalMemberPageResponse getMembers(UserSearchCondition condition) {
         InternalMemberPageResponse page = restClient.get()
             .uri(memberServerUrl + "/internal/members?role={role}&status={status}&keyword={keyword}",
                 condition.role(),
                 condition.status(),
                 condition.keyword())
             .retrieve()
-            .body(new ParameterizedTypeReference<>() {});
-
-        return page != null ? page.content() : List.of();
+            .body(new ParameterizedTypeReference<InternalMemberPageResponse>() {});
+        return page != null ? page : new InternalMemberPageResponse(List.of(), 0, 0, 0, 0);
     }
 
 

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientSettlementInternalClientImpl.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientSettlementInternalClientImpl.java
@@ -1,0 +1,42 @@
+package com.devticket.admin.infrastructure.external.client;
+
+import com.devticket.admin.infrastructure.external.dto.res.InternalSettlementPageResponse;
+import com.devticket.admin.presentation.dto.req.AdminSettlementSearchRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Primary
+@Component
+@RequiredArgsConstructor
+public class RestClientSettlementInternalClientImpl implements SettlementInternalClient {
+
+    private final RestClient restClient;
+
+    @Value("${internal.settlement-service.url}")
+    private String settlementServerUrl;
+
+    @Override
+    public InternalSettlementPageResponse getSettlements(AdminSettlementSearchRequest condition) {
+        return restClient.get()
+            .uri(settlementServerUrl + "/internal/settlements?status={st}&sellerId={sid}&startDate={sd}&endDate={ed}&page={p}&size={z}",
+                nvl(condition.status()), nvl(condition.sellerId()),
+                nvl(condition.startDate()), nvl(condition.endDate()),
+                condition.page() == null ? 0 : condition.page(),
+                condition.size() == null ? 20 : condition.size())
+            .retrieve()
+            .body(InternalSettlementPageResponse.class);
+    }
+
+    @Override
+    public void runSettlement() {
+        restClient.post()
+            .uri(settlementServerUrl + "/internal/settlements/run")
+            .retrieve()
+            .toBodilessEntity();
+    }
+
+    private static String nvl(String v) { return v == null ? "" : v; }
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/SettlementInternalClient.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/SettlementInternalClient.java
@@ -1,0 +1,9 @@
+package com.devticket.admin.infrastructure.external.client;
+
+import com.devticket.admin.infrastructure.external.dto.res.InternalSettlementPageResponse;
+import com.devticket.admin.presentation.dto.req.AdminSettlementSearchRequest;
+
+public interface SettlementInternalClient {
+    InternalSettlementPageResponse getSettlements(AdminSettlementSearchRequest condition);
+    void runSettlement();
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/InternalAdminEventPageResponse.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/InternalAdminEventPageResponse.java
@@ -1,0 +1,12 @@
+package com.devticket.admin.infrastructure.external.dto.res;
+
+import java.util.List;
+
+public record InternalAdminEventPageResponse(
+    List<InternalAdminEventResponse> content,
+    Integer page,
+    Integer size,
+    Long totalElements,
+    Integer totalPages
+) {}
+

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/InternalAdminEventResponse.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/InternalAdminEventResponse.java
@@ -1,0 +1,6 @@
+package com.devticket.admin.infrastructure.external.dto.res;
+
+public record InternalAdminEventResponse(
+    String eventId, String title, String sellerNickname, String status,
+    String eventDateTime, Integer totalQuantity, Integer remainingQuantity, String createdAt
+) {}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/InternalResponse.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/InternalResponse.java
@@ -1,0 +1,7 @@
+package com.devticket.admin.infrastructure.external.dto.res;
+
+public record InternalResponse<T>(
+    Boolean success,
+    T data,
+    Object error
+) {}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/InternalSettlementPageResponse.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/InternalSettlementPageResponse.java
@@ -1,0 +1,12 @@
+package com.devticket.admin.infrastructure.external.dto.res;
+
+import java.util.List;
+
+public record InternalSettlementPageResponse(
+    List<InternalSettlementResponse> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPage
+) {
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/InternalSettlementPageResponse.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/InternalSettlementPageResponse.java
@@ -7,6 +7,6 @@ public record InternalSettlementPageResponse(
     int page,
     int size,
     long totalElements,
-    int totalPage
+    int totalPages
 ) {
 }

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/InternalSettlementResponse.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/InternalSettlementResponse.java
@@ -1,10 +1,8 @@
-package com.devticket.admin.presentation.dto.res;
+package com.devticket.admin.infrastructure.external.dto.res;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
-public record SettlementResponse(
-
+public record InternalSettlementResponse(
     Long settlementId,
     LocalDateTime periodStart,
     LocalDateTime periodEnd,
@@ -14,8 +12,5 @@ public record SettlementResponse(
     Long finalSettlementAmount,
     String status,
     LocalDateTime settledAt
-
 ) {
-
-
 }

--- a/admin/src/main/java/com/devticket/admin/infrastructure/persistence/repository/AdminActionHistoryJpaRepository.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/persistence/repository/AdminActionHistoryJpaRepository.java
@@ -1,9 +1,12 @@
 package com.devticket.admin.infrastructure.persistence.repository;
 
 import com.devticket.admin.domain.model.AdminActionHistory;
+import com.devticket.admin.domain.model.AdminTargetType;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdminActionHistoryJpaRepository extends JpaRepository<AdminActionHistory, Long> {
-
-
+    List<AdminActionHistory> findByTargetTypeAndTargetIdOrderByCreatedAtDesc(
+        AdminTargetType targetType, UUID targetId);
 }

--- a/admin/src/main/java/com/devticket/admin/infrastructure/persistence/repository/AdminActionHistoryRepositoryImpl.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/persistence/repository/AdminActionHistoryRepositoryImpl.java
@@ -1,7 +1,10 @@
 package com.devticket.admin.infrastructure.persistence.repository;
 
 import com.devticket.admin.domain.model.AdminActionHistory;
+import com.devticket.admin.domain.model.AdminTargetType;
 import com.devticket.admin.domain.repository.AdminActionRepository;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -15,5 +18,11 @@ public class AdminActionHistoryRepositoryImpl implements AdminActionRepository {
     @Override
     public void save(AdminActionHistory adminActionHistory) {
         adminActionHistoryJpaRepository.save(adminActionHistory);
+    }
+
+    @Override
+    public List<AdminActionHistory> findByTarget(AdminTargetType targetType, UUID targetId) {
+        return adminActionHistoryJpaRepository
+            .findByTargetTypeAndTargetIdOrderByCreatedAtDesc(targetType, targetId);
     }
 }

--- a/admin/src/main/java/com/devticket/admin/presentation/controller/AdminDashboardController.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/controller/AdminDashboardController.java
@@ -6,17 +6,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/admin")
 @Tag(name = "관리자 대시보드 통계 API")
 public class AdminDashboardController {
 
     @Operation(summary = "관리자 대시보드 통계 API")
     @ApiResponse(responseCode = "200", description = "대시보드 통계 조회 성공")
     @ApiResponse(responseCode = "403", description = "접근 권한 없음 (COMMON_005)")
-    @GetMapping("/admin/dashboard")
+    @GetMapping("/dashboard")
     public AdminDashboardResponse getAdminDashboard() {
 
         return new AdminDashboardResponse(1521L, 1L, 5L, 4L);

--- a/admin/src/main/java/com/devticket/admin/presentation/controller/AdminEventController.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/controller/AdminEventController.java
@@ -1,53 +1,48 @@
 package com.devticket.admin.presentation.controller;
 
+import com.devticket.admin.application.service.AdminEventService;
 import com.devticket.admin.presentation.dto.req.AdminEventSearchRequest;
 import com.devticket.admin.presentation.dto.res.AdminEventListResponse;
-import com.devticket.admin.presentation.dto.res.AdminEventResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/admin")
 @Tag(name = "관리자 Event 관리 API")
 public class AdminEventController {
+
+    private final AdminEventService adminEventService;
 
     @Operation(summary = "관리자 Event 리스트 조회", description = "관리자가 전체 리스트를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "이벤트 목록 조회 성공")
     @ApiResponse(responseCode = "403", description = "접근 권한 없음 (COMMON_005)")
-    @GetMapping("/admin/events")
-    public AdminEventListResponse getEventList(@ModelAttribute AdminEventSearchRequest condition) {
-
-        // TODO: 서비스 구현 전 임시 Mock
-        List<AdminEventResponse> mockContent = List.of(
-            new AdminEventResponse(
-                "1d7f4d4a-1c6b-4aa2-b49e-8ed2fdb10001",
-                "Spring Boot 심화 밋업",
-                "DevKim",
-                "ON_SALE",
-                "2026-04-10T19:00:00",
-                50,
-                23,
-                "2026-03-23T15:00:00"
-            )
-        );
-
-        return new AdminEventListResponse(mockContent, 0, 20, 1L, 1);
+    @GetMapping("/events")
+    public AdminEventListResponse getEventList(@ModelAttribute @Valid AdminEventSearchRequest condition) {
+        return adminEventService.getEventList(condition);   // Mock 제거
     }
 
 
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "관리자 Event 삭제 API", description = "관리자가 이벤트를 삭제합니다.")
-    @PatchMapping("/admin/events/{eventId}/force-cancel")
-    public void cancelEvent(@PathVariable UUID eventId) {
-        
+    @PatchMapping("/events/{eventId}/force-cancel")
+    public void cancelEvent(
+        @RequestHeader("X-User-Id") UUID adminId,          // ← adminId 추가
+        @PathVariable UUID eventId) {
+        adminEventService.forceCancel(adminId, eventId);   // 빈 body 구현
     }
 
 }

--- a/admin/src/main/java/com/devticket/admin/presentation/controller/AdminSellerController.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/controller/AdminSellerController.java
@@ -14,10 +14,12 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/admin")
 @Tag(name = "SELLER(판매자) 신청 관리 API")
 public class AdminSellerController {
 
@@ -26,7 +28,7 @@ public class AdminSellerController {
     @Operation(summary = "판매자 신청 리스트 조회 API")
     @ApiResponse(responseCode = "200", description = "판매자 신청 리스트 조회 성공")
     @ApiResponse(responseCode = "403", description = "접근 권한 없음 (COMMON_005)")
-    @GetMapping("/api/admin/seller-applications")
+    @GetMapping("/seller-applications")
     public List<SellerApplicationListResponse> getSellerApplicationList() {
         return adminSellerService.getSellerApplicationList();
     }
@@ -36,7 +38,7 @@ public class AdminSellerController {
     @ApiResponse(responseCode = "404", description = "존재하지 않는 회원 (MEMBER_009)")
     @ApiResponse(responseCode = "409", description = "이미 처리된 판매자 신청 건 (ADMIN_003)")
     @ApiResponse(responseCode = "403", description = "접근 권한 없음 (COMMON_005)")
-    @PatchMapping("/api/admin/seller-applications/{applicationId}")
+    @PatchMapping("/seller-applications/{applicationId}")
     public void decideApplication(
         @RequestHeader("X-User-Id") UUID adminId,
         @PathVariable UUID applicationId,

--- a/admin/src/main/java/com/devticket/admin/presentation/controller/AdminSettlementController.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/controller/AdminSettlementController.java
@@ -1,52 +1,47 @@
 package com.devticket.admin.presentation.controller;
 
+import com.devticket.admin.application.service.AdminSettlementService;
 import com.devticket.admin.presentation.dto.req.AdminSettlementSearchRequest;
 import com.devticket.admin.presentation.dto.res.AdminSettelmentListResponse;
 import com.devticket.admin.presentation.dto.res.SettlementResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/admin")
 @Tag(name = "관리자 정산 내역 관리 API")
 public class AdminSettlementController {
+
+    AdminSettlementService adminSettlementService;
 
     @Operation(summary = "관리자 정산 내역 조회 API")
     @ApiResponse(responseCode = "200", description = "정산 목록 조회 성공")
     @ApiResponse(responseCode = "403", description = "접근 권한 없음 (COMMON_005)")
-    @GetMapping("/admin/settlements")
-    public AdminSettelmentListResponse getAdminSettlementList(@ModelAttribute AdminSettlementSearchRequest condition) {
-        List<SettlementResponse> mockContent = List.of(
-            new SettlementResponse(
-                "a1b2c3d4-5678-9012-abcd-ef1234567890",
-                "2026-03-01T00:00:00",
-                "2026-03-31T23:59:59",
-                1000000,
-                50000,
-                95000,
-                855000,
-                "COMPLETED",
-                "2026-04-01T10:00:00"
-            )
-        );
-
-        return new AdminSettelmentListResponse(mockContent, 0, 20, 1L, 1);
+    @GetMapping("/settlements")
+    public AdminSettelmentListResponse getAdminSettlementList(
+        @ModelAttribute @Valid AdminSettlementSearchRequest condition) {
+        return adminSettlementService.getSettlementList(condition);
     }
 
     @Operation(summary = "관리자 정산 프로세스 실행")
     @ApiResponse(responseCode = "204", description = "정산 프로세스 실행 성공")
     @ApiResponse(responseCode = "403", description = "접근 권한 없음 (COMMON_005)")
     @ApiResponse(responseCode = "409", description = "이미 실행 중인 정산 프로세스 존재 (SETTLEMENT_002)")
-    @PostMapping("/admin/settlements/run")
-    public void runSettlement() {
-
+    @PostMapping("/settlements/run")
+    public void runSettlement(@RequestHeader("X-User-Id") UUID adminId) {
+//        adminSettlementService.runSettlement(adminId);
     }
 
 }

--- a/admin/src/main/java/com/devticket/admin/presentation/controller/AdminSettlementController.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/controller/AdminSettlementController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "관리자 정산 내역 관리 API")
 public class AdminSettlementController {
 
-    AdminSettlementService adminSettlementService;
+    private final AdminSettlementService adminSettlementService;
 
     @Operation(summary = "관리자 정산 내역 조회 API")
     @ApiResponse(responseCode = "200", description = "정산 목록 조회 성공")

--- a/admin/src/main/java/com/devticket/admin/presentation/controller/AdminUsersController.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/controller/AdminUsersController.java
@@ -4,22 +4,30 @@ import com.devticket.admin.application.service.AdminUserService;
 import com.devticket.admin.presentation.dto.req.UserRoleRequest;
 import com.devticket.admin.presentation.dto.req.UserSearchCondition;
 import com.devticket.admin.presentation.dto.req.UserStatusRequest;
+import com.devticket.admin.presentation.dto.res.AdminUserListResponse;
+import com.devticket.admin.presentation.dto.res.UserDetailResponse;
 import com.devticket.admin.presentation.dto.res.UserListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/admin")
 @Tag(name = "Admin User", description = "관리자 회원 관리 API")
 public class AdminUsersController {
 
@@ -27,34 +35,37 @@ public class AdminUsersController {
 
     @Operation(summary = "회원 목록 조회")
     @ApiResponse(responseCode = "200", description = "정산 내역 조회 성공")
-    @GetMapping("/admin/users")
-    public List<UserListResponse> getUsers(
-        @RequestBody UserSearchCondition condition) {
-
+    @GetMapping("/users")
+    public AdminUserListResponse getUsers(@ModelAttribute @Valid UserSearchCondition condition) {
+        // GET에 @RequestBody는 문제의 소지가 큼 → @ModelAttribute
         return adminUserService.getMembers(condition);
     }
 
+    @GetMapping("/users/{userId}")             // ← 신규
+    public UserDetailResponse getUserDetail(@PathVariable UUID userId) {
+        return adminUserService.getUserDetail(userId);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "회원 제재 api")
     @ApiResponse(responseCode = "200", description = "회원 제재 성공")
-    @PatchMapping("/admin/users/{userId}/status")
+    @PatchMapping("/users/{userId}/status")
     public void penalizeUser(
         @RequestHeader("X-User-Id") UUID adminId,
         @PathVariable UUID userId,
-        @RequestBody UserStatusRequest request) {
-
+        @RequestBody @Valid UserStatusRequest request) {
         adminUserService.penalizeUser(adminId, userId, request);
     }
 
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "회원 권한 변경 api")
     @ApiResponse(responseCode = "200", description = "회원 권한 변경 성공")
-    @PatchMapping("/admin/users/{userId}/role")
+    @PatchMapping("/users/{userId}/role")
     public void updateUserRole(
         @RequestHeader("X-User-Id") UUID adminId,
         @PathVariable UUID userId,
-        @RequestBody UserRoleRequest request) {
-
+        @RequestBody @Valid UserRoleRequest request) {
         adminUserService.updateUserRole(adminId, userId, request);
-
     }
 
 

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/req/AdminSettlementSearchRequest.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/req/AdminSettlementSearchRequest.java
@@ -13,7 +13,7 @@ public record AdminSettlementSearchRequest(
     String sellerId,
 
     @Schema(description = "정산 시작일 범위 시작 (YYYY-MM-DD)", example = "2026-03-01")
-    String stardDate,
+    String startDate,
 
     @Schema(description = "정산 시작일 범위 종료 (YYYY-MM-DD)", example = "2026-03-31")
     String endDate,

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/req/UserSearchCondition.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/req/UserSearchCondition.java
@@ -6,42 +6,44 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record UserSearchCondition(
 
-    @Schema(description = "권한 검색 필터",
-        example = "USER",
-        allowableValues = {"USER", "SELLER", "ADMIN"})
+    @Schema(description = "권한 검색 필터", example = "USER", allowableValues = {"USER", "SELLER", "ADMIN"})
     String role,
 
-    @Schema(description = "상태 검색 필터",
-        example = "ACTIVE",
-        allowableValues = {"ACTIVE", "SUSPENDED", "WITHDRAWN"})
+    @Schema(description = "상태 검색 필터", example = "ACTIVE", allowableValues = {"ACTIVE", "SUSPENDED", "WITHDRAWN"})
     String status,
 
     @Schema(description = "이메일 또는 닉네임 검색어", example = "홍길동")
-    String keyword) {
+    String keyword,
 
+    @Schema(description = "페이지 번호", example = "0")
+    Integer page,
 
+    @Schema(description = "페이지 크기", example = "50")
+    Integer size
+) {
     public UserSearchCondition {
-        // 1. role 값 유효성 체크
         if (role != null) {
-
             try {
                 UserRole.valueOf(role);
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("유효하지 않은 role 값" + role);
+                throw new IllegalArgumentException("유효하지 않은 role 값: " + role);
             }
-
         }
 
-        // 2. status 값 유효성 체크
         if (status != null) {
-
             try {
                 UserStatus.valueOf(status);
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("유효하지 status 않은  값" + status);
+                throw new IllegalArgumentException("유효하지 않은 status 값: " + status);
             }
+        }
 
+        if (page != null && page < 0) {
+            throw new IllegalArgumentException("page는 0 이상이어야 합니다.");
+        }
+
+        if (size != null && size <= 0) {
+            throw new IllegalArgumentException("size는 1 이상이어야 합니다.");
         }
     }
-
 }

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/AdminActionHistorySummary.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/AdminActionHistorySummary.java
@@ -1,0 +1,10 @@
+package com.devticket.admin.presentation.dto.res;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AdminActionHistorySummary(
+    String actionType,
+    UUID adminId,
+    LocalDateTime createdAt
+) {}

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/AdminSettelmentListResponse.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/AdminSettelmentListResponse.java
@@ -18,7 +18,7 @@ public record AdminSettelmentListResponse(
     Long totalElements,
 
     @Schema(description = "전체 페이지 수", example = "1")
-    Integer totalPage
+    Integer totalPages
 ) {
 
 }

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/AdminUserListResponse.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/AdminUserListResponse.java
@@ -1,0 +1,11 @@
+package com.devticket.admin.presentation.dto.res;
+
+import java.util.List;
+
+public record AdminUserListResponse(
+    List<UserListItem> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages
+) {}

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/InternalMemberDetailResponse.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/InternalMemberDetailResponse.java
@@ -1,0 +1,9 @@
+package com.devticket.admin.presentation.dto.res;
+
+public record InternalMemberDetailResponse(
+    String id, String email, String nickname,
+    String role, String status, String providerType,
+    String createdAt, String withdrawnAt
+) {}
+
+

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/InternalMemberPageResponse.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/InternalMemberPageResponse.java
@@ -2,10 +2,22 @@ package com.devticket.admin.presentation.dto.res;
 
 import com.devticket.admin.infrastructure.external.dto.res.InternalMemberInfoResponse;
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 public record InternalMemberPageResponse(
     List<InternalMemberInfoResponse> content,
     int page,
     int size,
-    long totalElements
-) {}
+    long totalElements,
+    int totalPages
+) {
+    public static InternalMemberPageResponse from(Page<InternalMemberInfoResponse> page) {
+        return new InternalMemberPageResponse(
+            page.getContent(),
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages()
+        );
+    }
+}

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/InternalMemberPageResponse.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/InternalMemberPageResponse.java
@@ -1,0 +1,11 @@
+package com.devticket.admin.presentation.dto.res;
+
+import com.devticket.admin.infrastructure.external.dto.res.InternalMemberInfoResponse;
+import java.util.List;
+
+public record InternalMemberPageResponse(
+    List<InternalMemberInfoResponse> content,
+    int page,
+    int size,
+    long totalElements
+) {}

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/UserDetailResponse.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/UserDetailResponse.java
@@ -1,0 +1,15 @@
+package com.devticket.admin.presentation.dto.res;
+
+import java.util.List;
+
+public record UserDetailResponse(
+    String userId,
+    String email,
+    String nickname,
+    String role,
+    String status,
+    String providerType,
+    String createdAt,
+    String withdrawnAt,
+    List<AdminActionHistorySummary> penaltyHistory    // 제재/권한변경 이력
+) {}

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/UserListItem.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/UserListItem.java
@@ -1,7 +1,9 @@
-package com.devticket.admin.infrastructure.external.dto.res;
+package com.devticket.admin.presentation.dto.res;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
 
-public record InternalMemberInfoResponse(
+public record UserListItem(
     String userId,
     String email,
     String nickname,

--- a/admin/src/main/resources/application-local.yml
+++ b/admin/src/main/resources/application-local.yml
@@ -34,3 +34,7 @@ logging:
 internal:
   member-service:
     url: http://localhost:8081
+  event-service:
+    url: http://localhost:8082
+  settlement-service:
+    url: http://localhost:8085

--- a/admin/src/test/java/com/devticket/admin/AdminApplicationTests.java
+++ b/admin/src/test/java/com/devticket/admin/AdminApplicationTests.java
@@ -3,11 +3,11 @@ package com.devticket.admin;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+//@SpringBootTest
 class AdminApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+//	@Test
+//	void contextLoads() {
+//	}
 
 }

--- a/admin/src/test/java/com/devticket/admin/service/AdminEventServiceImplTest.java
+++ b/admin/src/test/java/com/devticket/admin/service/AdminEventServiceImplTest.java
@@ -1,0 +1,128 @@
+package com.devticket.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.devticket.admin.application.service.AdminEventServiceImpl;
+import com.devticket.admin.domain.model.AdminActionHistory;
+import com.devticket.admin.domain.model.AdminActionType;
+import com.devticket.admin.domain.model.AdminTargetType;
+import com.devticket.admin.domain.repository.AdminActionRepository;
+import com.devticket.admin.infrastructure.external.client.EventInternalClient;
+import com.devticket.admin.infrastructure.external.dto.res.InternalAdminEventPageResponse;
+import com.devticket.admin.infrastructure.external.dto.res.InternalAdminEventResponse;
+import com.devticket.admin.presentation.dto.req.AdminEventSearchRequest;
+import com.devticket.admin.presentation.dto.res.AdminEventListResponse;
+import com.devticket.admin.presentation.dto.res.AdminEventResponse;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminEventServiceImpl 단위 테스트")
+class AdminEventServiceImplTest {
+
+    @Mock
+    private EventInternalClient eventInternalClient;
+
+    @Mock
+    private AdminActionRepository adminActionRepository;
+
+    @InjectMocks
+    private AdminEventServiceImpl adminEventService;
+
+    @Nested
+    @DisplayName("getEventList")
+    class GetEventList {
+
+        @Test
+        @DisplayName("내부 클라이언트 응답을 매핑해 이벤트 목록을 반환한다")
+        void shouldReturnMappedEventList() {
+            // given
+            AdminEventSearchRequest condition =
+                new AdminEventSearchRequest("Spring", "ON_SALE", null, 0, 20);
+            InternalAdminEventResponse internal = new InternalAdminEventResponse(
+                "event-1", "Spring 밋업", "DevKim", "ON_SALE",
+                "2026-04-10T19:00:00", 50, 30, "2026-03-01T15:00:00"
+            );
+            InternalAdminEventPageResponse page = new InternalAdminEventPageResponse(
+                List.of(internal), 0, 20, 1L, 1
+            );
+            given(eventInternalClient.getEvents(condition)).willReturn(page);
+
+            // when
+            AdminEventListResponse response = adminEventService.getEventList(condition);
+
+            // then
+            assertThat(response.page()).isEqualTo(0);
+            assertThat(response.size()).isEqualTo(20);
+            assertThat(response.totalElements()).isEqualTo(1L);
+            assertThat(response.totalPages()).isEqualTo(1);
+            assertThat(response.content()).hasSize(1);
+
+            AdminEventResponse mapped = response.content().get(0);
+            assertThat(mapped.eventId()).isEqualTo("event-1");
+            assertThat(mapped.title()).isEqualTo("Spring 밋업");
+            assertThat(mapped.sellerNickname()).isEqualTo("DevKim");
+            assertThat(mapped.status()).isEqualTo("ON_SALE");
+            assertThat(mapped.eventDateTime()).isEqualTo("2026-04-10T19:00:00");
+            assertThat(mapped.totalQuantity()).isEqualTo(50);
+            assertThat(mapped.remainingQuantity()).isEqualTo(30);
+            assertThat(mapped.createdAt()).isEqualTo("2026-03-01T15:00:00");
+        }
+
+        @Test
+        @DisplayName("내부 클라이언트가 빈 목록을 반환하면 빈 응답을 그대로 반환한다")
+        void shouldReturnEmptyListWhenNoEvents() {
+            // given
+            AdminEventSearchRequest condition =
+                new AdminEventSearchRequest(null, null, null, 0, 20);
+            given(eventInternalClient.getEvents(condition))
+                .willReturn(new InternalAdminEventPageResponse(List.of(), 0, 20, 0L, 0));
+
+            // when
+            AdminEventListResponse response = adminEventService.getEventList(condition);
+
+            // then
+            assertThat(response.content()).isEmpty();
+            assertThat(response.totalElements()).isZero();
+            assertThat(response.totalPages()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("forceCancel")
+    class ForceCancel {
+
+        @Test
+        @DisplayName("이벤트를 강제 취소하고 FORCE_CANCEL_EVENT 이력을 저장한다")
+        void shouldForceCancelEventAndSaveHistory() {
+            // given
+            UUID adminId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+
+            // when
+            adminEventService.forceCancel(adminId, eventId);
+
+            // then
+            then(eventInternalClient).should().forceCancel(eventId);
+
+            ArgumentCaptor<AdminActionHistory> captor = ArgumentCaptor.forClass(AdminActionHistory.class);
+            then(adminActionRepository).should().save(captor.capture());
+
+            AdminActionHistory saved = captor.getValue();
+            assertThat(saved.getAdminId()).isEqualTo(adminId);
+            assertThat(saved.getTargetType()).isEqualTo(AdminTargetType.EVENT);
+            assertThat(saved.getTargetId()).isEqualTo(eventId);
+            assertThat(saved.getActionType()).isEqualTo(AdminActionType.FORCE_CANCEL_EVENT);
+        }
+    }
+}

--- a/admin/src/test/java/com/devticket/admin/service/AdminSellerServiceImplTest.java
+++ b/admin/src/test/java/com/devticket/admin/service/AdminSellerServiceImplTest.java
@@ -1,0 +1,113 @@
+package com.devticket.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.devticket.admin.application.service.AdminSellerServiceImpl;
+import com.devticket.admin.infrastructure.external.client.MemberInternalClient;
+import com.devticket.admin.infrastructure.external.dto.req.InternalDecideSellerApplicationRequest;
+import com.devticket.admin.infrastructure.external.dto.res.InternalSellerApplicationResponse;
+import com.devticket.admin.presentation.dto.req.AdminDecideSellerApplicationRequest;
+import com.devticket.admin.presentation.dto.res.SellerApplicationListResponse;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminSellerServiceImpl 단위 테스트")
+class AdminSellerServiceImplTest {
+
+    @Mock
+    private MemberInternalClient memberInternalClient;
+
+    @InjectMocks
+    private AdminSellerServiceImpl adminSellerService;
+
+    @Nested
+    @DisplayName("getSellerApplicationList")
+    class GetSellerApplicationList {
+
+        @Test
+        @DisplayName("내부 클라이언트의 판매자 신청 목록을 매핑해 반환한다")
+        void shouldReturnMappedSellerApplications() {
+            // given
+            InternalSellerApplicationResponse application = new InternalSellerApplicationResponse(
+                "app-1", "user-1", "국민은행", "123-456-789", "홍길동", "PENDING", "2026-04-10T10:00:00"
+            );
+            given(memberInternalClient.getSellerApplications()).willReturn(List.of(application));
+
+            // when
+            List<SellerApplicationListResponse> result = adminSellerService.getSellerApplicationList();
+
+            // then
+            assertThat(result).hasSize(1);
+            SellerApplicationListResponse first = result.get(0);
+            assertThat(first.applicationId()).isEqualTo("app-1");
+            assertThat(first.userId()).isEqualTo("user-1");
+            assertThat(first.bankName()).isEqualTo("국민은행");
+            assertThat(first.accountNumber()).isEqualTo("123-456-789");
+            assertThat(first.accountHolder()).isEqualTo("홍길동");
+            assertThat(first.status()).isEqualTo("PENDING");
+            assertThat(first.createdAt()).isEqualTo("2026-04-10T10:00:00");
+        }
+
+        @Test
+        @DisplayName("신청 내역이 없으면 빈 목록을 반환한다")
+        void shouldReturnEmptyListWhenNoApplications() {
+            // given
+            given(memberInternalClient.getSellerApplications()).willReturn(List.of());
+
+            // when
+            List<SellerApplicationListResponse> result = adminSellerService.getSellerApplicationList();
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("decideApplication")
+    class DecideApplication {
+
+        @Test
+        @DisplayName("판매자 신청 결정 요청을 내부 클라이언트로 위임한다 - APPROVE")
+        void shouldForwardApproveDecisionToInternalClient() {
+            // given
+            UUID adminId = UUID.randomUUID();
+            UUID applicationId = UUID.randomUUID();
+            AdminDecideSellerApplicationRequest request =
+                new AdminDecideSellerApplicationRequest("APPROVE");
+
+            // when
+            adminSellerService.decideApplication(adminId, applicationId, request);
+
+            // then
+            then(memberInternalClient).should()
+                .decideSellerApplication(applicationId, new InternalDecideSellerApplicationRequest("APPROVE"));
+        }
+
+        @Test
+        @DisplayName("판매자 신청 결정 요청을 내부 클라이언트로 위임한다 - REJECT")
+        void shouldForwardRejectDecisionToInternalClient() {
+            // given
+            UUID adminId = UUID.randomUUID();
+            UUID applicationId = UUID.randomUUID();
+            AdminDecideSellerApplicationRequest request =
+                new AdminDecideSellerApplicationRequest("REJECT");
+
+            // when
+            adminSellerService.decideApplication(adminId, applicationId, request);
+
+            // then
+            then(memberInternalClient).should()
+                .decideSellerApplication(applicationId, new InternalDecideSellerApplicationRequest("REJECT"));
+        }
+    }
+}

--- a/admin/src/test/java/com/devticket/admin/service/AdminSettlementServiceImplTest.java
+++ b/admin/src/test/java/com/devticket/admin/service/AdminSettlementServiceImplTest.java
@@ -1,0 +1,133 @@
+package com.devticket.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.devticket.admin.application.service.AdminSettlementServiceImpl;
+import com.devticket.admin.domain.model.AdminActionHistory;
+import com.devticket.admin.domain.model.AdminActionType;
+import com.devticket.admin.domain.model.AdminTargetType;
+import com.devticket.admin.domain.repository.AdminActionRepository;
+import com.devticket.admin.infrastructure.external.client.SettlementInternalClient;
+import com.devticket.admin.infrastructure.external.dto.res.InternalSettlementPageResponse;
+import com.devticket.admin.infrastructure.external.dto.res.InternalSettlementResponse;
+import com.devticket.admin.presentation.dto.req.AdminSettlementSearchRequest;
+import com.devticket.admin.presentation.dto.res.AdminSettelmentListResponse;
+import com.devticket.admin.presentation.dto.res.SettlementResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminSettlementServiceImpl 단위 테스트")
+class AdminSettlementServiceImplTest {
+
+    @Mock
+    private SettlementInternalClient settlementInternalClient;
+
+    @Mock
+    private AdminActionRepository adminActionRepository;
+
+    @InjectMocks
+    private AdminSettlementServiceImpl adminSettlementService;
+
+    @Nested
+    @DisplayName("getSettlementList")
+    class GetSettlementList {
+
+        @Test
+        @DisplayName("내부 클라이언트 응답을 매핑해 정산 목록을 반환한다")
+        void shouldReturnMappedSettlementList() {
+            // given
+            AdminSettlementSearchRequest condition =
+                new AdminSettlementSearchRequest("COMPLETED", null, null, null, 0, 20);
+
+            LocalDateTime now = LocalDateTime.of(2026, 4, 1, 12, 0, 0);
+            InternalSettlementResponse internal = new InternalSettlementResponse(
+                1L, now.minusDays(7), now,
+                10_000L, 1_000L, 500L, 8_500L, "COMPLETED", now
+            );
+            InternalSettlementPageResponse page = new InternalSettlementPageResponse(
+                List.of(internal), 0, 20, 1L, 1
+            );
+            given(settlementInternalClient.getSettlements(condition)).willReturn(page);
+
+            // when
+            AdminSettelmentListResponse response = adminSettlementService.getSettlementList(condition);
+
+            // then
+            assertThat(response.page()).isEqualTo(0);
+            assertThat(response.size()).isEqualTo(20);
+            assertThat(response.totalElements()).isEqualTo(1L);
+            assertThat(response.totalPages()).isEqualTo(1);
+            assertThat(response.content()).hasSize(1);
+
+            SettlementResponse first = response.content().get(0);
+            assertThat(first.settlementId()).isEqualTo(1L);
+            assertThat(first.periodStart()).isEqualTo(now.minusDays(7));
+            assertThat(first.periodEnd()).isEqualTo(now);
+            assertThat(first.totalSalesAmount()).isEqualTo(10_000L);
+            assertThat(first.totalRefundAmount()).isEqualTo(1_000L);
+            assertThat(first.totalFeeAmount()).isEqualTo(500L);
+            assertThat(first.finalSettlementAmount()).isEqualTo(8_500L);
+            assertThat(first.status()).isEqualTo("COMPLETED");
+            assertThat(first.settledAt()).isEqualTo(now);
+
+            then(settlementInternalClient).should().getSettlements(condition);
+        }
+
+        @Test
+        @DisplayName("내부 클라이언트가 빈 페이지를 반환하면 빈 목록을 그대로 응답한다")
+        void shouldReturnEmptyListWhenNoSettlements() {
+            // given
+            AdminSettlementSearchRequest condition =
+                new AdminSettlementSearchRequest(null, null, null, null, 0, 20);
+            given(settlementInternalClient.getSettlements(condition))
+                .willReturn(new InternalSettlementPageResponse(List.of(), 0, 20, 0L, 0));
+
+            // when
+            AdminSettelmentListResponse response = adminSettlementService.getSettlementList(condition);
+
+            // then
+            assertThat(response.content()).isEmpty();
+            assertThat(response.totalElements()).isZero();
+            assertThat(response.totalPages()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("runSettlement")
+    class RunSettlement {
+
+        @Test
+        @DisplayName("정산 실행 후 RUN_SETTLEMENT 액션 이력을 저장한다")
+        void shouldRunSettlementAndSaveHistory() {
+            // given
+            UUID adminId = UUID.randomUUID();
+
+            // when
+            adminSettlementService.runSettlement(adminId);
+
+            // then
+            then(settlementInternalClient).should().runSettlement();
+
+            ArgumentCaptor<AdminActionHistory> captor = ArgumentCaptor.forClass(AdminActionHistory.class);
+            then(adminActionRepository).should().save(captor.capture());
+
+            AdminActionHistory saved = captor.getValue();
+            assertThat(saved.getAdminId()).isEqualTo(adminId);
+            assertThat(saved.getTargetType()).isEqualTo(AdminTargetType.SETTLEMENT);
+            assertThat(saved.getTargetId()).isNull();
+            assertThat(saved.getActionType()).isEqualTo(AdminActionType.RUN_SETTLEMENT);
+        }
+    }
+}

--- a/admin/src/test/java/com/devticket/admin/service/AdminUserServiceImplTest.java
+++ b/admin/src/test/java/com/devticket/admin/service/AdminUserServiceImplTest.java
@@ -1,0 +1,278 @@
+package com.devticket.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.devticket.admin.application.service.AdminUserServiceImpl;
+import com.devticket.admin.domain.model.AdminActionHistory;
+import com.devticket.admin.domain.model.AdminActionType;
+import com.devticket.admin.domain.model.AdminTargetType;
+import com.devticket.admin.domain.repository.AdminActionRepository;
+import com.devticket.admin.infrastructure.external.client.MemberInternalClient;
+import com.devticket.admin.infrastructure.external.dto.res.InternalMemberInfoResponse;
+import com.devticket.admin.infrastructure.persistence.repository.AdminActionHistoryRepositoryImpl;
+import com.devticket.admin.presentation.dto.req.UserRoleRequest;
+import com.devticket.admin.presentation.dto.req.UserSearchCondition;
+import com.devticket.admin.presentation.dto.req.UserStatusRequest;
+import com.devticket.admin.presentation.dto.res.AdminUserListResponse;
+import com.devticket.admin.presentation.dto.res.InternalMemberDetailResponse;
+import com.devticket.admin.presentation.dto.res.InternalMemberPageResponse;
+import com.devticket.admin.presentation.dto.res.UserDetailResponse;
+import com.devticket.admin.presentation.dto.res.UserListItem;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminUserServiceImpl 단위 테스트")
+class AdminUserServiceImplTest {
+
+    @Mock
+    private MemberInternalClient memberInternalClient;
+
+    @Mock
+    private AdminActionHistoryRepositoryImpl adminActionHistoryRepository;
+
+    @Mock
+    private AdminActionRepository adminActionRepository;
+
+    private AdminUserServiceImpl adminUserService;
+
+    @BeforeEach
+    void setUp() {
+        // AdminActionHistoryRepositoryImpl 이 AdminActionRepository 를 구현하기 때문에
+        // @InjectMocks 만으로는 두 의존성을 정확히 구분해서 주입하지 못한다.
+        // 생성자 인자 순서대로 명시적으로 주입한다.
+        adminUserService = new AdminUserServiceImpl(
+            memberInternalClient,
+            adminActionHistoryRepository,
+            adminActionRepository
+        );
+    }
+
+    @Nested
+    @DisplayName("getMembers")
+    class GetMembers {
+
+        @Test
+        @DisplayName("내부 회원 페이지 응답을 어드민 회원 목록으로 매핑한다")
+        void shouldReturnMappedMemberList() {
+            // given
+            UserSearchCondition condition =
+                new UserSearchCondition("USER", "ACTIVE", "kim", 0, 50);
+            InternalMemberInfoResponse member = new InternalMemberInfoResponse(
+                "user-1", "kim@test.com", "kimkim",
+                "USER", "ACTIVE", "LOCAL",
+                "2026-01-01T00:00:00", null
+            );
+            InternalMemberPageResponse page =
+                new InternalMemberPageResponse(List.of(member), 0, 50, 1L, 1);
+            given(memberInternalClient.getMembers(condition)).willReturn(page);
+
+            // when
+            AdminUserListResponse response = adminUserService.getMembers(condition);
+
+            // then
+            assertThat(response.page()).isEqualTo(0);
+            assertThat(response.size()).isEqualTo(50);
+            assertThat(response.totalElements()).isEqualTo(1L);
+            assertThat(response.totalPages()).isEqualTo(1);
+            assertThat(response.content()).hasSize(1);
+
+            UserListItem item = response.content().get(0);
+            assertThat(item.userId()).isEqualTo("user-1");
+            assertThat(item.email()).isEqualTo("kim@test.com");
+            assertThat(item.nickname()).isEqualTo("kimkim");
+            assertThat(item.role()).isEqualTo("USER");
+            assertThat(item.status()).isEqualTo("ACTIVE");
+            assertThat(item.providerType()).isEqualTo("LOCAL");
+            assertThat(item.createdAt()).isEqualTo("2026-01-01T00:00:00");
+            assertThat(item.withdrawnAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("내부 클라이언트가 빈 페이지를 반환하면 빈 목록을 반환한다")
+        void shouldReturnEmptyListWhenNoMembers() {
+            // given
+            UserSearchCondition condition =
+                new UserSearchCondition(null, null, null, 0, 50);
+            given(memberInternalClient.getMembers(condition))
+                .willReturn(new InternalMemberPageResponse(List.of(), 0, 50, 0L, 0));
+
+            // when
+            AdminUserListResponse response = adminUserService.getMembers(condition);
+
+            // then
+            assertThat(response.content()).isEmpty();
+            assertThat(response.totalElements()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("getUserDetail")
+    class GetUserDetail {
+
+        @Test
+        @DisplayName("회원 정보와 어드민 액션 이력을 합쳐 응답한다")
+        void shouldReturnUserDetailWithHistory() {
+            // given
+            UUID userId = UUID.randomUUID();
+            UUID adminId = UUID.randomUUID();
+            InternalMemberDetailResponse memberDetail = new InternalMemberDetailResponse(
+                userId.toString(), "lee@test.com", "lee",
+                "USER", "ACTIVE", "LOCAL",
+                "2026-01-01T00:00:00", null
+            );
+            given(memberInternalClient.getMember(userId)).willReturn(memberDetail);
+
+            AdminActionHistory history = AdminActionHistory.builder()
+                .adminId(adminId)
+                .targetType(AdminTargetType.USER)
+                .targetId(userId)
+                .actionType(AdminActionType.SUSPENDED_USER)
+                .build();
+            given(adminActionRepository.findByTarget(AdminTargetType.USER, userId))
+                .willReturn(List.of(history));
+
+            // when
+            UserDetailResponse response = adminUserService.getUserDetail(userId);
+
+            // then
+            assertThat(response.userId()).isEqualTo(userId.toString());
+            assertThat(response.email()).isEqualTo("lee@test.com");
+            assertThat(response.nickname()).isEqualTo("lee");
+            assertThat(response.role()).isEqualTo("USER");
+            assertThat(response.status()).isEqualTo("ACTIVE");
+            assertThat(response.providerType()).isEqualTo("LOCAL");
+
+            assertThat(response.penaltyHistory()).hasSize(1);
+            assertThat(response.penaltyHistory().get(0).actionType())
+                .isEqualTo("SUSPENDED_USER");
+            assertThat(response.penaltyHistory().get(0).adminId()).isEqualTo(adminId);
+        }
+
+        @Test
+        @DisplayName("어드민 액션 이력이 없으면 빈 리스트를 반환한다")
+        void shouldReturnEmptyHistoryWhenNoActions() {
+            // given - findByTarget 는 Mockito 기본 동작인 빈 리스트 반환에 의존한다
+            UUID userId = UUID.randomUUID();
+            InternalMemberDetailResponse memberDetail = new InternalMemberDetailResponse(
+                userId.toString(), "park@test.com", "park",
+                "USER", "ACTIVE", "LOCAL",
+                "2026-01-01T00:00:00", null
+            );
+            given(memberInternalClient.getMember(userId)).willReturn(memberDetail);
+
+            // when
+            UserDetailResponse response = adminUserService.getUserDetail(userId);
+
+            // then
+            assertThat(response.penaltyHistory()).isEmpty();
+            then(adminActionRepository).should().findByTarget(AdminTargetType.USER, userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("penalizeUser")
+    class PenalizeUser {
+
+        @Test
+        @DisplayName("상태가 SUSPENDED 면 회원 상태를 변경하고 SUSPENDED_USER 이력을 저장한다")
+        void shouldSuspendUserAndSaveHistory() {
+            // given
+            UUID adminId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            UserStatusRequest request = new UserStatusRequest("SUSPENDED");
+
+            // when
+            adminUserService.penalizeUser(adminId, userId, request);
+
+            // then
+            then(memberInternalClient).should().updateUserStatus(userId, request);
+
+            ArgumentCaptor<AdminActionHistory> captor = ArgumentCaptor.forClass(AdminActionHistory.class);
+            then(adminActionHistoryRepository).should().save(captor.capture());
+
+            AdminActionHistory saved = captor.getValue();
+            assertThat(saved.getAdminId()).isEqualTo(adminId);
+            assertThat(saved.getTargetType()).isEqualTo(AdminTargetType.USER);
+            assertThat(saved.getTargetId()).isEqualTo(userId);
+            assertThat(saved.getActionType()).isEqualTo(AdminActionType.SUSPENDED_USER);
+        }
+
+        @Test
+        @DisplayName("상태가 WITHDRAWN 면 WITHDRAW_USER 이력을 저장한다")
+        void shouldWithdrawUserAndSaveHistory() {
+            // given
+            UUID adminId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            UserStatusRequest request = new UserStatusRequest("WITHDRAWN");
+
+            // when
+            adminUserService.penalizeUser(adminId, userId, request);
+
+            // then
+            then(memberInternalClient).should().updateUserStatus(userId, request);
+
+            ArgumentCaptor<AdminActionHistory> captor = ArgumentCaptor.forClass(AdminActionHistory.class);
+            then(adminActionHistoryRepository).should().save(captor.capture());
+            assertThat(captor.getValue().getActionType())
+                .isEqualTo(AdminActionType.WITHDRAW_USER);
+        }
+
+        @Test
+        @DisplayName("상태가 ACTIVE 면 회원 상태만 변경하고 이력은 저장하지 않는다")
+        void shouldNotSaveHistoryWhenActive() {
+            // given
+            UUID adminId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            UserStatusRequest request = new UserStatusRequest("ACTIVE");
+
+            // when
+            adminUserService.penalizeUser(adminId, userId, request);
+
+            // then
+            then(memberInternalClient).should().updateUserStatus(userId, request);
+            then(adminActionHistoryRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUserRole")
+    class UpdateUserRole {
+
+        @Test
+        @DisplayName("회원 권한을 변경하고 CHANGE_ROLE 이력을 저장한다")
+        void shouldUpdateRoleAndSaveHistory() {
+            // given
+            UUID adminId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            UserRoleRequest request = new UserRoleRequest("SELLER");
+
+            // when
+            adminUserService.updateUserRole(adminId, userId, request);
+
+            // then
+            then(memberInternalClient).should().updateUserRole(userId, request);
+
+            ArgumentCaptor<AdminActionHistory> captor = ArgumentCaptor.forClass(AdminActionHistory.class);
+            then(adminActionHistoryRepository).should().save(captor.capture());
+
+            AdminActionHistory saved = captor.getValue();
+            assertThat(saved.getAdminId()).isEqualTo(adminId);
+            assertThat(saved.getTargetType()).isEqualTo(AdminTargetType.USER);
+            assertThat(saved.getTargetId()).isEqualTo(userId);
+            assertThat(saved.getActionType()).isEqualTo(AdminActionType.CHANGE_ROLE);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용
- Admin 서비스가 내부 모듈(Member/Event/Settlement)과 연동되도록 서비스/클라이언트 계층을 확장했습니다.
- 회원 목록 조회 응답을 페이지 기반으로 변경하고(`AdminUserListResponse`), 상세 조회 시 관리자 액션 이력을 함께 반환하도록 보완했습니다.
- 이벤트 목록 조회 및 강제 종료(force cancel) 기능을 내부 이벤트 모듈 호출 기반으로 구현했습니다.
- 정산 목록 조회 및 정산 실행(run settlement) 기능을 내부 정산 모듈 호출 기반으로 구현했습니다.
- 관리자 액션 이력 저장 대상에 정산 실행 액션(`RUN_SETTLEMENT`)을 추가했습니다.

## 변경 사항
- **application/service**
  - `AdminEventService`, `AdminEventServiceImpl` 추가
  - `AdminSettlementService`, `AdminSettlementServiceImpl` 추가
  - `AdminUserService`, `AdminUserServiceImpl` 수정 (회원 목록 페이징 응답 구조 반영, 이력 조회 연동)
- **domain**
  - `AdminActionType`에 `RUN_SETTLEMENT` 추가
  - `AdminActionRepository`에 `findByTarget(...)` 추가
- **infrastructure**
  - 내부 연동 클라이언트 확장:
    - `EventInternalClient`, `SettlementInternalClient`, `MemberInternalClient` 및 RestClient 구현체 수정/추가
  - 내부 응답 DTO 다수 추가:
    - 이벤트/회원/정산 페이지 응답, 공통 `InternalResponse` 등
  - `JpaConfig` 추가 (`@EnableJpaAuditing`)
- **presentation**
  - Admin 컨트롤러/요청·응답 DTO 다수 수정 및 추가
  - 회원/이벤트/정산 조회 응답 모델 정리
- **config**
  - `admin/src/main/resources/application-local.yml` 수정 (내부 모듈 연동 설정 반영)

## 테스트
- [x] 단위 테스트 통과
- [x] 통합 테스트 통과 (해당 시)

> 참고: PR Checks 기준 `CI - admin Service / build-and-test`가 실패했으며, 로그에 `Gradle Test - Process completed with exit code 1`가 표시됩니다.

## 관련 문서
- API 문서: 없음 (PR 내 별도 링크 확인되지 않음)
- ERD 변경: 없음 (확인된 변경 파일 기준 DB 스키마 변경 파일 없음)