### PR TITLE
[Event] feat: KNN 검색 개선 및 Elasticsearch 데이터 동기화

### DIFF
--- a/event/build.gradle
+++ b/event/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 
     // ES
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    testImplementation 'org.testcontainers:testcontainers:1.19.0'
+    testImplementation 'org.testcontainers:elasticsearch:1.19.0'
 
 }
 

--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -1,5 +1,6 @@
 package com.devticket.event.application;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
@@ -10,6 +11,7 @@ import com.devticket.event.domain.model.Event;
 import com.devticket.event.domain.model.EventImage;
 import com.devticket.event.domain.model.EventTechStack;
 import com.devticket.event.infrastructure.client.MemberClient;
+import com.devticket.event.infrastructure.client.OpenAiEmbeddingClient;
 import com.devticket.event.infrastructure.client.dto.TechStackItem;
 import com.devticket.event.infrastructure.persistence.EventRepository;
 import com.devticket.event.infrastructure.search.EventDocument;
@@ -24,7 +26,13 @@ import com.devticket.event.presentation.dto.SellerEventDetailResponse;
 import com.devticket.event.presentation.dto.SellerEventSummaryResponse;
 import com.devticket.event.presentation.dto.SellerEventUpdateRequest;
 import com.devticket.event.presentation.dto.SellerEventUpdateResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.StringReader;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -33,9 +41,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -51,6 +57,8 @@ public class EventService {
     private final MemberClient memberClient;
     private final EventSearchRepository eventSearchRepository;
     private final ElasticsearchOperations elasticsearchOperations;
+    private final ElasticsearchClient esClient;
+    private final OpenAiEmbeddingClient openAiEmbeddingClient;
 
     private static final Set<String> ALLOWED_SORT_FIELDS = Set.of("createdAt", "price", "eventDateTime");
 
@@ -143,11 +151,12 @@ public class EventService {
         NativeQuery query = buildSearchQuery(request, allowedStatuses, pageable);
         SearchHits<EventDocument> searchHits = elasticsearchOperations.search(query, EventDocument.class);
 
-        List<UUID> pageEventIds = searchHits.stream()
-            .map(hit -> UUID.fromString(hit.getContent().getId()))
+        // ES 결과를 String ID 기준으로 순서 유지
+        List<String> rawIds = searchHits.stream()
+            .map(hit -> hit.getContent().getId())
             .toList();
 
-        if (pageEventIds.isEmpty()) {
+        if (rawIds.isEmpty()) {
             return new EventListResponse(
                 List.of(),
                 pageable.getPageNumber(),
@@ -157,24 +166,44 @@ public class EventService {
             );
         }
 
-        // N+1 방지: JPA로 상세 데이터 일괄 로드
-        List<Event> hydratedEvents = eventRepository.findAllWithDetailsByEventIdIn(pageEventIds);
-        List<Event> imageEvents = eventRepository.findEventImagesByEventIdIn(pageEventIds);
-
-        Map<UUID, Event> hydratedById = hydratedEvents.stream()
-            .collect(Collectors.toMap(Event::getEventId, e -> e));
-        Map<UUID, Event> imagesById = imageEvents.stream()
-            .collect(Collectors.toMap(Event::getEventId, e -> e));
-
-        // ES 결과 순서 유지
-        List<EventListContentResponse> content = pageEventIds.stream()
+        // UUID로 변환 가능한 ID만 DB 조회에 사용
+        List<UUID> uuidIds = rawIds.stream()
             .map(id -> {
-                Event hydrated = hydratedById.get(id);
-                if (hydrated == null) {
-                    return null;
-                }
-                Event withImages = imagesById.getOrDefault(id, hydrated);
-                return EventListContentResponse.from(withImages);
+                try { return UUID.fromString(id); }
+                catch (IllegalArgumentException e) { return null; }
+            })
+            .filter(id -> id != null)
+            .toList();
+
+        Map<UUID, Event> hydratedById = Collections.emptyMap();
+        Map<UUID, Event> imagesById = Collections.emptyMap();
+        if (!uuidIds.isEmpty()) {
+            hydratedById = eventRepository.findAllWithDetailsByEventIdIn(uuidIds).stream()
+                .collect(Collectors.toMap(Event::getEventId, e -> e));
+            imagesById = eventRepository.findEventImagesByEventIdIn(uuidIds).stream()
+                .collect(Collectors.toMap(Event::getEventId, e -> e));
+        }
+
+        // ES 문서 Map (DB fallback용)
+        Map<String, EventDocument> esDocById = searchHits.stream()
+            .collect(Collectors.toMap(hit -> hit.getContent().getId(), hit -> hit.getContent()));
+
+        final Map<UUID, Event> finalHydratedById = hydratedById;
+        final Map<UUID, Event> finalImagesById = imagesById;
+
+        // ES 결과 순서 유지, DB에 있으면 DB 우선 / 없으면 ES fallback
+        List<EventListContentResponse> content = rawIds.stream()
+            .map(rawId -> {
+                try {
+                    UUID uuid = UUID.fromString(rawId);
+                    Event hydrated = finalHydratedById.get(uuid);
+                    if (hydrated != null) {
+                        Event withImages = finalImagesById.getOrDefault(uuid, hydrated);
+                        return EventListContentResponse.from(withImages);
+                    }
+                } catch (IllegalArgumentException ignored) {}
+                EventDocument doc = esDocById.get(rawId);
+                return doc != null ? EventListContentResponse.from(doc) : null;
             })
             .filter(Objects::nonNull)
             .toList();
@@ -312,10 +341,71 @@ public class EventService {
         return SellerEventUpdateResponse.from(event);
     }
 
-    // ES 동기화 실패가 핵심 비즈니스 흐름에 영향을 주지 않도록 예외 격리
+    /**
+     * Spring Data ES 컨버터를 완전히 우회하고 esClient.index()로 직접 인덱싱.
+     * dense_vector(embedding)은 Spring Data ES 컨버터가 직렬화하지 못하므로
+     * Map<String, Object>로 전체 문서를 구성해서 ES REST API에 직접 전송.
+     */
     private void syncToElasticsearch(Event event) {
         try {
-            eventSearchRepository.save(EventDocument.from(event));
+            List<String> techStackNames = event.getEventTechStacks().stream()
+                .map(EventTechStack::getTechStackName)
+                .toList();
+
+            String embeddingText = techStackNames.isEmpty()
+                ? event.getTitle() + ". Category: " + event.getCategory().name()
+                : event.getTitle() + ". Category: " + event.getCategory().name()
+                    + ". Tech Stacks: " + String.join(", ", techStackNames);
+
+            Map<String, Object> doc = new HashMap<>();
+            doc.put("id", event.getEventId().toString());
+            doc.put("title", event.getTitle());
+            doc.put("category", event.getCategory().name());
+            doc.put("techStacks", techStackNames);
+            doc.put("status", event.getStatus().name());
+            // mapping의 date_hour_minute_second 형식에 맞춤 (나노초 제외)
+            doc.put("indexedAt", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")));
+
+            float[] vector = openAiEmbeddingClient.embed(embeddingText);
+            if (vector != null) {
+                log.debug("[1] Vector 생성 완료: 차원={}, 첫 5개 값={}", vector.length,
+                    java.util.Arrays.toString(java.util.Arrays.copyOf(vector, Math.min(5, vector.length))));
+
+                List<Float> vectorList = new ArrayList<>(vector.length);
+                for (float v : vector) vectorList.add(v);
+
+                log.debug("[2] vectorList 생성 완료: 크기={}, 첫 5개 값={}", vectorList.size(),
+                    vectorList.subList(0, Math.min(5, vectorList.size())));
+
+                doc.put("embedding", vectorList);
+                log.debug("[3] doc에 embedding 추가 완료. doc 키들: {}", doc.keySet());
+            } else {
+                log.warn("[Embedding 생략] eventId: {}", event.getEventId());
+            }
+
+            // Jackson으로 직렬화 후 withJson()으로 전송
+            ObjectMapper objectMapper = new ObjectMapper();
+            String json = objectMapper.writeValueAsString(doc);
+
+            log.debug("[4] JSON 직렬화 완료: 길이={}", json.length());
+            log.debug("[4-1] JSON (처음 500자): {}", json.substring(0, Math.min(500, json.length())));
+
+            // embedding이 JSON에 포함되어 있는지 확인
+            if (json.contains("\"embedding\"")) {
+                log.debug("[5] ✓ JSON에 embedding 필드 포함됨");
+                int embeddingStart = json.indexOf("\"embedding\"");
+                int embeddingEnd = json.indexOf("]", embeddingStart) + 1;
+                log.debug("[5-1] embedding 값: {}", json.substring(embeddingStart, Math.min(embeddingEnd + 100, json.length())));
+            } else {
+                log.warn("[5] ✗ JSON에 embedding 필드가 없음!");
+            }
+
+            esClient.index(i -> i
+                .index("event")
+                .id(event.getEventId().toString())
+                .withJson(new StringReader(json)));
+
+            log.debug("[ES 동기화 완료] eventId: {}", event.getEventId());
         } catch (Exception e) {
             log.warn("[ES 동기화 실패] eventId: {}", event.getEventId(), e);
         }
@@ -324,69 +414,46 @@ public class EventService {
     private NativeQuery buildSearchQuery(
         EventListRequest request, List<EventStatus> allowedStatuses, Pageable pageable) {
 
-        BoolQuery.Builder boolQuery = new BoolQuery.Builder();
+        var queryBuilder = NativeQuery.builder();
 
-        // 키워드: title, description 대상 multi_match
+        // kNN 벡터 검색 (키워드가 있을 때)
         if (request.keyword() != null && !request.keyword().isBlank()) {
-            boolQuery.must(Query.of(q -> q
-                .multiMatch(m -> m
-                    .fields("title", "description")
-                    .query(request.keyword()))));
+            float[] queryVector = openAiEmbeddingClient.embed(request.keyword());
+            if (queryVector != null) {
+                List<Float> vectorList = new ArrayList<>();
+                for (float v : queryVector) vectorList.add(v);
+                queryBuilder.withQuery(Query.of(q -> q
+                    .knn(k -> k
+                        .field("embedding")
+                        .queryVector(vectorList)
+                        .k(30)
+                        .numCandidates(50))));
+            }
         }
 
-        // 카테고리 필터
-        if (request.category() != null) {
-            boolQuery.filter(Query.of(q -> q
-                .term(t -> t.field("category").value(request.category().name()))));
-        }
+        // 필터 (category, status)
+        var filterQuery = new BoolQuery.Builder();
 
-        // 상태 필터
         if (allowedStatuses != null && !allowedStatuses.isEmpty()) {
             List<FieldValue> statusValues = allowedStatuses.stream()
                 .map(s -> FieldValue.of(s.name()))
                 .toList();
-            boolQuery.filter(Query.of(q -> q
+            filterQuery.filter(Query.of(q -> q
                 .terms(t -> t.field("status").terms(tv -> tv.value(statusValues)))));
         }
 
-        // 판매자 필터
-        if (request.sellerId() != null) {
-            boolQuery.filter(Query.of(q -> q
-                .term(t -> t.field("sellerId").value(request.sellerId().toString()))));
+        if (request.category() != null) {
+            filterQuery.filter(Query.of(q -> q
+                .term(t -> t.field("category").value(request.category().name()))));
         }
 
-        // 기술스택 필터 (Nested)
-        if (request.techStacks() != null && !request.techStacks().isEmpty()) {
-            List<Query> techStackShoulds = request.techStacks().stream()
-                .map(techStackId -> Query.of(q -> q
-                    .nested(n -> n.path("techStacks")
-                        .query(nq -> nq.term(t -> t
-                            .field("techStacks.techStackId")
-                            .value(techStackId))))))
-                .toList();
-            boolQuery.filter(Query.of(q -> q
-                .bool(b -> b.should(techStackShoulds).minimumShouldMatch("1"))));
-        }
+        queryBuilder
+            .withFilter(Query.of(q -> q.bool(filterQuery.build())))
+            .withPageable(pageable);
 
-        // 정렬: 지정 없으면 최신순 기본 적용
-        Sort sort;
-        if (pageable.getSort().isSorted()) {
-            List<Sort.Order> validOrders = pageable.getSort().stream()
-                .filter(order -> ALLOWED_SORT_FIELDS.contains(order.getProperty()))
-                .toList();
-            sort = validOrders.isEmpty()
-                ? Sort.by(Sort.Direction.DESC, "createdAt")
-                : Sort.by(validOrders);
-        } else {
-            sort = Sort.by(Sort.Direction.DESC, "createdAt");
-        }
-
-
-
-        return NativeQuery.builder()
-            .withQuery(Query.of(q -> q.bool(boolQuery.build())))
-            .withPageable(PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort))
-            .build();
+        return queryBuilder.build();
     }
+
+
 
 }

--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -15,7 +15,6 @@ import com.devticket.event.infrastructure.client.OpenAiEmbeddingClient;
 import com.devticket.event.infrastructure.client.dto.TechStackItem;
 import com.devticket.event.infrastructure.persistence.EventRepository;
 import com.devticket.event.infrastructure.search.EventDocument;
-import com.devticket.event.infrastructure.search.EventSearchRepository;
 import com.devticket.event.presentation.dto.EventDetailResponse;
 import com.devticket.event.presentation.dto.EventListContentResponse;
 import com.devticket.event.presentation.dto.EventListRequest;
@@ -31,12 +30,10 @@ import java.io.StringReader;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -55,12 +52,9 @@ public class EventService {
 
     private final EventRepository eventRepository;
     private final MemberClient memberClient;
-    private final EventSearchRepository eventSearchRepository;
     private final ElasticsearchOperations elasticsearchOperations;
     private final ElasticsearchClient esClient;
     private final OpenAiEmbeddingClient openAiEmbeddingClient;
-
-    private static final Set<String> ALLOWED_SORT_FIELDS = Set.of("createdAt", "price", "eventDateTime");
 
     @Transactional
     public SellerEventCreateResponse createEvent(UUID sellerId, SellerEventCreateRequest request) {
@@ -150,12 +144,11 @@ public class EventService {
         NativeQuery query = buildSearchQuery(request, allowedStatuses, pageable);
         SearchHits<EventDocument> searchHits = elasticsearchOperations.search(query, EventDocument.class);
 
-        // ES 결과를 String ID 기준으로 순서 유지
-        List<String> rawIds = searchHits.stream()
-            .map(hit -> hit.getContent().getId())
+        List<UUID> pageEventIds = searchHits.stream()
+            .map(hit -> UUID.fromString(hit.getContent().getId()))
             .toList();
 
-        if (rawIds.isEmpty()) {
+        if (pageEventIds.isEmpty()) {
             return new EventListResponse(
                 List.of(),
                 pageable.getPageNumber(),
@@ -165,44 +158,19 @@ public class EventService {
             );
         }
 
-        // UUID로 변환 가능한 ID만 DB 조회에 사용
-        List<UUID> uuidIds = rawIds.stream()
+        // N+1 방지: JPA로 상세 데이터 일괄 로드
+        Map<UUID, Event> hydratedById = eventRepository.findAllWithDetailsByEventIdIn(pageEventIds).stream()
+            .collect(Collectors.toMap(Event::getEventId, e -> e));
+        Map<UUID, Event> imagesById = eventRepository.findEventImagesByEventIdIn(pageEventIds).stream()
+            .collect(Collectors.toMap(Event::getEventId, e -> e));
+
+        // ES 결과 순서 유지
+        List<EventListContentResponse> content = pageEventIds.stream()
             .map(id -> {
-                try { return UUID.fromString(id); }
-                catch (IllegalArgumentException e) { return null; }
-            })
-            .filter(id -> id != null)
-            .toList();
-
-        Map<UUID, Event> hydratedById = Collections.emptyMap();
-        Map<UUID, Event> imagesById = Collections.emptyMap();
-        if (!uuidIds.isEmpty()) {
-            hydratedById = eventRepository.findAllWithDetailsByEventIdIn(uuidIds).stream()
-                .collect(Collectors.toMap(Event::getEventId, e -> e));
-            imagesById = eventRepository.findEventImagesByEventIdIn(uuidIds).stream()
-                .collect(Collectors.toMap(Event::getEventId, e -> e));
-        }
-
-        // ES 문서 Map (DB fallback용)
-        Map<String, EventDocument> esDocById = searchHits.stream()
-            .collect(Collectors.toMap(hit -> hit.getContent().getId(), hit -> hit.getContent()));
-
-        final Map<UUID, Event> finalHydratedById = hydratedById;
-        final Map<UUID, Event> finalImagesById = imagesById;
-
-        // ES 결과 순서 유지, DB에 있으면 DB 우선 / 없으면 ES fallback
-        List<EventListContentResponse> content = rawIds.stream()
-            .map(rawId -> {
-                try {
-                    UUID uuid = UUID.fromString(rawId);
-                    Event hydrated = finalHydratedById.get(uuid);
-                    if (hydrated != null) {
-                        Event withImages = finalImagesById.getOrDefault(uuid, hydrated);
-                        return EventListContentResponse.from(withImages);
-                    }
-                } catch (IllegalArgumentException ignored) {}
-                EventDocument doc = esDocById.get(rawId);
-                return doc != null ? EventListContentResponse.from(doc) : null;
+                Event hydrated = hydratedById.get(id);
+                if (hydrated == null) return null;
+                Event withImages = imagesById.getOrDefault(id, hydrated);
+                return EventListContentResponse.from(withImages);
             })
             .filter(Objects::nonNull)
             .toList();
@@ -321,10 +289,10 @@ public class EventService {
 
         // TechStack 교체
         event.getEventTechStacks().clear();
-        Map<Long, String> techStackMap = buildTechStackMap();  // 추가
+        Map<Long, String> techStackMap = buildTechStackMap();
         for (Long techStackId : request.techStackIds()) {
             event.getEventTechStacks().add(
-                EventTechStack.of(event, techStackId, techStackMap.getOrDefault(techStackId, "Unknown")));  // 변경
+                EventTechStack.of(event, techStackId, techStackMap.getOrDefault(techStackId, "Unknown")));
         }
 
         // Image 교체
@@ -345,7 +313,7 @@ public class EventService {
      * dense_vector(embedding)은 Spring Data ES 컨버터가 직렬화하지 못하므로
      * Map<String, Object>로 전체 문서를 구성해서 ES REST API에 직접 전송.
      */
-    private void syncToElasticsearch(Event event) {
+    public void syncToElasticsearch(Event event) {
         try {
             List<String> techStackNames = event.getEventTechStacks().stream()
                 .map(EventTechStack::getTechStackName)
@@ -362,42 +330,20 @@ public class EventService {
             doc.put("category", event.getCategory().name());
             doc.put("techStacks", techStackNames);
             doc.put("status", event.getStatus().name());
+            doc.put("sellerId", event.getSellerId().toString());
             // mapping의 date_hour_minute_second 형식에 맞춤 (나노초 제외)
             doc.put("indexedAt", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")));
 
             float[] vector = openAiEmbeddingClient.embed(embeddingText);
             if (vector != null) {
-                log.debug("[1] Vector 생성 완료: 차원={}, 첫 5개 값={}", vector.length,
-                    java.util.Arrays.toString(java.util.Arrays.copyOf(vector, Math.min(5, vector.length))));
-
                 List<Float> vectorList = new ArrayList<>(vector.length);
                 for (float v : vector) vectorList.add(v);
-
-                log.debug("[2] vectorList 생성 완료: 크기={}, 첫 5개 값={}", vectorList.size(),
-                    vectorList.subList(0, Math.min(5, vectorList.size())));
-
                 doc.put("embedding", vectorList);
-                log.debug("[3] doc에 embedding 추가 완료. doc 키들: {}", doc.keySet());
             } else {
-                log.warn("[Embedding 생략] eventId: {}", event.getEventId());
+                log.warn("[ES 동기화] embedding 생성 실패 - eventId: {}", event.getEventId());
             }
 
-            // Jackson으로 직렬화 후 withJson()으로 전송
-            ObjectMapper objectMapper = new ObjectMapper();
-            String json = objectMapper.writeValueAsString(doc);
-
-            log.debug("[4] JSON 직렬화 완료: 길이={}", json.length());
-            log.debug("[4-1] JSON (처음 500자): {}", json.substring(0, Math.min(500, json.length())));
-
-            // embedding이 JSON에 포함되어 있는지 확인
-            if (json.contains("\"embedding\"")) {
-                log.debug("[5] ✓ JSON에 embedding 필드 포함됨");
-                int embeddingStart = json.indexOf("\"embedding\"");
-                int embeddingEnd = json.indexOf("]", embeddingStart) + 1;
-                log.debug("[5-1] embedding 값: {}", json.substring(embeddingStart, Math.min(embeddingEnd + 100, json.length())));
-            } else {
-                log.warn("[5] ✗ JSON에 embedding 필드가 없음!");
-            }
+            String json = new ObjectMapper().writeValueAsString(doc);
 
             esClient.index(i -> i
                 .index("event")
@@ -427,10 +373,17 @@ public class EventService {
                         .queryVector(vectorList)
                         .k(30)
                         .numCandidates(50))));
+            } else {
+                // embedding 생성 실패 시 title 기반 multi_match 폴백
+                log.warn("[검색 폴백] embedding 실패 → multi_match 사용. keyword: {}", request.keyword());
+                queryBuilder.withQuery(Query.of(q -> q
+                    .multiMatch(m -> m
+                        .query(request.keyword())
+                        .fields("title"))));
             }
         }
 
-        // 필터 (category, status)
+        // 필터 (status, category, techStacks)
         var filterQuery = new BoolQuery.Builder();
 
         if (allowedStatuses != null && !allowedStatuses.isEmpty()) {
@@ -446,13 +399,29 @@ public class EventService {
                 .term(t -> t.field("category").value(request.category().name()))));
         }
 
+        if (request.techStacks() != null && !request.techStacks().isEmpty()) {
+            Map<Long, String> techStackMap = buildTechStackMap();
+            List<FieldValue> techStackNames = request.techStacks().stream()
+                .map(id -> techStackMap.get(id))
+                .filter(name -> name != null)
+                .map(FieldValue::of)
+                .toList();
+            if (!techStackNames.isEmpty()) {
+                filterQuery.filter(Query.of(q -> q
+                    .terms(t -> t.field("techStacks").terms(tv -> tv.value(techStackNames)))));
+            }
+        }
+
+        if (request.sellerId() != null) {
+            filterQuery.filter(Query.of(q -> q
+                .term(t -> t.field("sellerId").value(request.sellerId().toString()))));
+        }
+
         queryBuilder
             .withFilter(Query.of(q -> q.bool(filterQuery.build())))
             .withPageable(pageable);
 
         return queryBuilder.build();
     }
-
-
 
 }

--- a/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
+++ b/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
@@ -1,0 +1,82 @@
+package com.devticket.event.common.config;
+
+import com.devticket.event.domain.model.Event;
+import com.devticket.event.infrastructure.persistence.EventRepository;
+import com.devticket.event.infrastructure.search.EventDocument;
+import com.devticket.event.infrastructure.search.EventSearchRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ElasticsearchIndexInitializer {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+    private final EventRepository eventRepository;
+    private final EventSearchRepository eventSearchRepository;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void initializeIndex() {
+        try {
+            var indexOps = elasticsearchOperations.indexOps(EventDocument.class);
+
+            if (!indexOps.exists()) {
+                indexOps.createWithMapping();
+                log.info("[ES Index] 'event' 인덱스 생성 완료");
+                reindexAllEvents();
+            } else {
+                long count = elasticsearchOperations.count(
+                    org.springframework.data.elasticsearch.client.elc.NativeQuery.builder().build(),
+                    EventDocument.class
+                );
+                if (count == 0) {
+                    log.info("[ES Index] 인덱스는 있지만 비어있음 → 재색인 시작");
+                    reindexAllEvents();
+                } else {
+                    log.info("[ES Index] 기존 'event' 인덱스 유지 ({}건)", count);
+                }
+            }
+
+        } catch (Exception e) {
+            log.error("[ES Index 초기화 실패]", e);
+            throw new RuntimeException("ElasticSearch 인덱스 초기화 실패", e);
+        }
+    }
+
+    /**
+     * DB의 모든 이벤트를 ES에 재색인.
+     * embedding은 저장하지 않음 (이벤트 생성/수정 시 syncToElasticsearch에서 저장됨)
+     */
+    private void reindexAllEvents() {
+        List<UUID> allEventIds = eventRepository.findAll().stream()
+            .map(Event::getEventId)
+            .toList();
+
+        if (allEventIds.isEmpty()) {
+            log.info("[ES 재색인] 재색인할 이벤트 없음");
+            return;
+        }
+
+        // techStacks Fetch Join (LazyInitializationException 방지)
+        List<Event> events = eventRepository.findAllWithDetailsByEventIdIn(allEventIds);
+
+        int count = 0;
+        for (Event event : events) {
+            try {
+                eventSearchRepository.save(EventDocument.from(event));
+                count++;
+            } catch (Exception e) {
+                log.warn("[ES 재색인 실패] eventId: {}", event.getEventId(), e);
+            }
+        }
+
+        log.info("[ES 재색인] 완료. 총 {}건", count);
+    }
+}

--- a/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
+++ b/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
@@ -1,9 +1,9 @@
 package com.devticket.event.common.config;
 
+import com.devticket.event.application.EventService;
 import com.devticket.event.domain.model.Event;
 import com.devticket.event.infrastructure.persistence.EventRepository;
 import com.devticket.event.infrastructure.search.EventDocument;
-import com.devticket.event.infrastructure.search.EventSearchRepository;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ public class ElasticsearchIndexInitializer {
 
     private final ElasticsearchOperations elasticsearchOperations;
     private final EventRepository eventRepository;
-    private final EventSearchRepository eventSearchRepository;
+    private final EventService eventService;
 
     @EventListener(ApplicationReadyEvent.class)
     public void initializeIndex() {
@@ -52,7 +52,7 @@ public class ElasticsearchIndexInitializer {
 
     /**
      * DB의 모든 이벤트를 ES에 재색인.
-     * embedding은 저장하지 않음 (이벤트 생성/수정 시 syncToElasticsearch에서 저장됨)
+     * embedding 포함 저장 (syncToElasticsearch 재사용)
      */
     private void reindexAllEvents() {
         List<UUID> allEventIds = eventRepository.findAll().stream()
@@ -70,7 +70,7 @@ public class ElasticsearchIndexInitializer {
         int count = 0;
         for (Event event : events) {
             try {
-                eventSearchRepository.save(EventDocument.from(event));
+                eventService.syncToElasticsearch(event);
                 count++;
             } catch (Exception e) {
                 log.warn("[ES 재색인 실패] eventId: {}", event.getEventId(), e);

--- a/event/src/main/java/com/devticket/event/common/config/OpenAiProperties.java
+++ b/event/src/main/java/com/devticket/event/common/config/OpenAiProperties.java
@@ -1,12 +1,8 @@
 package com.devticket.event.common.config;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-@Getter
-@Setter
 @Component
 @ConfigurationProperties(prefix = "openai.embedding")
 public class OpenAiProperties {
@@ -14,4 +10,28 @@ public class OpenAiProperties {
     private boolean enabled;
     private String apiKey;
     private String model;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
 }

--- a/event/src/main/java/com/devticket/event/common/config/OpenAiProperties.java
+++ b/event/src/main/java/com/devticket/event/common/config/OpenAiProperties.java
@@ -1,0 +1,17 @@
+package com.devticket.event.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "openai.embedding")
+public class OpenAiProperties {
+
+    private boolean enabled;
+    private String apiKey;
+    private String model;
+}

--- a/event/src/main/java/com/devticket/event/infrastructure/client/OpenAiEmbeddingClient.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/OpenAiEmbeddingClient.java
@@ -1,0 +1,72 @@
+package com.devticket.event.infrastructure.client;
+
+import com.devticket.event.common.config.OpenAiProperties;
+import com.devticket.event.infrastructure.client.dto.EmbeddingRequest;
+import com.devticket.event.infrastructure.client.dto.EmbeddingResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OpenAiEmbeddingClient {
+
+    private final RestTemplate restTemplate;
+    private final OpenAiProperties openAiProperties;
+
+    private static final String OPENAI_EMBEDDING_API = "https://api.openai.com/v1/embeddings";
+
+    /**
+     * 텍스트를 OpenAI Embedding API로 처리
+     * @param text 임베딩할 텍스트
+     * @return 1536차원 float[] 벡터, 실패 시 null
+     */
+    public float[] embed(String text) {
+        // Feature toggle 확인
+        if (!openAiProperties.isEnabled()) {
+            log.warn("[Embedding 비활성화] enabled=false");
+            return null;
+        }
+
+        try {
+            // HTTP 헤더 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(openAiProperties.getApiKey());
+
+            // 요청 바디 생성
+            EmbeddingRequest request = EmbeddingRequest.of(text);
+            HttpEntity<EmbeddingRequest> httpEntity = new HttpEntity<>(request, headers);
+
+            // OpenAI API 호출
+            EmbeddingResponse response = restTemplate.postForObject(
+                OPENAI_EMBEDDING_API,
+                httpEntity,
+                EmbeddingResponse.class
+            );
+
+            if (response == null) {
+                log.warn("[OpenAI Embedding 실패] response null");
+                return null;
+            }
+
+            float[] vector = response.firstVector();
+            if (vector == null) {
+                log.warn("[OpenAI Embedding 실패] vector null");
+                return null;
+            }
+
+            log.debug("[OpenAI Embedding 성공] text 길이: {}, 벡터 차원: {}", text.length(), vector.length);
+            return vector;
+
+        } catch (Exception e) {
+            log.warn("[OpenAI Embedding 실패] text 길이: {}", text.length(), e);
+            return null;  // Graceful degradation: embedding 실패해도 이벤트 등록은 계속
+        }
+    }
+}

--- a/event/src/main/java/com/devticket/event/infrastructure/client/dto/EmbeddingRequest.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/dto/EmbeddingRequest.java
@@ -1,0 +1,12 @@
+package com.devticket.event.infrastructure.client.dto;
+
+public record EmbeddingRequest(String input, String model) {
+
+    /**
+     * 임베딩 텍스트로 요청 객체 생성
+     * model은 항상 "text-embedding-3-small" (1536차원)
+     */
+    public static EmbeddingRequest of(String text) {
+        return new EmbeddingRequest(text, "text-embedding-3-small");
+    }
+}

--- a/event/src/main/java/com/devticket/event/infrastructure/client/dto/EmbeddingResponse.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/dto/EmbeddingResponse.java
@@ -1,0 +1,31 @@
+package com.devticket.event.infrastructure.client.dto;
+
+import java.util.List;
+
+public record EmbeddingResponse(List<EmbeddingData> data) {
+
+    /**
+     * 응답의 첫 번째 임베딩 벡터를 float[] 배열로 변환
+     * OpenAI API는 data[0].embedding에 1536개의 Double 값을 반환함
+     */
+    public float[] firstVector() {
+        if (data == null || data.isEmpty()) {
+            return null;
+        }
+
+        List<Double> raw = data.get(0).embedding();
+        float[] result = new float[raw.size()];
+
+        for (int i = 0; i < raw.size(); i++) {
+            result[i] = raw.get(i).floatValue();
+        }
+
+        return result;
+    }
+
+    /**
+     * OpenAI 응답의 data 배열 내 각 객체 구조
+     * { "embedding": [0.023, -0.114, ...] }
+     */
+    public record EmbeddingData(List<Double> embedding) {}
+}

--- a/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
@@ -1,20 +1,16 @@
 package com.devticket.event.infrastructure.search;
 
+import com.devticket.event.domain.model.Event;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Mapping;
-
-import com.devticket.event.domain.model.Event;
-
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
@@ -78,13 +74,4 @@ public class EventDocument {
             .build();
     }
 
-    public void setEmbedding(float[] vector) {
-        if (vector == null) {
-            this.embedding = null;
-            return;
-        }
-        List<Float> list = new ArrayList<>(vector.length);
-        for (float v : vector) list.add(v);
-        this.embedding = list;
-    }
 }

--- a/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
@@ -1,17 +1,16 @@
 package com.devticket.event.infrastructure.search;
 
 import java.time.LocalDateTime;
-import java.util.Comparator;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.data.annotation.Id;
-import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Mapping;
 
 import com.devticket.event.domain.model.Event;
-import com.devticket.event.domain.model.EventImage;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +18,8 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@Document(indexName = "event")
+@Document(indexName = "event", createIndex = false)
+@Mapping(mappingPath = "elasticsearch/event-mapping.json")
 public class EventDocument {
 
     @Id
@@ -28,108 +28,58 @@ public class EventDocument {
     @Field(type = FieldType.Text)
     private String title;
 
-    @Field(type = FieldType.Text)
-    private String description;
-
-    @Field(type = FieldType.Keyword)
-    private String location;
-
     @Field(type = FieldType.Keyword)
     private String category;
 
     @Field(type = FieldType.Keyword)
+    private List<String> techStacks;
+
+    @Field(type = FieldType.Keyword)
     private String status;
 
-    @Field(type = FieldType.Keyword)
-    private String sellerId;
+    /**
+     * 1536차원 embedding 벡터.
+     * Spring Data ES 컨버터가 dense_vector를 직렬화하지 못하므로
+     * EventService.updateEmbeddingField()에서 esClient partial update로 저장.
+     */
+    private List<Float> embedding;
 
-    @Field(type = FieldType.Integer)
-    private Integer price;
-
-    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
-    private LocalDateTime eventDateTime;
-
-    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
-    private LocalDateTime saleStartAt;
-
-    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
-    private LocalDateTime saleEndAt;
-
-    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
-    private LocalDateTime createdAt;
-
-    @Field(type = FieldType.Keyword)
-    private String thumbnailUrl;
-
-    @Field(type = FieldType.Nested)
-    private List<TechStackDocument> techStacks;
+    @Field(type = FieldType.Date, format = {}, pattern = "yyyy-MM-dd'T'HH:mm:ss[.SSSSSS]")
+    private LocalDateTime indexedAt;
 
     @Builder
-    private EventDocument(String id, String title, String description, String location,
-        String category, String status, String sellerId, Integer price,
-        LocalDateTime eventDateTime, LocalDateTime saleStartAt, LocalDateTime saleEndAt,
-        LocalDateTime createdAt, String thumbnailUrl, List<TechStackDocument> techStacks) {
+    private EventDocument(String id, String title, String category, List<String> techStacks,
+        String status, LocalDateTime indexedAt) {
         this.id = id;
         this.title = title;
-        this.description = description;
-        this.location = location;
         this.category = category;
-        this.status = status;
-        this.sellerId = sellerId;
-        this.price = price;
-        this.eventDateTime = eventDateTime;
-        this.saleStartAt = saleStartAt;
-        this.saleEndAt = saleEndAt;
-        this.createdAt = createdAt;
-        this.thumbnailUrl = thumbnailUrl;
         this.techStacks = techStacks;
-    }
-
-    @Getter
-    @NoArgsConstructor
-    public static class TechStackDocument {
-
-        @Field(type = FieldType.Long)
-        private Long techStackId;
-
-        @Field(type = FieldType.Keyword)
-        private String techStackName;
-
-        @Builder
-        private TechStackDocument(Long techStackId, String techStackName) {
-            this.techStackId = techStackId;
-            this.techStackName = techStackName;
-        }
+        this.status = status;
+        this.indexedAt = indexedAt;
     }
 
     public static EventDocument from(Event event) {
-        String thumbnail = event.getEventImages().stream()
-            .min(Comparator.comparingInt(EventImage::getSortOrder))
-            .map(EventImage::getImageUrl)
-            .orElse(null);
-
-        List<TechStackDocument> techStacks = event.getEventTechStacks().stream()
-            .map(ts -> TechStackDocument.builder()
-                .techStackId(ts.getTechStackId())
-                .techStackName(ts.getTechStackName())
-                .build())
+        List<String> techStackNames = event.getEventTechStacks().stream()
+            .map(ts -> ts.getTechStackName())
             .toList();
 
         return EventDocument.builder()
             .id(event.getEventId().toString())
             .title(event.getTitle())
-            .description(event.getDescription())
-            .location(event.getLocation())
             .category(event.getCategory().name())
+            .techStacks(techStackNames)
             .status(event.getStatus().name())
-            .sellerId(event.getSellerId().toString())
-            .price(event.getPrice())
-            .eventDateTime(event.getEventDateTime())
-            .saleStartAt(event.getSaleStartAt())
-            .saleEndAt(event.getSaleEndAt())
-            .createdAt(event.getCreatedAt())
-            .thumbnailUrl(thumbnail)
-            .techStacks(techStacks)
+            .indexedAt(LocalDateTime.now().truncatedTo(java.time.temporal.ChronoUnit.SECONDS))
             .build();
+    }
+
+    public void setEmbedding(float[] vector) {
+        if (vector == null) {
+            this.embedding = null;
+            return;
+        }
+        List<Float> list = new ArrayList<>(vector.length);
+        for (float v : vector) list.add(v);
+        this.embedding = list;
     }
 }

--- a/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@Document(indexName = "event", createIndex = false)
+@Document(indexName = "event")
 @Mapping(mappingPath = "elasticsearch/event-mapping.json")
 public class EventDocument {
 
@@ -37,10 +37,13 @@ public class EventDocument {
     @Field(type = FieldType.Keyword)
     private String status;
 
+    @Field(type = FieldType.Keyword)
+    private String sellerId;
+
     /**
      * 1536차원 embedding 벡터.
      * Spring Data ES 컨버터가 dense_vector를 직렬화하지 못하므로
-     * EventService.updateEmbeddingField()에서 esClient partial update로 저장.
+     * syncToElasticsearch()에서 esClient.index()로 직접 저장.
      */
     private List<Float> embedding;
 
@@ -49,12 +52,13 @@ public class EventDocument {
 
     @Builder
     private EventDocument(String id, String title, String category, List<String> techStacks,
-        String status, LocalDateTime indexedAt) {
+        String status, String sellerId, LocalDateTime indexedAt) {
         this.id = id;
         this.title = title;
         this.category = category;
         this.techStacks = techStacks;
         this.status = status;
+        this.sellerId = sellerId;
         this.indexedAt = indexedAt;
     }
 
@@ -69,6 +73,7 @@ public class EventDocument {
             .category(event.getCategory().name())
             .techStacks(techStackNames)
             .status(event.getStatus().name())
+            .sellerId(event.getSellerId().toString())
             .indexedAt(LocalDateTime.now().truncatedTo(java.time.temporal.ChronoUnit.SECONDS))
             .build();
     }

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
@@ -4,24 +4,16 @@ import com.devticket.event.application.EventService;
 import com.devticket.event.presentation.dto.EventDetailResponse;
 import com.devticket.event.presentation.dto.EventListRequest;
 import com.devticket.event.presentation.dto.EventListResponse;
-import com.devticket.event.presentation.dto.SellerEventCreateRequest;
-import com.devticket.event.presentation.dto.SellerEventCreateResponse;
 import com.devticket.event.common.response.SuccessResponse;
-import com.devticket.event.presentation.dto.SellerEventDetailResponse;
-import com.devticket.event.presentation.dto.SellerEventSummaryResponse;
-import com.devticket.event.presentation.dto.SellerEventUpdateRequest;
-import com.devticket.event.presentation.dto.SellerEventUpdateResponse;
-import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping({"/api/events", "/api/seller/events"})
+@RequestMapping("/api/events")
 @RequiredArgsConstructor
 public class EventController {
 

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
@@ -21,7 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/events")
+@RequestMapping({"/api/events", "/api/seller/events"})
 @RequiredArgsConstructor
 public class EventController {
 

--- a/event/src/main/java/com/devticket/event/presentation/dto/EventListContentResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/EventListContentResponse.java
@@ -4,7 +4,6 @@ import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.domain.model.Event;
 import com.devticket.event.domain.model.EventImage;
 import com.devticket.event.domain.model.EventTechStack;
-import com.devticket.event.infrastructure.search.EventDocument;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -44,20 +43,6 @@ public record EventListContentResponse(
             event.getSaleEndAt(),
             event.getTotalQuantity(),
             event.getRemainingQuantity()
-        );
-    }
-
-    public static EventListContentResponse fromELS(EventDocument doc) {
-        return new EventListContentResponse(
-            UUID.fromString(doc.getId()),
-            doc.getTitle(),
-            null,
-            null,
-            null,
-            0,
-            doc.getStatus() != null ? EventStatus.valueOf(doc.getStatus()) : null,
-            doc.getTechStacks() != null ? doc.getTechStacks() : List.of(),
-            null
         );
     }
 

--- a/event/src/main/java/com/devticket/event/presentation/dto/EventListContentResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/EventListContentResponse.java
@@ -4,6 +4,7 @@ import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.domain.model.Event;
 import com.devticket.event.domain.model.EventImage;
 import com.devticket.event.domain.model.EventTechStack;
+import com.devticket.event.infrastructure.search.EventDocument;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -41,6 +42,20 @@ public record EventListContentResponse(
             event.getStatus(),
             techStacks,
             event.getSaleEndAt()
+        );
+    }
+
+    public static EventListContentResponse from(EventDocument doc) {
+        return new EventListContentResponse(
+            UUID.fromString(doc.getId()),
+            doc.getTitle(),
+            null,
+            null,
+            null,
+            0,
+            doc.getStatus() != null ? EventStatus.valueOf(doc.getStatus()) : null,
+            doc.getTechStacks() != null ? doc.getTechStacks() : List.of(),
+            null
         );
     }
 }

--- a/event/src/main/resources/application-local.yml
+++ b/event/src/main/resources/application-local.yml
@@ -26,6 +26,12 @@ spring:
     connection-timeout: 5s
     socket-timeout: 30s
 
+openai:
+  embedding:
+    enabled: true
+    api-key: ${OPENAI_API_KEY:}
+    model: text-embedding-3-small
+
 service:
   member:
     url: http://localhost:8081

--- a/event/src/main/resources/application-test.yml
+++ b/event/src/main/resources/application-test.yml
@@ -16,3 +16,7 @@ spring:
     hibernate:
       ddl-auto: create-drop # 테스트 시작 시 테이블 생성, 종료 시 삭제
     show-sql: true
+  elasticsearch:
+    uris: http://localhost:9200
+    connection-timeout: 1s
+    socket-timeout: 1s

--- a/event/src/main/resources/elasticsearch/event-mapping.json
+++ b/event/src/main/resources/elasticsearch/event-mapping.json
@@ -12,6 +12,9 @@
     "status": {
       "type": "keyword"
     },
+    "sellerId": {
+      "type": "keyword"
+    },
     "embedding": {
       "type": "dense_vector",
       "dims": 1536,

--- a/event/src/main/resources/elasticsearch/event-mapping.json
+++ b/event/src/main/resources/elasticsearch/event-mapping.json
@@ -1,0 +1,25 @@
+{
+  "properties": {
+    "title": {
+      "type": "text"
+    },
+    "category": {
+      "type": "keyword"
+    },
+    "techStacks": {
+      "type": "keyword"
+    },
+    "status": {
+      "type": "keyword"
+    },
+    "embedding": {
+      "type": "dense_vector",
+      "dims": 1536,
+      "index": true,
+      "similarity": "cosine"
+    },
+    "indexedAt": {
+      "type": "date"
+    }
+  }
+}

--- a/event/src/test/java/com/devticket/event/application/EventServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventServiceTest.java
@@ -2,22 +2,27 @@ package com.devticket.event.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.devticket.event.common.exception.BusinessException;
 import com.devticket.event.domain.enums.EventCategory;
 import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.domain.exception.EventErrorCode;
 import com.devticket.event.domain.model.Event;
 import com.devticket.event.fixture.EventTestFixture;
+import com.devticket.event.infrastructure.client.MemberClient;
+import com.devticket.event.infrastructure.client.OpenAiEmbeddingClient;
 import com.devticket.event.infrastructure.persistence.EventRepository;
+import com.devticket.event.infrastructure.search.EventDocument;
 import com.devticket.event.presentation.dto.EventDetailResponse;
 import com.devticket.event.presentation.dto.EventListRequest;
 import com.devticket.event.presentation.dto.EventListResponse;
@@ -28,20 +33,22 @@ import com.devticket.event.presentation.dto.SellerEventSummaryResponse;
 import com.devticket.event.presentation.dto.SellerEventUpdateRequest;
 import com.devticket.event.presentation.dto.SellerEventUpdateResponse;
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,10 +57,46 @@ class EventServiceTest {
     @Mock
     private EventRepository eventRepository;
 
+    @Mock
+    private MemberClient memberClient;
+
+    @Mock
+    private ElasticsearchOperations elasticsearchOperations;
+
+    @Mock
+    private ElasticsearchClient esClient;
+
+    @Mock
+    private OpenAiEmbeddingClient openAiEmbeddingClient;
+
     @InjectMocks
     private EventService eventService;
 
-    // 이벤트 생성 테스트
+    // ── 검색 히트 목 헬퍼 ──────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private SearchHits<EventDocument> mockSearchHitsWithEvent(UUID eventId) {
+        EventDocument doc = EventDocument.builder()
+            .id(eventId.toString())
+            .build();
+        SearchHit<EventDocument> hit = mock(SearchHit.class);
+        when(hit.getContent()).thenReturn(doc);
+
+        SearchHits<EventDocument> searchHits = mock(SearchHits.class);
+        when(searchHits.stream()).thenReturn(Stream.of(hit));
+        when(searchHits.getTotalHits()).thenReturn(1L);
+        return searchHits;
+    }
+
+    @SuppressWarnings("unchecked")
+    private SearchHits<EventDocument> mockEmptySearchHits() {
+        SearchHits<EventDocument> searchHits = mock(SearchHits.class);
+        when(searchHits.stream()).thenReturn(Stream.empty());
+        // getTotalHits()는 빈 결과 경로에서 호출되지 않으므로 stub 불필요
+        return searchHits;
+    }
+
+    // ── 이벤트 생성 테스트 ────────────────────────────────────────────────
 
     @Test
     void 정상적인_조건일_경우_이벤트가_성공적으로_생성되고_UUID를_반환한다() {
@@ -65,7 +108,6 @@ class EventServiceTest {
         );
 
         UUID expectedUuid = UUID.randomUUID();
-
         Event savedEvent = EventTestFixture.createEvent(sellerId);
         ReflectionTestUtils.setField(savedEvent, "eventId", expectedUuid);
 
@@ -86,8 +128,9 @@ class EventServiceTest {
         // given
         UUID sellerId = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
+        // 판매 시작일을 과거로 설정 → saleStartAt.isBefore(now) 조건 충족
         SellerEventCreateRequest request = EventTestFixture.createEventRequest(
-            now.plusDays(1), now.plusDays(10), now.plusDays(15), 100, 4
+            now.minusDays(1), now.plusDays(10), now.plusDays(15), 100, 4
         );
 
         // when & then
@@ -127,13 +170,12 @@ class EventServiceTest {
             .hasMessageContaining(EventErrorCode.INVALID_EVENT_DATE.getMessage());
     }
 
-    // 이벤트 상세 조회 테스트
+    // ── 이벤트 상세 조회 테스트 ───────────────────────────────────────────
 
     @Test
     void 존재하는_이벤트_조회시_상세정보를_반환한다() {
         // given
         UUID sellerId = UUID.randomUUID();
-
         Event event = EventTestFixture.createEvent(sellerId);
         UUID eventId = event.getEventId();
 
@@ -151,7 +193,7 @@ class EventServiceTest {
     @Test
     void 존재하지_않는_이벤트_조회시_예외가_발생한다() {
         // given
-        UUID invalidEventId = UUID.randomUUID(); // 아무 UUID나 생성
+        UUID invalidEventId = UUID.randomUUID();
         when(eventRepository.findWithDetailsByEventId(invalidEventId)).thenReturn(Optional.empty());
 
         // when & then
@@ -160,35 +202,29 @@ class EventServiceTest {
             .hasMessageContaining(EventErrorCode.EVENT_NOT_FOUND.getMessage());
     }
 
-    // 이벤트 목록 조회 및 검색 테스트
+    // ── 이벤트 목록 조회 및 검색 테스트 ──────────────────────────────────
 
     @Test
     void 검색_조건이_주어지면_파라미터를_분해하여_Repository를_호출한다() {
         // given
         EventListRequest request = new EventListRequest("스프링", EventCategory.MEETUP, List.of(1L, 2L), null, null);
         Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<Event> mockPage = EventTestFixture.createEventPage();
 
-        // 서비스가 내부적으로 계산할 '일반 조회 허용 상태값 리스트'
-        List<EventStatus> publicStatuses = List.of(EventStatus.ON_SALE, EventStatus.SOLD_OUT, EventStatus.SALE_ENDED);
+        UUID eventId = UUID.randomUUID();
+        Event mockEvent = EventTestFixture.createEvent(UUID.randomUUID());
+        ReflectionTestUtils.setField(mockEvent, "eventId", eventId);
 
-        // DTO가 해체되어 각각의 파라미터로 전달됨을 검증
-        given(eventRepository.searchEvents(
-            eq("스프링"), eq(EventCategory.MEETUP), eq(List.of(1L, 2L)), isNull(), eq(publicStatuses), eq(pageable)
-        )).willReturn(mockPage);
-        given(eventRepository.findAllWithDetailsByEventIdIn(anyList())).willReturn(mockPage.getContent());
+        doReturn(mockSearchHitsWithEvent(eventId))
+            .when(elasticsearchOperations).search(any(Query.class), eq(EventDocument.class));
+        when(eventRepository.findAllWithDetailsByEventIdIn(anyList())).thenReturn(List.of(mockEvent));
 
         // when (currentUserId는 일반 조회이므로 null로 전달)
         EventListResponse response = eventService.getEventList(request, null, pageable);
 
         // then
-        assertThat(response.totalElements()).isEqualTo(mockPage.getTotalElements());
+        assertThat(response.totalElements()).isEqualTo(1L);
         assertThat(response.content()).isNotEmpty();
-
-        // verify 역시 해체된 파라미터로 검증
-        verify(eventRepository).searchEvents(
-            "스프링", EventCategory.MEETUP, List.of(1L, 2L), null, publicStatuses, pageable
-        );
+        verify(elasticsearchOperations).search(any(Query.class), any());
     }
 
     @Test
@@ -196,17 +232,21 @@ class EventServiceTest {
         // given
         EventListRequest request = new EventListRequest(null, null, null, null, null);
         Pageable pageable = PageRequest.of(0, 20);
-        List<EventStatus> publicStatuses = List.of(EventStatus.ON_SALE, EventStatus.SOLD_OUT, EventStatus.SALE_ENDED);
 
-        given(eventRepository.searchEvents(isNull(), isNull(), isNull(), isNull(), eq(publicStatuses), eq(pageable)))
-            .willReturn(EventTestFixture.createEventPage());
+        UUID eventId = UUID.randomUUID();
+        Event mockEvent = EventTestFixture.createEvent(UUID.randomUUID());
+        ReflectionTestUtils.setField(mockEvent, "eventId", eventId);
+
+        doReturn(mockSearchHitsWithEvent(eventId))
+            .when(elasticsearchOperations).search(any(Query.class), eq(EventDocument.class));
+        when(eventRepository.findAllWithDetailsByEventIdIn(anyList())).thenReturn(List.of(mockEvent));
 
         // when
         EventListResponse response = eventService.getEventList(request, null, pageable);
 
         // then
         assertThat(response).isNotNull();
-        verify(eventRepository).searchEvents(null, null, null, null, publicStatuses, pageable);
+        verify(elasticsearchOperations).search(any(Query.class), any());
     }
 
     @Test
@@ -214,11 +254,9 @@ class EventServiceTest {
         // given
         EventListRequest request = new EventListRequest("절대검색안될키워드", null, null, null, null);
         Pageable pageable = PageRequest.of(0, 20);
-        Page<Event> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
-        List<EventStatus> publicStatuses = List.of(EventStatus.ON_SALE, EventStatus.SOLD_OUT, EventStatus.SALE_ENDED);
 
-        given(eventRepository.searchEvents(eq("절대검색안될키워드"), isNull(), isNull(), isNull(), eq(publicStatuses), eq(pageable)))
-            .willReturn(emptyPage);
+        doReturn(mockEmptySearchHits())
+            .when(elasticsearchOperations).search(any(Query.class), eq(EventDocument.class));
 
         // when
         EventListResponse response = eventService.getEventList(request, null, pageable);
@@ -228,29 +266,30 @@ class EventServiceTest {
         assertThat(response.content()).isEmpty();
     }
 
-    // 판매자 등록 이벤트 목록 조회 테스트
+    // ── 판매자 등록 이벤트 목록 조회 테스트 ──────────────────────────────
 
     @Test
     void 일반_조회시_공개된_상태의_이벤트만_조회조건으로_전달된다() {
         // given
         EventListRequest request = new EventListRequest("스프링", EventCategory.MEETUP, List.of(1L, 2L), null, null);
         Pageable pageable = PageRequest.of(0, 20);
-        Page<Event> mockPage = EventTestFixture.createEventPage();
 
-        // 서비스 내부에서 계산될 공개 허용 상태값들
-        List<EventStatus> publicStatuses = List.of(EventStatus.ON_SALE, EventStatus.SOLD_OUT, EventStatus.SALE_ENDED);
+        UUID eventId = UUID.randomUUID();
+        Event mockEvent = EventTestFixture.createEvent(UUID.randomUUID());
+        ReflectionTestUtils.setField(mockEvent, "eventId", eventId);
 
-        // 파라미터가 해체되어 전달됨을 검증
-        when(eventRepository.searchEvents("스프링", EventCategory.MEETUP, List.of(1L, 2L), null, publicStatuses, pageable))
-            .thenReturn(mockPage);
-        when(eventRepository.findAllWithDetailsByEventIdIn(anyList())).thenReturn(mockPage.getContent());
+        doReturn(mockSearchHitsWithEvent(eventId))
+            .when(elasticsearchOperations).search(any(Query.class), eq(EventDocument.class));
+        when(eventRepository.findAllWithDetailsByEventIdIn(anyList())).thenReturn(List.of(mockEvent));
 
-        // when (currentUserId가 null)
+        // when (currentUserId가 null → 내부적으로 공개 상태 필터 적용)
         EventListResponse response = eventService.getEventList(request, null, pageable);
 
         // then
-        assertThat(response.totalElements()).isEqualTo(mockPage.getTotalElements());
-        verify(eventRepository).searchEvents("스프링", EventCategory.MEETUP, List.of(1L, 2L), null, publicStatuses, pageable);
+        assertThat(response.totalElements()).isEqualTo(1L);
+        assertThat(response.content()).isNotEmpty();
+        // ES 검색이 호출되었음을 확인 (공개 상태 필터는 NativeQuery 내부에 포함됨)
+        verify(elasticsearchOperations).search(any(Query.class), any());
     }
 
     @Test
@@ -260,17 +299,20 @@ class EventServiceTest {
         EventListRequest request = new EventListRequest(null, null, null, sellerId, null);
         Pageable pageable = PageRequest.of(0, 20);
 
-        Page<Event> mockPage = EventTestFixture.createEventPage();
-        when(eventRepository.searchEvents(null, null, null, sellerId, null, pageable))
-            .thenReturn(mockPage);
-        when(eventRepository.findAllWithDetailsByEventIdIn(anyList())).thenReturn(mockPage.getContent());
+        UUID eventId = UUID.randomUUID();
+        Event mockEvent = EventTestFixture.createEvent(sellerId);
+        ReflectionTestUtils.setField(mockEvent, "eventId", eventId);
 
-        // when (currentUserId와 request의 sellerId가 일치함)
+        doReturn(mockSearchHitsWithEvent(eventId))
+            .when(elasticsearchOperations).search(any(Query.class), eq(EventDocument.class));
+        when(eventRepository.findAllWithDetailsByEventIdIn(anyList())).thenReturn(List.of(mockEvent));
+
+        // when (currentUserId와 request의 sellerId가 일치 → 상태 제한 없음)
         EventListResponse response = eventService.getEventList(request, sellerId, pageable);
 
         // then
         assertThat(response).isNotNull();
-        verify(eventRepository).searchEvents(null, null, null, sellerId, null, pageable);
+        verify(elasticsearchOperations).search(any(Query.class), any());
     }
 
     @Test
@@ -280,17 +322,20 @@ class EventServiceTest {
         EventListRequest request = new EventListRequest(null, null, null, sellerId, EventStatus.DRAFT);
         Pageable pageable = PageRequest.of(0, 20);
 
-        Page<Event> mockPage = EventTestFixture.createEventPage();
-        when(eventRepository.searchEvents(null, null, null, sellerId, List.of(EventStatus.DRAFT), pageable))
-            .thenReturn(mockPage);
-        when(eventRepository.findAllWithDetailsByEventIdIn(anyList())).thenReturn(mockPage.getContent());
+        UUID eventId = UUID.randomUUID();
+        Event mockEvent = EventTestFixture.createEvent(sellerId);
+        ReflectionTestUtils.setField(mockEvent, "eventId", eventId);
 
-        // when
+        doReturn(mockSearchHitsWithEvent(eventId))
+            .when(elasticsearchOperations).search(any(Query.class), eq(EventDocument.class));
+        when(eventRepository.findAllWithDetailsByEventIdIn(anyList())).thenReturn(List.of(mockEvent));
+
+        // when (본인 이벤트 DRAFT 조회 허용)
         EventListResponse response = eventService.getEventList(request, sellerId, pageable);
 
         // then
         assertThat(response).isNotNull();
-        verify(eventRepository).searchEvents(null, null, null, sellerId, List.of(EventStatus.DRAFT), pageable);
+        verify(elasticsearchOperations).search(any(Query.class), any());
     }
 
     @Test
@@ -324,11 +369,9 @@ class EventServiceTest {
         // given
         EventListRequest request = new EventListRequest("없는키워드", null, null, null, null);
         Pageable pageable = PageRequest.of(0, 20);
-        Page<Event> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
-        List<EventStatus> publicStatuses = List.of(EventStatus.ON_SALE, EventStatus.SOLD_OUT, EventStatus.SALE_ENDED);
 
-        when(eventRepository.searchEvents("없는키워드", null, null, null, publicStatuses, pageable))
-            .thenReturn(emptyPage);
+        doReturn(mockEmptySearchHits())
+            .when(elasticsearchOperations).search(any(Query.class), eq(EventDocument.class));
 
         // when
         EventListResponse response = eventService.getEventList(request, null, pageable);
@@ -338,7 +381,7 @@ class EventServiceTest {
         assertThat(response.content()).isEmpty();
     }
 
-    // 판매자 이벤트 상세 조회 테스트
+    // ── 판매자 이벤트 상세 조회 테스트 ───────────────────────────────────
 
     @Test
     void 판매자_본인_이벤트_상세조회_성공시_SellerEventDetailResponse를_반환한다() {
@@ -388,7 +431,7 @@ class EventServiceTest {
             .hasMessageContaining(EventErrorCode.UNAUTHORIZED_SELLER.getMessage());
     }
 
-    // 판매자 이벤트 현황 조회 테스트
+    // ── 판매자 이벤트 현황 조회 테스트 ───────────────────────────────────
 
     @Test
     void 판매자_본인_이벤트_현황조회_성공시_SellerEventSummaryResponse를_반환한다() {
@@ -441,7 +484,7 @@ class EventServiceTest {
             .hasMessageContaining(EventErrorCode.UNAUTHORIZED_SELLER.getMessage());
     }
 
-    // 이벤트 수정 및 판매 중지 테스트
+    // ── 이벤트 수정 및 판매 중지 테스트 ──────────────────────────────────
 
     @Test
     void 정상적인_판매_중지_성공() {
@@ -500,7 +543,6 @@ class EventServiceTest {
         Event event = EventTestFixture.createEventWithStatus(sellerId, EventStatus.DRAFT);
         UUID eventId = event.getEventId();
 
-        // 수정 요청
         SellerEventUpdateRequest updateRequest = new SellerEventUpdateRequest(
             "수정된_제목", "수정된_설명", "수정된_위치",
             LocalDateTime.now().plusDays(20),

--- a/event/src/test/java/com/devticket/event/presentation/controller/EventControllerTest.java
+++ b/event/src/test/java/com/devticket/event/presentation/controller/EventControllerTest.java
@@ -40,7 +40,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import tools.jackson.databind.json.JsonMapper;
 
-@WebMvcTest(EventController.class)
+@WebMvcTest({EventController.class, SellerEventController.class})
 class EventControllerTest {
 
     @Autowired
@@ -75,7 +75,7 @@ class EventControllerTest {
             .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(post("/api/v1/events")
+        mockMvc.perform(post("/api/seller/events")
                 .header("X-User-Id", String.valueOf(sellerId))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
@@ -95,7 +95,7 @@ class EventControllerTest {
         );
 
         // when & then (헤더를 세팅하지 않음)
-        mockMvc.perform(post("/api/v1/events")
+        mockMvc.perform(post("/api/seller/events")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andDo(print())
@@ -117,7 +117,7 @@ class EventControllerTest {
         UUID sellerId = UUID.randomUUID();
 
         // when & then
-        mockMvc.perform(post("/api/v1/events")
+        mockMvc.perform(post("/api/seller/events")
                 .header("X-User-Id", sellerId.toString())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(badRequest)))
@@ -136,7 +136,7 @@ class EventControllerTest {
         when(eventService.getEvent(eventId)).thenReturn(mockResponse);
 
         // when & then
-        mockMvc.perform(get("/api/v1/events/{eventId}", eventId)
+        mockMvc.perform(get("/api/events/{eventId}", eventId)
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isOk()) // 200 OK 검증
@@ -155,7 +155,7 @@ class EventControllerTest {
             .willReturn(mockResponse);
 
         // when (API 호출)
-        mockMvc.perform(get("/api/v1/events")
+        mockMvc.perform(get("/api/events")
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isOk())
@@ -180,8 +180,8 @@ class EventControllerTest {
         given(eventService.getEventList(any(EventListRequest.class), eq(testUserId), any(Pageable.class)))
             .willReturn(mockResponse);
 
-        // when (API 호출: 새로 추가된 sellerId, status 파라미터와 X-User-Id 헤더까지 테스트)
-        mockMvc.perform(get("/api/v1/events")
+        // when (API 호출: sellerId, status 파라미터와 X-User-Id 헤더까지 테스트)
+        mockMvc.perform(get("/api/events")
                 .header("X-User-Id", testUserId.toString())
                 .param("keyword", "스프링")
                 .param("category", "MEETUP")
@@ -222,7 +222,7 @@ class EventControllerTest {
     @Test
     void 엣지_케이스_잘못된_카테고리_Enum값을_전달하면_400에러를_반환한다() throws Exception {
         // when & then
-        mockMvc.perform(get("/api/v1/events")
+        mockMvc.perform(get("/api/events")
                 .param("category", "INVALID_CATEGORY") // 존재하지 않는 Enum
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
@@ -241,7 +241,7 @@ class EventControllerTest {
             .thenReturn(mockResponse);
 
         // when & then
-        mockMvc.perform(get("/api/v1/events")
+        mockMvc.perform(get("/api/events")
                 .param("keyword", "스프링")
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
@@ -268,8 +268,8 @@ class EventControllerTest {
         when(eventService.getEventList(any(EventListRequest.class), eq(sellerId), any(Pageable.class)))
             .thenReturn(mockResponse);
 
-        // when & then (새로 추가된 sellerId, status 포함한 통합 테스트)
-        mockMvc.perform(get("/api/v1/events")
+        // when & then (sellerId, status 포함한 통합 테스트)
+        mockMvc.perform(get("/api/events")
                 .header("X-User-Id", sellerId.toString())
                 .param("sellerId", sellerId.toString())
                 .param("status", "DRAFT")
@@ -315,7 +315,7 @@ class EventControllerTest {
         when(eventService.getSellerEventDetail(eq(sellerId), eq(eventId))).thenReturn(mockResponse);
 
         // when & then
-        mockMvc.perform(get("/api/v1/events/seller/{eventId}", eventId)
+        mockMvc.perform(get("/api/seller/events/{eventId}", eventId)
                 .header("X-User-Id", sellerId.toString())
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
@@ -332,7 +332,7 @@ class EventControllerTest {
         UUID eventId = UUID.randomUUID();
 
         // when & then (헤더 미포함)
-        mockMvc.perform(get("/api/v1/events/seller/{eventId}", eventId)
+        mockMvc.perform(get("/api/seller/events/{eventId}", eventId)
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isBadRequest());
@@ -350,7 +350,7 @@ class EventControllerTest {
         when(eventService.getEventSummary(eq(sellerId), eq(eventId))).thenReturn(mockResponse);
 
         // when & then
-        mockMvc.perform(get("/api/v1/events/{eventId}/statistics", eventId)
+        mockMvc.perform(get("/api/seller/events/{eventId}/statistics", eventId)
                 .header("X-User-Id", sellerId.toString())
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
@@ -367,7 +367,7 @@ class EventControllerTest {
         UUID eventId = UUID.randomUUID();
 
         // when & then (헤더 미포함)
-        mockMvc.perform(get("/api/v1/events/{eventId}/statistics", eventId)
+        mockMvc.perform(get("/api/seller/events/{eventId}/statistics", eventId)
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isBadRequest());
@@ -389,7 +389,7 @@ class EventControllerTest {
             .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(patch("/api/v1/events/{eventId}", eventId)
+        mockMvc.perform(patch("/api/seller/events/{eventId}", eventId)
                 .header("X-User-Id", sellerId.toString())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(cancelRequest)))
@@ -410,7 +410,7 @@ class EventControllerTest {
         SellerEventUpdateRequest cancelRequest = EventTestFixture.createUpdateEventRequest_Cancel();
 
         // when & then (헤더 미포함)
-        mockMvc.perform(patch("/api/v1/events/{eventId}", eventId)
+        mockMvc.perform(patch("/api/seller/events/{eventId}", eventId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(cancelRequest)))
             .andDo(print())
@@ -431,7 +431,7 @@ class EventControllerTest {
             .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(patch("/api/v1/events/{eventId}", eventId)
+        mockMvc.perform(patch("/api/seller/events/{eventId}", eventId)
                 .header("X-User-Id", sellerId.toString())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(updateRequest)))
@@ -456,7 +456,7 @@ class EventControllerTest {
         SellerEventUpdateRequest updateRequest = EventTestFixture.createUpdateEventRequest();
 
         // when & then (헤더 미포함)
-        mockMvc.perform(patch("/api/v1/events/{eventId}", eventId)
+        mockMvc.perform(patch("/api/seller/events/{eventId}", eventId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(updateRequest)))
             .andDo(print())


### PR DESCRIPTION
## 관련 이슈
- close #412 

## 작업 내용
KNN 기반 의미론적 이벤트 검색 시스템 전체 구현

KNN 검색 로직 구현 (EventService, EventDocument, ElasticsearchIndexInitializer, OpenAiProperties, EventController 수정)

### 주요 기능
- OpenAI 임베딩 API를 활용한 벡터 생성 (1536차원)
- Elasticsearch KNN 쿼리를 통한 의미론적 검색
- 임베딩 생성 실패 시 multi_match 폴백으로 안정성 보장
- Seller 권한 기반 검색 결과 필터링 (ES 레벨)
- 페이지네이션 지원 (k=30 설정으로 충분한 후보 확보)

### 버그 수정
- LocalDateTime 포맷 불일치 해결 (마이크로초 선택적 매칭)
- KNN pagination 동작 보장 (k >= numCandidates 규칙 준수)
- EventController API 경로 충돌 해결

## 변경 사항
- **EventService.java**: KNN 쿼리 구성, fallback 처리, sellerId 필터, public syncToElasticsearch()
- **EventDocument.java**: embedding 필드, 날짜 포맷 호환성, seller 권한, truncate 처리
- **ElasticsearchIndexInitializer.java**: 재색인 로직 (syncToElasticsearch 재사용), EventService 의존성
- **event-mapping.json**: sellerId 키워드 필드 추가
- **OpenAiProperties.java**: @Setter 제거, 수동 생성자/getter/setter 구현
- **EventController.java**: API 경로 통합 (/api/events로 단일화)