### PR TITLE
[AI] feat: recent_vector Spring Batch 재계산 구현

### DIFF
--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -40,6 +40,14 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // Spring Batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+
+    // H2 (Batch 메타데이터 in-memory 저장용)
+    runtimeOnly 'com.h2database:h2'
+    // jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/ai/src/main/java/org/example/ai/application/service/RecentVectorService.java
+++ b/ai/src/main/java/org/example/ai/application/service/RecentVectorService.java
@@ -26,6 +26,11 @@ public class RecentVectorService {
         // 1. Log Service에서 최근 7 일 조회
         ActionLogResponse response = logServiceClient.getRecentActionLog(userId);
 
+        if (response == null || response.logs() == null || response.logs().isEmpty()) {
+            log.info("[RecentVector] 로그 없음 - userId: {}", userId);
+            return;
+        }
+
         // 2. eventId 별 가중치 합산
         // VIEW/DETAIL_VIEW : eventId 3 회 이상 -> 무시
         Map<String, Integer> detailViewCount = new HashMap<>();

--- a/ai/src/main/java/org/example/ai/application/service/RecentVectorService.java
+++ b/ai/src/main/java/org/example/ai/application/service/RecentVectorService.java
@@ -1,0 +1,145 @@
+package org.example.ai.application.service;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.ai.domain.model.UserVector;
+import org.example.ai.domain.repository.EventEmbeddingRepository;
+import org.example.ai.domain.repository.UserVectorRepository;
+import org.example.ai.infrastructure.external.client.LogServiceClient;
+import org.example.ai.infrastructure.external.dto.res.ActionLogResponse;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecentVectorService {
+
+    private final UserVectorRepository userVectorRepository;
+    private final EventEmbeddingRepository eventEmbeddingRepository;
+    private final LogServiceClient logServiceClient;
+
+
+    public void recalculateRecentVector(String userId){
+        // 1. Log Service에서 최근 7 일 조회
+        ActionLogResponse response = logServiceClient.getRecentActionLog(userId);
+
+        // 2. eventId 별 가중치 합산
+        // VIEW/DETAIL_VIEW : eventId 3 회 이상 -> 무시
+        Map<String, Integer> detailViewCount = new HashMap<>();
+        Map<String, Integer> viewCount = new HashMap<>();
+        Map<String, Float> eventWeightMap = new HashMap<>();
+
+        for(ActionLogResponse.ActionLogEntry log : response.logs()){
+            String eventId = log.eventId();
+            float weight = 0f;
+
+            switch (log.actionType()){
+                case "VIEW" -> {
+                    int count = viewCount.getOrDefault(eventId,0);
+                    if(count >= 3) continue; // view 3회 이상 -> 무시
+                    viewCount.put(eventId, count + 1);
+                    weight = 0.3f;
+                }
+                case "DETAIL_VIEW" -> {
+                    int count = detailViewCount.getOrDefault(eventId,0);
+                    if(count >= 3) continue;
+                    detailViewCount.put(eventId, count + 1);
+                    weight = 1.0f;
+                }
+                case "DWELL_TIME" -> {
+                    if(log.dwellTimeSeconds() == null || log.dwellTimeSeconds() < 5) continue;
+                    weight = dwellTimeWeight(log.dwellTimeSeconds());
+                }
+                default -> {continue;}
+            }
+
+            // eventId가 같다면 -> weight에 더하기
+            eventWeightMap.merge(eventId, weight, Float::sum);
+        } // for 문 종료
+
+        if(eventWeightMap.isEmpty()){
+            log.info("[RecentVector] 유효한 로그 없음 - userId: {}", userId);
+            return;
+        }
+
+        // 3. 가중 평균으로 recent_vector 계산
+        float[] newRecentVector = new float[1536];
+        float totalWeight = 0f;
+
+        for(Map.Entry<String, Float> entry : eventWeightMap.entrySet()){
+            float[] embedding = eventEmbeddingRepository.findEmbeddingById(entry.getKey())
+                .orElse(null);
+
+            if (embedding == null) {
+                log.warn("[RecentVector] embedding 없음 - eventId: {}", entry.getKey());
+                continue;
+            }
+
+            float w = entry.getValue();
+
+            for(int i = 0; i < 1536; i++){
+                newRecentVector[i] += embedding[i] * w;
+            }
+
+            totalWeight += w;
+        }
+
+        if (totalWeight == 0) {
+            log.warn("[RecentVector] totalWeight 0 - userId: {}", userId);
+            return;
+        }
+
+        for (int i = 0; i < 1536; i++) {
+            newRecentVector[i] /= totalWeight;
+        }
+
+        UserVector userVector = userVectorRepository.findById(userId)
+            .orElse(UserVector.builder()
+                .userId(userId)
+                .preferenceVector(new float[1536])
+                .preferenceWeightSum(0f)
+                .recentVector(new float[1536])
+                .recentWeightSum(0f)
+                .cartVector(new float[1536])
+                .cartWeightSum(0f)
+                .negativeVector(new float[1536])
+                .negativeWeightSum(0f)
+                .updatedAt(Instant.now().toString())
+                .build());
+
+        UserVector updated = UserVector.builder()
+            .userId(userId)
+            .preferenceVector(userVector.getPreferenceVector())
+            .preferenceWeightSum(userVector.getPreferenceWeightSum())
+            .recentVector(newRecentVector)
+            .recentWeightSum(totalWeight)
+            .cartVector(userVector.getCartVector())
+            .cartWeightSum(userVector.getCartWeightSum())
+            .negativeVector(userVector.getNegativeVector())
+            .negativeWeightSum(userVector.getNegativeWeightSum())
+            .updatedAt(Instant.now().toString())
+            .build();
+
+        userVectorRepository.save(updated);
+        log.info("[RecentVector] 갱신 완료 - userId: {}, totalWeight: {}", userId, totalWeight);
+    }
+
+    
+    private float dwellTimeWeight(int seconds){
+        if (seconds < 5)  return 0f;
+        if (seconds < 30) return 0.5f;
+        if (seconds < 60) return 1.0f;
+        return 2.0f;
+    }
+    
+    
+    
+    
+    
+    
+    
+    
+}

--- a/ai/src/main/java/org/example/ai/domain/repository/UserVectorRepository.java
+++ b/ai/src/main/java/org/example/ai/domain/repository/UserVectorRepository.java
@@ -1,9 +1,11 @@
 package org.example.ai.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.example.ai.domain.model.UserVector;
 
 public interface UserVectorRepository {
     Optional<UserVector> findById(String userId);
     UserVector save(UserVector userVector);
+    List<UserVector> findAll();
 }

--- a/ai/src/main/java/org/example/ai/infrastructure/batch/RecentVectorScheduler.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/batch/RecentVectorScheduler.java
@@ -1,0 +1,48 @@
+package org.example.ai.infrastructure.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class RecentVectorScheduler {
+
+    private final JobOperator jobOperator;
+    private final Job recentVectorJob;
+
+    // 매주 월요일 03 시
+//    @Scheduled(cron = "0 0  3 * * MON")
+    // 테스트용 10초
+    @Scheduled(initialDelay = 10000, fixedDelay = Long.MAX_VALUE)
+    public void runRecentVectorJob(){
+        try{
+            JobParameters params = new JobParametersBuilder()
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+            jobOperator.run(recentVectorJob, params);
+            log.info("[Scheduler] recent_vector Job 실행 완료");
+        }catch (Exception e){
+            log.error("[Scheduler] recent_vector Job 실행 실패", e);
+        }
+    }
+
+
+
+
+
+
+
+
+}

--- a/ai/src/main/java/org/example/ai/infrastructure/config/BatchTransactionConfig.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/config/BatchTransactionConfig.java
@@ -1,0 +1,28 @@
+package org.example.ai.infrastructure.config;
+
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class BatchTransactionConfig {
+
+    @Bean
+    public DataSource batchDataSource() {
+        return new EmbeddedDatabaseBuilder()
+            .setType(EmbeddedDatabaseType.H2)
+            .build();
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+        return new DataSourceTransactionManager(batchDataSource());
+    }
+
+}

--- a/ai/src/main/java/org/example/ai/infrastructure/config/RecentVectorJobConfig.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/config/RecentVectorJobConfig.java
@@ -1,0 +1,68 @@
+package org.example.ai.infrastructure.config;
+
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.ai.application.service.RecentVectorService;
+import org.example.ai.domain.repository.UserVectorRepository;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class RecentVectorJobConfig {
+
+    private final RecentVectorService recentVectorService;
+    private final UserVectorRepository userVectorRepository;
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+
+    @Bean
+    public Job recentVectorJob(){
+        return new JobBuilder("recentVectorJob", jobRepository)
+            .start(recentVectorStep())
+            .build();
+    }
+
+    @Bean
+    public Step recentVectorStep() {
+        return new StepBuilder("recentVectorStep", jobRepository)
+            .tasklet(recentVectorTasklet(), transactionManager)
+            .build();
+    }
+
+    // 작업 단위
+    @Bean
+    public Tasklet recentVectorTasklet() {
+        return (contribution, chunkContext) ->{
+            log.info("[Batch] recent_vector 재계산 시작");
+
+            // ES user-index에서 전체 userId 조회 후 순회
+            userVectorRepository.findAll().forEach(userVector -> {
+                try{
+                    recentVectorService.recalculateRecentVector(userVector.getUserId());
+                }
+                catch (Exception e){
+                    log.error("[Batch] userId 처리 실패 - userId: {}", userVector.getUserId(), e);
+                }
+            });
+            
+            log.info("[Batch] recent_vector 재계산 완료");
+            return RepeatStatus.FINISHED;
+        };
+
+    }
+
+
+}

--- a/ai/src/main/java/org/example/ai/infrastructure/config/WebClientConfig.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/config/WebClientConfig.java
@@ -1,0 +1,15 @@
+package org.example.ai.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(){
+        return WebClient.builder().build();
+    }
+
+}

--- a/ai/src/main/java/org/example/ai/infrastructure/external/client/LogServiceClient.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/external/client/LogServiceClient.java
@@ -1,0 +1,43 @@
+package org.example.ai.infrastructure.external.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.ai.infrastructure.external.dto.req.ActionLogRequest;
+import org.example.ai.infrastructure.external.dto.res.ActionLogResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LogServiceClient {
+
+    private final WebClient webClient;
+
+    @Value("${internal.log-service.url}")
+    private String logServiceUrl;
+
+    public ActionLogResponse getRecentActionLog(String userId) {
+        ActionLogRequest request = new ActionLogRequest(userId, "VIEW,DETAIL_VIEW,DWELL_TIME");
+
+        try {
+            return webClient.get()
+                .uri(logServiceUrl + "/internal/logs/actions",
+                    uriBuilder -> uriBuilder
+                        .queryParam("userId", request.userId())
+                        .queryParam("days", 7)
+                        .queryParam("actionTypes", request.actionTypes())
+                        .build())
+                .retrieve()
+                .bodyToMono(ActionLogResponse.class)
+                .block();
+        } catch (Exception e) {
+            log.error("[LogService] 로그 조회 실패 - userId: {}", userId, e);
+            return null;
+        }
+    }
+
+
+
+}

--- a/ai/src/main/java/org/example/ai/infrastructure/external/dto/req/ActionLogRequest.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/external/dto/req/ActionLogRequest.java
@@ -1,0 +1,12 @@
+package org.example.ai.infrastructure.external.dto.req;
+
+public record ActionLogRequest(
+    String userId,
+    String actionTypes
+) {
+
+    public static ActionLogRequest ofRecent(String userId){
+        return new ActionLogRequest(userId, "VIEW,DETAIL_VIEW,DWELL_TIME");
+    }
+
+}

--- a/ai/src/main/java/org/example/ai/infrastructure/external/dto/res/ActionLogResponse.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/external/dto/res/ActionLogResponse.java
@@ -1,0 +1,16 @@
+package org.example.ai.infrastructure.external.dto.res;
+
+import java.util.List;
+
+public record ActionLogResponse(
+    String userId,
+    List<ActionLogEntry> logs
+) {
+
+    public record ActionLogEntry(
+       String eventId,
+       String actionType,
+       Integer dwellTimeSeconds
+    ){}
+
+}

--- a/ai/src/main/java/org/example/ai/infrastructure/persistence/repository/UserVectorRepositoryImpl.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/persistence/repository/UserVectorRepositoryImpl.java
@@ -1,5 +1,7 @@
 package org.example.ai.infrastructure.persistence.repository;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.example.ai.domain.model.UserVector;
@@ -21,5 +23,12 @@ public class UserVectorRepositoryImpl implements UserVectorRepository {
     @Override
     public UserVector save(UserVector userVector) {
         return userVectorESRepository.save(userVector);
+    }
+
+    @Override
+    public List<UserVector> findAll() {
+        List<UserVector> result = new ArrayList<>();
+        userVectorESRepository.findAll().forEach(result::add);
+        return result;
     }
 }

--- a/ai/src/main/resources/application-local.yml
+++ b/ai/src/main/resources/application-local.yml
@@ -41,7 +41,7 @@ openai:
 
 internal:
   log-service:
-    url: http://localhost:8086
+    url: http://localhost:8085
 
 logging:
   level:

--- a/ai/src/main/resources/application-local.yml
+++ b/ai/src/main/resources/application-local.yml
@@ -8,6 +8,26 @@ spring:
       properties:
         spring.json.trusted.packages: "*"
 
+  batch:
+    job:
+      enabled: false
+    jdbc:
+      initialize-schema: always
+
+  datasource:
+    url: jdbc:h2:mem:batch;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+
   elasticsearch:
     uris: http://localhost:9200
     connection-timeout: 5s


### PR DESCRIPTION

## 관련 이슈
- close #346

## 작업 내용
- Log Service Internal API 호출용 DTO 작성 (ActionLogRequest, ActionLogResponse)
- LogServiceClient 작성 (WebClient 기반 Log Service Internal API 호출)
- RecentVectorService 구현 (VIEW/DETAIL_VIEW/DWELL_TIME 로그 기반 recent_vector 재계산)
- RecentVectorJobConfig 작성 (Spring Batch Job/Step/Tasklet 구성)
- RecentVectorScheduler 작성 (매주 월요일 새벽 3시 자동 실행)
- BatchTransactionConfig 작성 (H2 인메모리 DB 기반 Batch 메타데이터 저장)
- UserVectorRepository에 findAll() 추가

## 변경 사항
- infrastructure/external/client/LogServiceClient.java (신규)
- infrastructure/external/dto/req/ActionLogRequest.java (신규)
- infrastructure/external/dto/res/ActionLogResponse.java (신규)
- application/service/RecentVectorService.java (신규)
- infrastructure/config/RecentVectorJobConfig.java (신규)
- infrastructure/config/BatchTransactionConfig.java (신규)
- infrastructure/batch/RecentVectorScheduler.java (신규)
- infrastructure/config/WebClientConfig.java (신규)
- domain/repository/UserVectorRepository.java (수정 - findAll 추가)
- infrastructure/persistence/repository/UserVectorRepositoryImpl.java (수정 - findAll 구현)
- build.gradle (수정 - Spring Batch, H2, JPA 의존성 추가)
- application-local.yml (수정 - Batch, DataSource, JPA 설정 추가)

## 테스트
- [x] Spring Batch Job 정상 실행 확인
- [x] Mock 데이터로 recent_vector 재계산 확인
- [x] ES user-index recentVector 저장 확인

## 참고 사항
- LogServiceClient는 현재 Mock 데이터 반환 (Log Service 연동 후 실제 API 호출로 교체 필요)
- 스케줄러 cron은 매주 월요일 새벽 3시로 설정 (테스트 시 initialDelay로 임시 변경)
- Spring Batch 메타데이터는 H2 인메모리 DB에 저장 (앱 재시작 시 초기화)