### PR TITLE
[Commerce] fix: 판매자 참여자 조회 API 수정

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
@@ -64,6 +64,11 @@ public class TicketService implements TicketUsecase {
                 .toList();
             log.debug("[getTicketList] eventIds 추출 완료 - count={}, eventIds={}", eventIds.size(), eventIds);
 
+            // eventIds가 비어있으면 외부 호출 스킵
+            if (eventIds.isEmpty()) {
+                return TicketListResponse.of(ticketPage, List.of());
+            }
+
             //외부 API호출 : Event정보 조회
             InternalBulkEventInfoRequest bulkRequest = new InternalBulkEventInfoRequest(eventIds);
             log.debug("[getTicketList] Event 외부 API 호출 시작 - bulkRequest={}", bulkRequest);
@@ -142,44 +147,45 @@ public class TicketService implements TicketUsecase {
 
     public SellerEventParticipantListResponse getParticipantList(UUID userId, UUID eventId,
         SellerEventParticipantListRequest request) {
-        // 0단계 : 사용자 소유권 검증
+
         InternalEventInfoResponse eventInfo = ticketToEventClient.getSingleEventInfo(eventId);
         if (!eventInfo.sellerId().equals(userId)) {
             throw new BusinessException(TicketErrorCode.UNAUTHORIZED_EVENT_ACCESS);
         }
 
-        // 1단계: eventId로 티켓 목록 조회 (페이징)
         Page<Ticket> ticketPage = ticketRepository.findAllByEventId(eventId, request);
 
-        // 2단계: 각 티켓별로 필요한 정보 조합
-        List<SellerEventParticipantResponse> participants = ticketPage.getContent().stream()
-            .map(ticket -> {
+        // 유저별 티켓 그룹핑
+        Map<UUID, List<Ticket>> ticketsByUser = ticketPage.getContent().stream()
+            .collect(Collectors.groupingBy(Ticket::getUserId));
 
-                // orderItemId로 OrderItem 조회
-                OrderItem orderItem = orderItemRepository.findByOrderItemId(ticket.getOrderItemId())
+        List<SellerEventParticipantResponse> participants = ticketsByUser.entrySet().stream()
+            .map(entry -> {
+                UUID ticketUserId = entry.getKey();
+                List<Ticket> userTickets = entry.getValue();
+                Ticket firstTicket = userTickets.get(0);
+
+                OrderItem orderItem = orderItemRepository.findByOrderItemId(firstTicket.getOrderItemId())
                     .orElseThrow(() -> new BusinessException(OrderItemErrorCode.ORDER_ITEM_NOT_FOUND));
 
-                // orderId로 Order 조회 → orderNumber 가져오기
                 Order order = orderRepository.findById(orderItem.getOrderId())
                     .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
-                // userId로 Member 서비스 호출 → email 가져오기
-                InternalMemberInfoResponse memberInfo = ticketToMemberClient.getMemberInfo(ticket.getUserId());
+                InternalMemberInfoResponse memberInfo = ticketToMemberClient.getMemberInfo(ticketUserId);
 
                 return SellerEventParticipantResponse.of(
-                    ticket.getTicketId().toString(),
+                    firstTicket.getTicketId().toString(),
                     order.getOrderId().toString(),
-                    ticket.getUserId().toString(),
-                    memberInfo.email(),
+                    ticketUserId.toString(),
                     memberInfo.nickname(),
-                    ticket.getIssuedAt().toString(),
+                    memberInfo.email(),
+                    userTickets.size(),
+                    firstTicket.getIssuedAt().toString(),
                     order.getOrderNumber()
                 );
             })
             .toList();
 
-        // 3단계: 응답 구성
         return SellerEventParticipantListResponse.of(ticketPage, participants);
-
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
@@ -144,7 +144,7 @@ public class TicketService implements TicketUsecase {
         SellerEventParticipantListRequest request) {
         // 0단계 : 사용자 소유권 검증
         InternalEventInfoResponse eventInfo = ticketToEventClient.getSingleEventInfo(eventId);
-        if (eventInfo.sellerId().equals(userId)) {
+        if (!eventInfo.sellerId().equals(userId)) {
             throw new BusinessException(TicketErrorCode.UNAUTHORIZED_EVENT_ACCESS);
         }
 
@@ -171,6 +171,7 @@ public class TicketService implements TicketUsecase {
                     order.getOrderId().toString(),
                     ticket.getUserId().toString(),
                     memberInfo.email(),
+                    memberInfo.nickname(),
                     ticket.getIssuedAt().toString(),
                     order.getOrderNumber()
                 );

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/external/client/dto/InternalMemberInfoResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/external/client/dto/InternalMemberInfoResponse.java
@@ -1,7 +1,8 @@
 package com.devticket.commerce.ticket.infrastructure.external.client.dto;
 
 public record InternalMemberInfoResponse(
-    String email
+    String email,
+    String nickname
 ) {
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/SellerTicketController.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/SellerTicketController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/seller/events")
+@RequestMapping("/api/seller/events")
 @Tag(name = "Seller Ticket API", description = "판매자 대상 티켓 API")
 public class SellerTicketController {
 

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantListResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantListResponse.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Page;
 
 public record SellerEventParticipantListResponse(
 
-    List<SellerEventParticipantResponse> sellerEventParticipantListResponse,
+    List<SellerEventParticipantResponse> content,
 
     int page,
 

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantResponse.java
@@ -7,6 +7,7 @@ public record SellerEventParticipantResponse(
     String userId,
     String userName,
     String email,
+    int quantity,
     String purchasedAt,
     String orderNumber
 ) {
@@ -17,10 +18,11 @@ public record SellerEventParticipantResponse(
         String userId,
         String userName,
         String email,
+        int quantity,
         String purchasedAt,
         String orderNumber) {
         return new SellerEventParticipantResponse(
-            ticketId, orderId, userId, userName, email, purchasedAt, orderNumber
+            ticketId, orderId, userId, userName, email, quantity, purchasedAt, orderNumber
         );
     }
 

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantResponse.java
@@ -5,7 +5,7 @@ public record SellerEventParticipantResponse(
     String ticketId,
     String orderId,
     String userId,
-//    String userName, 차후 entity 수정 후 결정
+    String userName,
     String email,
     String purchasedAt,
     String orderNumber
@@ -15,12 +15,12 @@ public record SellerEventParticipantResponse(
         String ticketId,
         String orderId,
         String userId,
-//        String userName,
+        String userName,
         String email,
         String purchasedAt,
         String orderNumber) {
         return new SellerEventParticipantResponse(
-            ticketId, orderId, userId, email, purchasedAt, orderNumber
+            ticketId, orderId, userId, userName, email, purchasedAt, orderNumber
         );
     }
 


### PR DESCRIPTION
## 작업 내용
- 판매자 이벤트 참여자 목록 조회 API 정상 동작하도록 수정
- 프론트엔드 응답 구조와 일치하도록 DTO 필드명 통일

## 변경 사항
- `SellerTicketController`: RequestMapping `/seller/events` → `/api/seller/events`, 응답 SuccessResponse 래핑
- `TicketService.getParticipantList`: 소유권 검증 조건 반전 버그 수정 (`equals` → `!equals`)
- `SellerEventParticipantListResponse`: 필드명 `sellerEventParticipantListResponse` → `content`
- `SellerEventParticipantResponse`: `nickname` 필드 추가
- `InternalMemberInfoResponse` (client DTO): `nickname` 필드 추가

## 테스트
- [ ] 판매자 대시보드 → 이벤트 상세 → 참여자 목록 정상 조회 확인
- [ ] Swagger 동작 확인

## 참고 사항
- Member Internal API는 이미 nickname 포함 응답 중이므로 Member 측 변경 없음
- Gateway 라우팅에서 `/api/seller/events/{eventId}/participants`는 commerce-service로 포워딩 필요