### PR TITLE
[Payment] feat: (2/3) Outbox 인프라 + PG/Wallet 결제 Kafka 전환

### DIFF
--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -36,13 +36,15 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+	testImplementation 'org.awaitility:awaitility:4.2.1'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'com.h2database:h2'
-
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'io.micrometer:micrometer-registry-prometheus'
-    implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:6.3.1'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.3.1'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
 }
 
 tasks.named('test') {

--- a/payment/src/main/java/com/devticket/payment/common/config/ShedLockConfig.java
+++ b/payment/src/main/java/com/devticket/payment/common/config/ShedLockConfig.java
@@ -1,0 +1,25 @@
+package com.devticket.payment.common.config;
+
+import javax.sql.DataSource;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "30s")
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+            JdbcTemplateLockProvider.Configuration.builder()
+                .withJdbcTemplate(new JdbcTemplate(dataSource))
+                .withTableName("payment.shedlock")
+                .usingDbTime()
+                .build()
+        );
+    }
+}

--- a/payment/src/main/java/com/devticket/payment/common/messaging/KafkaTopics.java
+++ b/payment/src/main/java/com/devticket/payment/common/messaging/KafkaTopics.java
@@ -2,12 +2,31 @@ package com.devticket.payment.common.messaging;
 
 public final class KafkaTopics {
 
+    // Saga 흐름
     public static final String PAYMENT_COMPLETED = "payment.completed";
+    public static final String PAYMENT_FAILED = "payment.failed";
+    public static final String TICKET_ISSUE_FAILED = "ticket.issue-failed";
+
+    // 환불 (Orchestrator)
     public static final String REFUND_COMPLETED = "refund.completed";
+
+    // 이벤트 관리
     public static final String EVENT_FORCE_CANCELLED = "event.force-cancelled";
     public static final String EVENT_SALE_STOPPED = "event.sale-stopped";
-    public static final String MEMBER_SUSPENDED = "member.suspended";
-    public static final String ACTION_LOG = "action.log";
+
+    // 환불 Orchestration (Refund Saga)
+    public static final String REFUND_REQUESTED = "refund.requested";
+    public static final String REFUND_ORDER_CANCEL = "refund.order.cancel";
+    public static final String REFUND_ORDER_DONE = "refund.order.done";
+    public static final String REFUND_ORDER_FAILED = "refund.order.failed";
+    public static final String REFUND_TICKET_CANCEL = "refund.ticket.cancel";
+    public static final String REFUND_TICKET_DONE = "refund.ticket.done";
+    public static final String REFUND_TICKET_FAILED = "refund.ticket.failed";
+    public static final String REFUND_STOCK_RESTORE = "refund.stock.restore";
+    public static final String REFUND_STOCK_DONE = "refund.stock.done";
+    public static final String REFUND_STOCK_FAILED = "refund.stock.failed";
+    public static final String REFUND_ORDER_COMPENSATE = "refund.order.compensate";
+    public static final String REFUND_TICKET_COMPENSATE = "refund.ticket.compensate";
 
     private KafkaTopics() {
     }

--- a/payment/src/main/java/com/devticket/payment/common/messaging/MessageDeduplicationService.java
+++ b/payment/src/main/java/com/devticket/payment/common/messaging/MessageDeduplicationService.java
@@ -21,7 +21,7 @@ public class MessageDeduplicationService {
      * 메시지를 처리 완료로 기록한다.
      * 반드시 비즈니스 로직과 같은 트랜잭션 안에서 호출해야 한다.
      */
-    public void markProcessed(UUID messageId) {
-        processedMessageRepository.save(ProcessedMessage.of(messageId));
+    public void markProcessed(UUID messageId, String topic) {
+        processedMessageRepository.save(ProcessedMessage.of(messageId, topic));
     }
 }

--- a/payment/src/main/java/com/devticket/payment/common/messaging/ProcessedMessage.java
+++ b/payment/src/main/java/com/devticket/payment/common/messaging/ProcessedMessage.java
@@ -25,12 +25,16 @@ public class ProcessedMessage {
     @Column(name = "message_id", nullable = false, unique = true)
     private UUID messageId;
 
+    @Column(name = "topic", nullable = false, length = 128)
+    private String topic;
+
     @Column(name = "processed_at", nullable = false, updatable = false)
     private LocalDateTime processedAt;
 
-    public static ProcessedMessage of(UUID messageId) {
+    public static ProcessedMessage of(UUID messageId, String topic) {
         ProcessedMessage pm = new ProcessedMessage();
         pm.messageId = messageId;
+        pm.topic = topic;
         pm.processedAt = LocalDateTime.now();
         return pm;
     }

--- a/payment/src/main/java/com/devticket/payment/common/outbox/Outbox.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/Outbox.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -27,14 +28,17 @@ public class Outbox extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "aggregate_type", nullable = false, length = 50)
-    private String aggregateType;
-
-    @Column(name = "aggregate_id", nullable = false)
-    private Long aggregateId;
+    @Column(name = "aggregate_id", nullable = false, length = 36)
+    private String aggregateId;
 
     @Column(name = "event_type", nullable = false, length = 100)
     private String eventType;
+
+    @Column(name = "topic", nullable = false, length = 128)
+    private String topic;
+
+    @Column(name = "partition_key", length = 36)
+    private String partitionKey;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String payload;
@@ -49,14 +53,21 @@ public class Outbox extends BaseEntity {
     @Column(name = "retry_count", nullable = false)
     private int retryCount;
 
+    @Column(name = "next_retry_at")
+    private Instant nextRetryAt;
+
+    @Column(name = "sent_at")
+    private Instant sentAt;
+
     private static final int MAX_RETRY = 5;
 
-    public static Outbox create(String aggregateType, Long aggregateId,
-                                String eventType, String payload) {
+    public static Outbox create(String aggregateId, String eventType,
+                                String topic, String partitionKey, String payload) {
         Outbox outbox = new Outbox();
-        outbox.aggregateType = aggregateType;
         outbox.aggregateId = aggregateId;
         outbox.eventType = eventType;
+        outbox.topic = topic;
+        outbox.partitionKey = partitionKey;
         outbox.payload = payload;
         outbox.status = OutboxStatus.PENDING;
         outbox.messageId = UUID.randomUUID();
@@ -66,12 +77,15 @@ public class Outbox extends BaseEntity {
 
     public void markSent() {
         this.status = OutboxStatus.SENT;
+        this.sentAt = Instant.now();
     }
 
     public void increaseRetryCount() {
         this.retryCount++;
         if (this.retryCount >= MAX_RETRY) {
             this.status = OutboxStatus.FAILED;
+        } else {
+            this.nextRetryAt = Instant.now().plusSeconds(this.retryCount * 60L);
         }
     }
 

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxEventMessage.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxEventMessage.java
@@ -1,13 +1,13 @@
 package com.devticket.payment.common.outbox;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 public record OutboxEventMessage(
     UUID messageId,
     String eventType,
     String payload,
-    LocalDateTime timestamp
+    Instant timestamp
 ) {
 
     public static OutboxEventMessage from(Outbox outbox) {
@@ -15,7 +15,7 @@ public record OutboxEventMessage(
             outbox.getMessageId(),
             outbox.getEventType(),
             outbox.getPayload(),
-            LocalDateTime.now()
+            Instant.now()
         );
     }
 }

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxEventProducer.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxEventProducer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
+import org.apache.kafka.common.KafkaException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
@@ -35,7 +36,7 @@ public class OutboxEventProducer {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new OutboxPublishException("Kafka 발행 중 인터럽트 발생", e);
-        } catch (ExecutionException e) {
+        } catch (ExecutionException | KafkaException e) {
             throw new OutboxPublishException("Kafka 발행 실패", e);
         }
     }

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxRepository.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxRepository.java
@@ -1,9 +1,16 @@
 package com.devticket.payment.common.outbox;
 
+import java.time.Instant;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OutboxRepository extends JpaRepository<Outbox, Long> {
 
-    List<Outbox> findTop50ByStatusOrderByCreatedAtAsc(OutboxStatus status);
+    @Query("SELECT o FROM Outbox o WHERE o.status = :status " +
+           "AND (o.nextRetryAt IS NULL OR o.nextRetryAt <= :now) " +
+           "ORDER BY o.createdAt ASC LIMIT 50")
+    List<Outbox> findPendingForRetry(@Param("status") OutboxStatus status,
+                                     @Param("now") Instant now);
 }

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxScheduler.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxScheduler.java
@@ -1,8 +1,10 @@
 package com.devticket.payment.common.outbox;
 
+import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,10 +18,11 @@ public class OutboxScheduler {
     private final OutboxEventProducer outboxEventProducer;
 
     @Scheduled(fixedDelay = 3000)
+    @SchedulerLock(name = "outbox-scheduler", lockAtMostFor = "25s", lockAtLeastFor = "5s")
     @Transactional
     public void publishPendingEvents() {
         List<Outbox> pendingList =
-            outboxRepository.findTop50ByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING);
+            outboxRepository.findPendingForRetry(OutboxStatus.PENDING, Instant.now());
 
         if (pendingList.isEmpty()) {
             return;
@@ -30,9 +33,11 @@ public class OutboxScheduler {
         for (Outbox outbox : pendingList) {
             try {
                 OutboxEventMessage message = OutboxEventMessage.from(outbox);
-                String key = outbox.getAggregateId().toString();
+                String key = outbox.getPartitionKey() != null
+                    ? outbox.getPartitionKey()
+                    : outbox.getAggregateId();
 
-                outboxEventProducer.send(outbox.getEventType(), key, message);
+                outboxEventProducer.send(outbox.getTopic(), key, message);
                 outbox.markSent();
             } catch (OutboxPublishException e) {
                 log.warn("[OutboxScheduler] 이벤트 발행 실패 — outboxId={}, eventType={}, retry={}, error={}",

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxScheduler.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxScheduler.java
@@ -18,7 +18,7 @@ public class OutboxScheduler {
     private final OutboxEventProducer outboxEventProducer;
 
     @Scheduled(fixedDelay = 3000)
-    @SchedulerLock(name = "outbox-scheduler", lockAtMostFor = "25s", lockAtLeastFor = "5s")
+    @SchedulerLock(name = "outbox-scheduler", lockAtMostFor = "30s", lockAtLeastFor = "5s")
     @Transactional
     public void publishPendingEvents() {
         List<Outbox> pendingList =

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxService.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxService.java
@@ -18,21 +18,22 @@ public class OutboxService {
      * Outbox 이벤트를 저장한다.
      * 반드시 비즈니스 로직과 같은 트랜잭션 안에서 호출해야 한다.
      *
-     * @param aggregateType 발행 주체 도메인 (예: "WALLET", "PAYMENT", "REFUND")
-     * @param aggregateId   관련 엔티티 PK
-     * @param eventType     Kafka 토픽명 (예: "payment.completed")
-     * @param payload       이벤트 페이로드 객체 (JSON 직렬화됨)
+     * @param aggregateId  관련 엔티티 식별자 (UUID 문자열)
+     * @param eventType    도메인 이벤트 타입 (예: "payment.completed")
+     * @param topic        Kafka 토픽명 (예: "payment.completed")
+     * @param partitionKey Kafka 파티션 키 (예: orderId)
+     * @param payload      이벤트 페이로드 객체 (JSON 직렬화됨)
      * @return 생성된 Outbox 엔티티
      */
-    public Outbox save(String aggregateType, Long aggregateId,
-                       String eventType, Object payload) {
+    public Outbox save(String aggregateId, String eventType,
+                       String topic, String partitionKey, Object payload) {
         try {
             String json = objectMapper.writeValueAsString(payload);
-            Outbox outbox = Outbox.create(aggregateType, aggregateId, eventType, json);
+            Outbox outbox = Outbox.create(aggregateId, eventType, topic, partitionKey, json);
             return outboxRepository.save(outbox);
         } catch (JsonProcessingException e) {
-            log.error("[Outbox] 페이로드 직렬화 실패 — aggregateType={}, aggregateId={}, eventType={}",
-                aggregateType, aggregateId, eventType, e);
+            log.error("[Outbox] 페이로드 직렬화 실패 — aggregateId={}, eventType={}, topic={}",
+                aggregateId, eventType, topic, e);
             throw new IllegalStateException("Outbox 페이로드 직렬화 실패", e);
         }
     }

--- a/payment/src/main/java/com/devticket/payment/mock/MockCommerceController.java
+++ b/payment/src/main/java/com/devticket/payment/mock/MockCommerceController.java
@@ -1,50 +1,74 @@
-//package com.devticket.payment.mock;
-//
-//import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderInfoResponse;
-//import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderItemInfoResponse;
-//import java.util.UUID;
-//import org.springframework.context.annotation.Profile;
-//import org.springframework.web.bind.annotation.GetMapping;
-//import org.springframework.web.bind.annotation.PathVariable;
-//import org.springframework.web.bind.annotation.PostMapping;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//@RestController
-//@RequestMapping("/mock/commerce")
-//@Profile("local")
-//public class MockCommerceController {
-//
-//    @GetMapping("/internal/orders/{orderId}")
-//    public InternalOrderInfoResponse getOrderInfo(@PathVariable String orderId) {
-//        return new InternalOrderInfoResponse(
-//            1L,
-//            UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
-//            "test",
-//            50000,
-//            "PAYMENT_PENDING",
-//            "2024-01-01T00:00:00"
-//        );
-//    }
-//
-//    @PostMapping("/internal/orders/{orderId}/payment-completed")
-//    public void completePayment(@PathVariable String orderId) {
-//        // 성공 응답만 반환
-//    }
-//
-//    @PostMapping("/internal/orders/{orderId}/payment-failed")
-//    public void failOrder(@PathVariable String orderId) {
-//        // 성공 응답만 반환
-//    }
-//
-//    @GetMapping("/internal/order-items/by-ticket/{ticketId}")
-//    public InternalOrderItemInfoResponse getOrderItemByTicketId(@PathVariable String ticketId) {
-//        return new InternalOrderItemInfoResponse(
-//            1L,                                                          // orderItemId
-//            1L,                                                          // orderId
-//            UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),    // userId
-//            15L,                                                         // eventId
-//            50000                                                        // amount
-//        );
-//    }
-//}
+package com.devticket.payment.mock;
+
+import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderInfoResponse;
+import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderItemInfoResponse;
+import com.devticket.payment.wallet.domain.model.Wallet;
+import com.devticket.payment.wallet.domain.repository.WalletRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Payment 단독 수동 테스트용 Mock 엔드포인트.
+ * test 프로필에서만 활성화.
+ */
+@RestController
+@Profile("test")
+@RequiredArgsConstructor
+public class MockCommerceController {
+
+    private static final UUID MOCK_USER_ID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+    private final WalletRepository walletRepository;
+
+    @GetMapping("/internal/orders/{orderId}")
+    public InternalOrderInfoResponse getOrderInfo(@PathVariable UUID orderId) {
+        return new InternalOrderInfoResponse(
+            orderId,
+            MOCK_USER_ID,
+            "MOCK-ORD-001",
+            50000,
+            "PAYMENT_PENDING",
+            "2025-01-01T00:00:00",
+            List.of(
+                new InternalOrderInfoResponse.OrderItem(
+                    UUID.fromString("550e8400-e29b-41d4-a716-446655440010"), 2
+                )
+            )
+        );
+    }
+
+    @GetMapping("/internal/order-items/by-ticket/{ticketId}")
+    public InternalOrderItemInfoResponse getOrderItemByTicketId(@PathVariable String ticketId) {
+        return new InternalOrderItemInfoResponse(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            MOCK_USER_ID,
+            UUID.fromString("550e8400-e29b-41d4-a716-446655440010"),
+            50000
+        );
+    }
+
+    /**
+     * 테스트용 지갑 잔액 충전. PG 연동 없이 DB에 직접 반영.
+     * POST /mock/wallet/charge?userId=...&amount=100000
+     */
+    @PostMapping("/mock/wallet/charge")
+    @Transactional
+    public Map<String, Object> mockCharge(
+        @RequestParam UUID userId,
+        @RequestParam int amount) {
+        Wallet wallet = walletRepository.findByUserId(userId)
+            .orElseGet(() -> walletRepository.save(Wallet.create(userId)));
+        walletRepository.chargeBalanceAtomic(userId, amount);
+        Wallet updated = walletRepository.findByUserId(userId).orElseThrow();
+        return Map.of("userId", userId, "charged", amount, "balance", updated.getBalance());
+    }
+}

--- a/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
@@ -1,6 +1,20 @@
 package com.devticket.payment.payment.application.service;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.devticket.payment.common.exception.BusinessException;
+import com.devticket.payment.common.messaging.KafkaTopics;
+import com.devticket.payment.common.outbox.OutboxService;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmCommand;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
@@ -19,32 +33,23 @@ import com.devticket.payment.payment.presentation.dto.PaymentFailRequest;
 import com.devticket.payment.payment.presentation.dto.PaymentFailResponse;
 import com.devticket.payment.payment.presentation.dto.PaymentReadyRequest;
 import com.devticket.payment.payment.presentation.dto.PaymentReadyResponse;
-import com.devticket.payment.wallet.domain.exception.WalletErrorCode;
-import com.devticket.payment.wallet.domain.exception.WalletException;
-import com.devticket.payment.wallet.domain.model.Wallet;
-import com.devticket.payment.wallet.domain.model.WalletTransaction;
-import com.devticket.payment.wallet.domain.repository.WalletRepository;
-import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.UUID;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import com.devticket.payment.wallet.application.event.PaymentCompletedEvent;
+import com.devticket.payment.wallet.application.event.PaymentFailedEvent;
+import com.devticket.payment.wallet.application.service.WalletService;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional(readOnly = true)
 public class PaymentServiceImpl implements PaymentService {
 
     private static final int MAX_FAILURE_REASON_LENGTH = 255;
 
     private final PaymentRepository paymentRepository;
-    private final WalletRepository walletRepository;
-    private final WalletTransactionRepository walletTransactionRepository;
     private final CommerceInternalClient commerceInternalClient;
     private final PgPaymentClient pgPaymentClient;
+    private final OutboxService outboxService;
+    private final WalletService walletService;
 
     //결제 준비
     @Override
@@ -65,9 +70,12 @@ public class PaymentServiceImpl implements PaymentService {
 
         Payment savedPayment = paymentRepository.save(payment);
 
-        //예치금 결제일 경우 - 바로 결제
+        //예치금 결제일 경우 - WalletService로 위임 (원자적 UPDATE + Outbox 발행)
         if (request.paymentMethod() == PaymentMethod.WALLET) {
-            return processWalletPayment(userId, order, request.orderId(), savedPayment);
+            walletService.processWalletPayment(userId, request.orderId(), order.totalAmount());
+            Payment updated = paymentRepository.findByOrderId(order.id())
+                .orElseThrow(() -> new PaymentException(PaymentErrorCode.INVALID_PAYMENT_REQUEST));
+            return PaymentReadyResponse.from(updated, request.orderId(), order.orderNumber(), order.status());
         }
 
         return PaymentReadyResponse.from(
@@ -79,6 +87,7 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     @Override
+    @Transactional
     public PaymentConfirmResponse confirmPgPayment(UUID userId, PaymentConfirmRequest request) {
 
         InternalOrderInfoResponse order = commerceInternalClient.getOrderInfo(request.orderId());
@@ -86,9 +95,9 @@ public class PaymentServiceImpl implements PaymentService {
         Payment payment = paymentRepository.findByOrderId(order.id())
             .orElseThrow(() -> new PaymentException(PaymentErrorCode.INVALID_PAYMENT_REQUEST));
 
-        validateOrderOwner(payment.getUserId(), userId); // 올바른 사용자인지 확인
-        validatePaymentStatus(payment, request.paymentId()); // 결제 상태 검증 (중복 승인 방지)
-        validatePaymentAmount(payment, request); // 금액 검증
+        validateOrderOwner(payment.getUserId(), userId);
+        validatePaymentStatus(payment, request.paymentId());
+        validatePaymentAmount(payment, request);
 
         // PG 승인 요청
         PgPaymentConfirmResult result = confirmWithPg(request);
@@ -97,72 +106,24 @@ public class PaymentServiceImpl implements PaymentService {
         payment.approve(result.paymentKey(), parseApprovedAt(result.approvedAt()));
         paymentRepository.save(payment);
 
-        // 주문 완료 처리 — 실패 시 PG 취소 후 보상
-        try {
-            commerceInternalClient.completePayment(payment.getOrderId());
-        } catch (Exception e) {
-            log.error(
-                "주문 완료 처리 실패. PG 취소 보상 트랜잭션 시도: orderId={}, paymentKey={}",
-                payment.getOrderId(),
-                payment.getPaymentKey(),
-                e
-            );
-            cancelPgPayment(payment);
-
-            throw new PaymentException(PaymentErrorCode.ORDER_COMPLETE_FAILED);
-        }
+        // payment.completed Outbox 발행 (트랜잭션 내)
+        PaymentCompletedEvent event = PaymentCompletedEvent.builder()
+            .orderId(payment.getOrderId())
+            .userId(payment.getUserId())
+            .paymentId(payment.getPaymentId())
+            .paymentMethod(payment.getPaymentMethod())
+            .totalAmount(payment.getAmount())
+            .timestamp(Instant.now())
+            .build();
+        outboxService.save(
+            payment.getPaymentId().toString(),
+            KafkaTopics.PAYMENT_COMPLETED,
+            KafkaTopics.PAYMENT_COMPLETED,
+            payment.getOrderId().toString(),
+            event
+        );
 
         return PaymentConfirmResponse.from(payment);
-    }
-
-    //예치금 결제
-    private PaymentReadyResponse processWalletPayment(
-        UUID userId,
-        InternalOrderInfoResponse order,
-        UUID orderId,
-        Payment payment
-    ) {
-        Wallet wallet = walletRepository.findByUserId(userId)
-            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
-
-        String transactionKey = "WALLET:PAY:" + orderId;
-
-        boolean exists = walletTransactionRepository.existsByTransactionKey(transactionKey);
-        if (exists) {
-            throw new PaymentException(PaymentErrorCode.ALREADY_PROCESSED_PAYMENT);
-        }
-
-        if (wallet.getBalance() < order.totalAmount()) {
-            throw new WalletException(WalletErrorCode.INSUFFICIENT_BALANCE);
-        }
-
-        //잔액 차감
-        //TODO : 재시도 로직 추가 OR Atomic Update메서드 사용방식으로 변경하기
-        wallet.use(payment.getAmount());
-
-        //wallet transaction 생성
-        WalletTransaction walletTransaction = WalletTransaction.createUse(
-            wallet.getId(),
-            userId,
-            transactionKey,
-            payment.getAmount(),
-            wallet.getBalance(),
-            payment.getOrderId()
-        );
-
-        walletTransactionRepository.save(walletTransaction);
-
-        //결제 상태 SUCCESS로 변경
-        payment.approve("WALLET-" + payment.getPaymentId());
-
-        //TODO: 주문 완료 처리 추가
-
-        return PaymentReadyResponse.from(
-            payment,
-            orderId,
-            order.orderNumber(),
-            order.status()
-        );
     }
 
     //올바른 사용자인지 확인
@@ -214,11 +175,27 @@ public class PaymentServiceImpl implements PaymentService {
         log.info("PG 결제 실패 처리 완료: orderId={}, code={}, message={}",
             request.orderId(), request.code(), request.message());
 
-        try {
-            commerceInternalClient.failOrder(order.id());
-        } catch (Exception e) {
-            log.error("주문 실패 처리 중 Commerce 연동 오류: orderId={}", order.id(), e);
-        }
+        // payment.failed Outbox 발행 (트랜잭션 내)
+        List<PaymentFailedEvent.OrderItem> orderItems = order.orderItems() == null
+            ? List.of()
+            : order.orderItems().stream()
+                .map(item -> new PaymentFailedEvent.OrderItem(item.eventId(), item.quantity()))
+                .toList();
+
+        PaymentFailedEvent event = PaymentFailedEvent.builder()
+            .orderId(payment.getOrderId())
+            .userId(payment.getUserId())
+            .orderItems(orderItems)
+            .reason(reason)
+            .timestamp(Instant.now())
+            .build();
+        outboxService.save(
+            payment.getPaymentId().toString(),
+            KafkaTopics.PAYMENT_FAILED,
+            KafkaTopics.PAYMENT_FAILED,
+            payment.getOrderId().toString(),
+            event
+        );
 
         return PaymentFailResponse.from(payment);
     }
@@ -263,32 +240,6 @@ public class PaymentServiceImpl implements PaymentService {
         );
     }
 
-    private void cancelPgPayment(Payment payment) {
-        try {
-            pgPaymentClient.cancel(payment.getPaymentKey(), "주문 완료 처리 실패로 인한 자동 취소");
-
-            payment.fail("주문 완료 처리 실패로 승인 후 자동 취소됨");
-            paymentRepository.save(payment);
-
-            log.warn(
-                "PG 자동 취소 성공: orderId={}, paymentKey={}",
-                payment.getOrderId(),
-                payment.getPaymentKey()
-            );
-        } catch (Exception e) {
-            log.error(
-                "PG 자동 취소 실패 - 수동 확인 필요: orderId={}, paymentKey={}",
-                payment.getOrderId(),
-                payment.getPaymentKey(),
-                e
-            );
-
-            payment.fail("주문 완료 처리 실패 및 PG 자동 취소 실패");
-            paymentRepository.save(payment);
-
-            throw new PaymentException(PaymentErrorCode.PG_REFUND_FAILED);
-        }
-    }
 
 
     private LocalDateTime parseApprovedAt(String approvedAt) {

--- a/payment/src/main/java/com/devticket/payment/payment/domain/enums/PaymentStatus.java
+++ b/payment/src/main/java/com/devticket/payment/payment/domain/enums/PaymentStatus.java
@@ -1,9 +1,23 @@
 package com.devticket.payment.payment.domain.enums;
 
+import java.util.Set;
+
 public enum PaymentStatus {
     READY,
     SUCCESS,
     FAILED,
     CANCELLED,
-    REFUNDED
+    REFUNDED;
+
+    public boolean canTransitionTo(PaymentStatus target) {
+        return getAllowedTransitions().contains(target);
+    }
+
+    private Set<PaymentStatus> getAllowedTransitions() {
+        return switch (this) {
+            case READY -> Set.of(SUCCESS, FAILED, CANCELLED);
+            case SUCCESS -> Set.of(REFUNDED, CANCELLED);
+            case FAILED, CANCELLED, REFUNDED -> Set.of();
+        };
+    }
 }

--- a/payment/src/main/java/com/devticket/payment/payment/domain/exception/PaymentErrorCode.java
+++ b/payment/src/main/java/com/devticket/payment/payment/domain/exception/PaymentErrorCode.java
@@ -14,7 +14,8 @@ public enum PaymentErrorCode implements ErrorCode {
     PG_TIMEOUT(502, "PAYMENT_004", "PG사 응답 지연으로 결제에 실패했습니다."),
     PG_REFUND_FAILED(502, "PAYMENT_005", "PG사 환불 처리에 실패했습니다."),
     ORDER_COMPLETE_FAILED(502, "PAYMENT_006", "주문 완료 처리(Commerce 연동)에 실패했습니다."),
-    PG_CANCEL_FAILED(502,       "PAYMENT_007", "PG 결제 취소에 실패했습니다."),;
+    PG_CANCEL_FAILED(502,       "PAYMENT_007", "PG 결제 취소에 실패했습니다."),
+    INVALID_STATUS_TRANSITION(409, "PAYMENT_008", "허용되지 않는 결제 상태 전이입니다.");
 
     private final int status;
     private final String code;

--- a/payment/src/main/java/com/devticket/payment/payment/domain/model/Payment.java
+++ b/payment/src/main/java/com/devticket/payment/payment/domain/model/Payment.java
@@ -3,6 +3,8 @@ package com.devticket.payment.payment.domain.model;
 import com.devticket.payment.common.entity.BaseEntity;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.enums.PaymentStatus;
+import com.devticket.payment.payment.domain.exception.PaymentErrorCode;
+import com.devticket.payment.payment.domain.exception.PaymentException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -26,6 +29,10 @@ public class Payment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
 
     @Column(name = "payment_id", nullable = false, unique = true)
     private UUID paymentId;
@@ -84,28 +91,43 @@ public class Payment extends BaseEntity {
        ======================= */
 
     public void approve(String paymentKey) {
+        validateTransition(PaymentStatus.SUCCESS);
         this.paymentKey = paymentKey;
         this.status = PaymentStatus.SUCCESS;
         this.approvedAt = LocalDateTime.now();
     }
 
     public void approve(String paymentKey, LocalDateTime approvedAt) {
+        validateTransition(PaymentStatus.SUCCESS);
         this.paymentKey = paymentKey;
         this.status = PaymentStatus.SUCCESS;
         this.approvedAt = approvedAt;
     }
 
     public void fail(String reason) {
+        validateTransition(PaymentStatus.FAILED);
         this.status = PaymentStatus.FAILED;
         this.failureReason = reason;
     }
 
     public void cancel() {
+        validateTransition(PaymentStatus.CANCELLED);
         this.status = PaymentStatus.CANCELLED;
     }
 
     public void refund() {
+        validateTransition(PaymentStatus.REFUNDED);
         this.status = PaymentStatus.REFUNDED;
+    }
+
+    public boolean canTransitionTo(PaymentStatus target) {
+        return this.status.canTransitionTo(target);
+    }
+
+    private void validateTransition(PaymentStatus target) {
+        if (!this.status.canTransitionTo(target)) {
+            throw new PaymentException(PaymentErrorCode.INVALID_STATUS_TRANSITION);
+        }
     }
 
     public void softDelete() {

--- a/payment/src/main/java/com/devticket/payment/payment/infrastructure/client/dto/InternalOrderInfoResponse.java
+++ b/payment/src/main/java/com/devticket/payment/payment/infrastructure/client/dto/InternalOrderInfoResponse.java
@@ -1,5 +1,6 @@
 package com.devticket.payment.payment.infrastructure.client.dto;
 
+import java.util.List;
 import java.util.UUID;
 
 public record InternalOrderInfoResponse(
@@ -8,5 +9,11 @@ public record InternalOrderInfoResponse(
     String orderNumber,// ex) "Spring Boot 심화 밋업 외 1건"
     int totalAmount,
     String status,
-    String orderedAt
-) {}
+    String orderedAt,
+    List<OrderItem> orderItems
+) {
+    public record OrderItem(
+        UUID eventId,
+        int quantity
+    ) {}
+}

--- a/payment/src/main/java/com/devticket/payment/wallet/application/event/EventCancelledEvent.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/event/EventCancelledEvent.java
@@ -1,16 +1,17 @@
 package com.devticket.payment.wallet.application.event;
 
-import java.time.LocalDateTime;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.devticket.payment.wallet.domain.enums.CancelledBy;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
 
-@Getter
-@NoArgsConstructor
-public class EventCancelledEvent {
+@Builder
+public record EventCancelledEvent(
+    UUID eventId,
+    UUID sellerId,
+    CancelledBy cancelledBy,
+    UUID adminId,           // cancelledBy=ADMIN 시에만 존재 (nullable)
+    Instant timestamp
+) {
 
-    private Long eventId;
-    private Long sellerId;
-    private String cancelledBy; // "ADMIN" | "SELLER"
-    private Long adminId;       // cancelledBy=ADMIN 시에만 존재 (nullable)
-    private LocalDateTime timestamp;
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/application/event/PaymentCompletedEvent.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/event/PaymentCompletedEvent.java
@@ -1,17 +1,18 @@
 package com.devticket.payment.wallet.application.event;
 
-import java.time.LocalDateTime;
+import com.devticket.payment.payment.domain.enums.PaymentMethod;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record PaymentCompletedEvent(
     UUID orderId,
-    String userId,
-    String paymentId,
-    String paymentMethod, // "WALLET" | "PG"
+    UUID userId,
+    UUID paymentId,
+    PaymentMethod paymentMethod,
     int totalAmount,
-    LocalDateTime timestamp
+    Instant timestamp
 ) {
 
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/application/event/PaymentFailedEvent.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/event/PaymentFailedEvent.java
@@ -1,0 +1,20 @@
+package com.devticket.payment.wallet.application.event;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record PaymentFailedEvent(
+    UUID orderId,
+    UUID userId,
+    List<OrderItem> orderItems,   // 재고 복구 대상 목록
+    String reason,
+    Instant timestamp
+) {
+    public record OrderItem(
+        UUID eventId,
+        int quantity
+    ) {}
+}

--- a/payment/src/main/java/com/devticket/payment/wallet/application/event/RefundCompletedEvent.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/event/RefundCompletedEvent.java
@@ -1,19 +1,20 @@
 package com.devticket.payment.wallet.application.event;
 
-import java.time.LocalDateTime;
+import com.devticket.payment.payment.domain.enums.PaymentMethod;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record RefundCompletedEvent(
-    String refundId,
+    UUID refundId,
     UUID orderId,
-    String userId,
-    String paymentId,
-    String paymentMethod, // "WALLET" | "PG"
+    UUID userId,
+    UUID paymentId,
+    PaymentMethod paymentMethod,
     int refundAmount,
     int refundRate,       // 0 | 50 | 100
-    LocalDateTime timestamp
+    Instant timestamp
 ) {
 
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -1,15 +1,33 @@
 package com.devticket.payment.wallet.application.service;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.devticket.payment.common.messaging.KafkaTopics;
 import com.devticket.payment.common.outbox.OutboxService;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmCommand;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
-import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentStatusResponse;
+import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.enums.PaymentStatus;
 import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
 import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
+import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentStatusResponse;
 import com.devticket.payment.wallet.application.event.PaymentCompletedEvent;
 import com.devticket.payment.wallet.domain.WalletPolicyConstants;
 import com.devticket.payment.wallet.domain.exception.WalletErrorCode;
@@ -29,19 +47,6 @@ import com.devticket.payment.wallet.presentation.dto.WalletChargeResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletTransactionListResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletWithdrawRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletWithdrawResponse;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -140,7 +145,6 @@ public class WalletServiceImpl implements WalletService {
             ));
         } catch (Exception e) {
             log.error("[WalletCharge] PG 승인 실패 — chargeId={}, error={}", chargeId, e.getMessage());
-            //PG결제승인 실패시 기존에 생성된 WalletCharge의 상태값 FAILED로 변경
             walletCharge.fail();
             return WalletChargeConfirmResponse.from(
                 walletCharge.getChargeId().toString(), walletCharge.getAmount(),
@@ -306,13 +310,19 @@ public class WalletServiceImpl implements WalletService {
 
         PaymentCompletedEvent event = PaymentCompletedEvent.builder()
             .orderId(orderId)
-            .userId(userId.toString())
-            .paymentId(payment.getPaymentId().toString())
-            .paymentMethod("WALLET")
+            .userId(userId)
+            .paymentId(payment.getPaymentId())
+            .paymentMethod(PaymentMethod.WALLET)
             .totalAmount(amount)
-            .timestamp(LocalDateTime.now())
+            .timestamp(Instant.now())
             .build();
-        outboxService.save("PAYMENT", payment.getId(), KafkaTopics.PAYMENT_COMPLETED, event);
+        outboxService.save(
+            payment.getPaymentId().toString(),
+            KafkaTopics.PAYMENT_COMPLETED,
+            KafkaTopics.PAYMENT_COMPLETED,
+            orderId.toString(),
+            event
+        );
 
         log.info("[WalletPayment] 예치금 결제 완료 — orderId={}, amount={}, balanceAfter={}",
             orderId, amount, wallet.getBalance());
@@ -397,14 +407,14 @@ public class WalletServiceImpl implements WalletService {
             // }
 
             // RefundCompletedEvent event = RefundCompletedEvent.builder()
-            // .refundId(refund.getRefundId().toString())
+            // .refundId(refund.getRefundId())
             // .orderId(orderId)
-            // .userId(userId.toString())
-            // .paymentId(payment.getPaymentId().toString())
-            // .paymentMethod(orderInfo.getPaymentMethod())
+            // .userId(userId)
+            // .paymentId(payment.getPaymentId())
+            // .paymentMethod(payment.getPaymentMethod())
             // .refundAmount(refundAmount)
             // .refundRate(100)
-            // .timestamp(LocalDateTime.now())
+            // .timestamp(Instant.now())
             // .build();
             // outboxService.save("REFUND", refund.getId(), KafkaTopics.REFUND_COMPLETED, event);
 

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/enums/CancelledBy.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/enums/CancelledBy.java
@@ -1,0 +1,6 @@
+package com.devticket.payment.wallet.domain.enums;
+
+public enum CancelledBy {
+    ADMIN,
+    SELLER
+}

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/WalletEventConsumer.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/WalletEventConsumer.java
@@ -2,6 +2,7 @@ package com.devticket.payment.wallet.infrastructure.kafka;
 
 import com.devticket.payment.common.messaging.KafkaTopics;
 import com.devticket.payment.common.messaging.MessageDeduplicationService;
+import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.wallet.application.event.EventCancelledEvent;
 import com.devticket.payment.wallet.application.event.RefundCompletedEvent;
 import com.devticket.payment.wallet.application.service.WalletService;
@@ -45,16 +46,16 @@ public class WalletEventConsumer {
             RefundCompletedEvent event = objectMapper.readValue(record.value(), RefundCompletedEvent.class);
 
             // 예치금 결제건만 복구 처리 (PG는 이미 PG 취소로 처리됨)
-            if ("WALLET".equals(event.paymentMethod())) {
+            if (PaymentMethod.WALLET == event.paymentMethod()) {
                 walletService.restoreBalance(
-                    UUID.fromString(event.userId()),
+                    event.userId(),
                     event.refundAmount(),
-                    UUID.fromString(event.refundId()),
+                    event.refundId(),
                     event.orderId()
                 );
             }
 
-            deduplicationService.markProcessed(toMessageUUID(messageId));
+            deduplicationService.markProcessed(toMessageUUID(messageId), record.topic());
             ack.acknowledge();
 
         } catch (Exception e) {
@@ -86,14 +87,14 @@ public class WalletEventConsumer {
             EventCancelledEvent event = objectMapper.readValue(record.value(), EventCancelledEvent.class);
 
             log.info("[Consumer] 이벤트 취소 수신 — eventId={}, cancelledBy={}",
-                event.getEventId(), event.getCancelledBy());
+                event.eventId(), event.cancelledBy());
 
             // TODO: Refund 모듈 완성 전까지 일괄 환불 미처리 — ACK하지 않고 예외로 DLT 보존
             // Refund 모듈 완성 후 아래 주석 해제하고 이 예외 블록 제거
             throw new UnsupportedOperationException(
-                "event.cancelled 일괄 환불 미구현 — Refund 모듈 완성 후 처리 예정. eventId=" + event.getEventId());
+                "event.cancelled 일괄 환불 미구현 — Refund 모듈 완성 후 처리 예정. eventId=" + event.eventId());
 
-            // walletService.processBatchRefund(event.getEventId());
+            // walletService.processBatchRefund(event.eventId());
             // deduplicationService.markProcessed(toMessageUUID(messageId));
             // ack.acknowledge();
 

--- a/payment/src/main/resources/application-test.yml
+++ b/payment/src/main/resources/application-test.yml
@@ -1,20 +1,30 @@
 spring:
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
-
   datasource:
-    # H2 메모리 DB를 사용하되, PostgreSQL 모드로 동작하도록 설정
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;INIT=CREATE SCHEMA IF NOT EXISTS payment\;CREATE SCHEMA IF NOT EXISTS refund\;CREATE TABLE IF NOT EXISTS payment.shedlock(name VARCHAR(64) NOT NULL PRIMARY KEY, lock_until TIMESTAMP NOT NULL, locked_at TIMESTAMP NOT NULL, locked_by VARCHAR(255) NOT NULL)
     driver-class-name: org.h2.Driver
     username: sa
     password:
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create-drop # 테스트 시작 시 테이블 생성, 종료 시 삭제
-    show-sql: true
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        default_schema: payment
+  kafka:
+    bootstrap-servers: localhost:9093
+    consumer:
+      group-id: devticket-payment
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+server:
+  port: 8085
 
 jwt:
   secret-key: test-jwt-secret-key
@@ -23,9 +33,9 @@ jwt:
 
 internal:
   commerce:
-    base-url: http://localhost:8083
+    base-url: http://localhost:8085
   event:
-    base-url: http://localhost:8082
+    base-url: http://localhost:8085
 
 pg:
   toss:

--- a/payment/src/test/java/com/devticket/payment/application/service/PaymentServiceImplTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/PaymentServiceImplTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.devticket.payment.common.outbox.OutboxService;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
 import com.devticket.payment.payment.application.service.PaymentServiceImpl;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
@@ -26,10 +27,8 @@ import com.devticket.payment.payment.presentation.dto.PaymentFailRequest;
 import com.devticket.payment.payment.presentation.dto.PaymentFailResponse;
 import com.devticket.payment.payment.presentation.dto.PaymentReadyRequest;
 import com.devticket.payment.payment.presentation.dto.PaymentReadyResponse;
-import com.devticket.payment.wallet.domain.exception.WalletException;
-import com.devticket.payment.wallet.domain.model.Wallet;
-import com.devticket.payment.wallet.domain.repository.WalletRepository;
-import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
+import com.devticket.payment.wallet.application.service.WalletService;
+import java.util.List;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
@@ -47,10 +46,10 @@ public class PaymentServiceImplTest {
 
     @Mock
     private PaymentRepository paymentRepository;
-    @Mock private WalletRepository walletRepository;
-    @Mock private WalletTransactionRepository walletTransactionRepository;
     @Mock private CommerceInternalClient commerceInternalClient;
     @Mock private PgPaymentClient pgPaymentClient;
+    @Mock private OutboxService outboxService;
+    @Mock private WalletService walletService;
 
     @InjectMocks
     private PaymentServiceImpl paymentService;
@@ -73,7 +72,8 @@ public class PaymentServiceImplTest {
             "ORD-20250815-001",
             130000,
             "PAYMENT_PENDING",
-            LocalDateTime.of(2025, 8, 15, 14, 30).toString()
+            LocalDateTime.of(2025, 8, 15, 14, 30).toString(),
+            List.of()
         );
     }
 
@@ -144,7 +144,8 @@ public class PaymentServiceImplTest {
             PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG);
             InternalOrderInfoResponse paidOrder = new InternalOrderInfoResponse(
                 ORDER_ID, USER_ID, "ORD-001", 130000, "PAID",
-                LocalDateTime.of(2025, 8, 15, 14, 30).toString()
+                LocalDateTime.of(2025, 8, 15, 14, 30).toString(),
+                List.of()
             );
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(paidOrder);
@@ -157,67 +158,24 @@ public class PaymentServiceImplTest {
         }
 
         @Test
-        @DisplayName("예치금 결제 준비 성공 — SUCCESS 상태, 잔액 차감")
+        @DisplayName("예치금 결제 준비 성공 — WalletService로 위임")
         void 예치금_결제_준비_성공() {
             // given
             PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.WALLET);
-            Wallet wallet = Wallet.create(USER_ID);
-            wallet.charge(200000);
+            Payment savedPayment = createReadyPayment();
+            savedPayment.approve("WALLET-" + savedPayment.getPaymentId());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.save(any(Payment.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
-            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(wallet));
-            given(walletTransactionRepository.existsByTransactionKey("WALLET:PAY:" + EXTERNAL_ORDER_ID))
-                .willReturn(false);
+            given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(savedPayment));
 
             // when
             PaymentReadyResponse response = paymentService.readyPayment(USER_ID, request);
 
             // then
+            verify(walletService).processWalletPayment(USER_ID, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
             assertThat(response.paymentStatus()).isEqualTo(PaymentStatus.SUCCESS);
-            assertThat(response.approvedAt()).isNotNull();
-            assertThat(wallet.getBalance()).isEqualTo(70000);
-        }
-
-        @Test
-        @DisplayName("예치금 잔액 부족 — 예외")
-        void 예치금_잔액_부족() {
-            // given
-            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.WALLET);
-            Wallet wallet = Wallet.create(USER_ID);
-            wallet.charge(10000);
-
-            given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
-            given(paymentRepository.save(any(Payment.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
-            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(wallet));
-            given(walletTransactionRepository.existsByTransactionKey("WALLET:PAY:" + EXTERNAL_ORDER_ID))
-                .willReturn(false);
-
-            // when & then
-            assertThatThrownBy(() -> paymentService.readyPayment(USER_ID, request))
-                .isInstanceOf(WalletException.class);
-        }
-
-        @Test
-        @DisplayName("이미_처리된_예치금_거래 — 예외")
-        void 이미_처리된_예치금_거래() {
-            // given
-            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.WALLET);
-            Wallet wallet = Wallet.create(USER_ID);
-            wallet.charge(200000);
-
-            given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
-            given(paymentRepository.save(any(Payment.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
-            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(wallet));
-            given(walletTransactionRepository.existsByTransactionKey("WALLET:PAY:" + EXTERNAL_ORDER_ID))
-                .willReturn(true);
-
-            // when & then
-            assertThatThrownBy(() -> paymentService.readyPayment(USER_ID, request))
-                .isInstanceOf(PaymentException.class);
         }
     }
 
@@ -250,7 +208,7 @@ public class PaymentServiceImplTest {
             assertThat(response.status()).isEqualTo(PaymentStatus.SUCCESS);
             assertThat(payment.getPaymentKey()).isEqualTo(PAYMENT_KEY);
             assertThat(payment.getApprovedAt()).isNotNull();
-            verify(commerceInternalClient).completePayment(orderInfo.id());
+            verify(outboxService).save(any(), any(), any(), any(), any());
         }
 
         @Test
@@ -352,12 +310,12 @@ public class PaymentServiceImplTest {
                 .extracting(e -> ((PaymentException) e).getErrorCode())
                 .isEqualTo(PaymentErrorCode.PG_CONFIRM_FAILED);
 
-            verify(commerceInternalClient, never()).completePayment(any());
+            verify(outboxService, never()).save(any(), any(), any(), any(), any());
         }
 
         @Test
-        @DisplayName("Commerce 주문 완료 실패 + PG 취소 성공 — ORDER_COMPLETE_FAILED 예외, payment FAILED 저장")
-        void Commerce_실패_PG_취소_성공() {
+        @DisplayName("PG 승인 성공 후 Outbox에 payment.completed 이벤트 저장")
+        void PG_승인_성공_후_Outbox_저장() {
             // given
             Payment payment = createReadyPayment();
             PaymentConfirmRequest request = new PaymentConfirmRequest(
@@ -368,44 +326,13 @@ public class PaymentServiceImplTest {
             given(pgPaymentClient.confirm(any())).willReturn(createPgConfirmResult());
             given(paymentRepository.save(any(Payment.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
-            willThrow(new RuntimeException("Commerce 오류"))
-                .given(commerceInternalClient).completePayment(orderInfo.id());
 
-            // when & then
-            assertThatThrownBy(() -> paymentService.confirmPgPayment(USER_ID, request))
-                .isInstanceOf(PaymentException.class)
-                .extracting(e -> ((PaymentException) e).getErrorCode())
-                .isEqualTo(PaymentErrorCode.ORDER_COMPLETE_FAILED);
+            // when
+            paymentService.confirmPgPayment(USER_ID, request);
 
-            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAILED);
-            verify(pgPaymentClient).cancel(any(), any());
-        }
-
-        @Test
-        @DisplayName("Commerce 주문 완료 실패 + PG 취소도 실패 — PG_REFUND_FAILED 예외, payment FAILED 저장")
-        void Commerce_실패_PG_취소_실패() {
-            // given
-            Payment payment = createReadyPayment();
-            PaymentConfirmRequest request = new PaymentConfirmRequest(
-                PAYMENT_KEY, PAYMENT_ID, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
-
-            given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
-            given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
-            given(pgPaymentClient.confirm(any())).willReturn(createPgConfirmResult());
-            given(paymentRepository.save(any(Payment.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
-            willThrow(new RuntimeException("Commerce 오류"))
-                .given(commerceInternalClient).completePayment(orderInfo.id());
-            willThrow(new PaymentException(PaymentErrorCode.PG_CANCEL_FAILED))
-                .given(pgPaymentClient).cancel(any(), any());
-
-            // when & then
-            assertThatThrownBy(() -> paymentService.confirmPgPayment(USER_ID, request))
-                .isInstanceOf(PaymentException.class)
-                .extracting(e -> ((PaymentException) e).getErrorCode())
-                .isEqualTo(PaymentErrorCode.PG_REFUND_FAILED);
-
-            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+            // then
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+            verify(outboxService).save(any(), any(), any(), any(), any());
         }
     }
 
@@ -418,7 +345,7 @@ public class PaymentServiceImplTest {
     class FailPgPaymentTest {
 
         @Test
-        @DisplayName("성공 — payment가 FAILED 상태, failureReason 저장, Commerce failOrder 호출")
+        @DisplayName("성공 — payment가 FAILED 상태, failureReason 저장, Outbox에 payment.failed 저장")
         void 성공() {
             // given
             Payment payment = createReadyPayment();
@@ -437,7 +364,7 @@ public class PaymentServiceImplTest {
             assertThat(response.status()).isEqualTo(PaymentStatus.FAILED);
             assertThat(response.failureReason()).isEqualTo("[PAY_PROCESS_CANCELED] 사용자가 결제를 취소했습니다.");
             assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAILED);
-            verify(commerceInternalClient).failOrder(orderInfo.id());
+            verify(outboxService).save(any(), any(), any(), any(), any());
         }
 
         @Test
@@ -493,28 +420,6 @@ public class PaymentServiceImplTest {
                 .isEqualTo(PaymentErrorCode.ALREADY_PROCESSED_PAYMENT);
 
             verify(paymentRepository, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("Commerce failOrder 실패 — 예외 없이 FAILED 상태 정상 반환")
-        void Commerce_failOrder_실패_시_정상_완료() {
-            // given
-            Payment payment = createReadyPayment();
-            PaymentFailRequest request = new PaymentFailRequest(EXTERNAL_ORDER_ID, null, null);
-
-            given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
-            given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(payment));
-            given(paymentRepository.save(any(Payment.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
-            willThrow(new RuntimeException("Commerce 오류"))
-                .given(commerceInternalClient).failOrder(orderInfo.id());
-
-            // when
-            PaymentFailResponse response = paymentService.failPgPayment(USER_ID, request);
-
-            // then — Commerce 연동 실패와 무관하게 결제 실패 처리는 완료
-            assertThat(response.status()).isEqualTo(PaymentStatus.FAILED);
-            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAILED);
         }
 
         @Nested
@@ -595,6 +500,66 @@ public class PaymentServiceImplTest {
                 // then
                 assertThat(response.failureReason()).isEqualTo("PG 결제 실패");
             }
+        }
+    }
+
+    // =========================================================
+    // failPgPayment — orderItems 매핑
+    // =========================================================
+
+    @Nested
+    @DisplayName("PG 결제 실패 — orderItems 매핑")
+    class FailPgPaymentOrderItemsTest {
+
+        @Test
+        @DisplayName("orderItems가 있으면 PaymentFailedEvent에 매핑")
+        void orderItems_매핑_성공() {
+            // given
+            Payment payment = createReadyPayment();
+            InternalOrderInfoResponse orderWithItems = new InternalOrderInfoResponse(
+                ORDER_ID, USER_ID, "ORD-001", 130000, "PAYMENT_PENDING",
+                LocalDateTime.of(2025, 8, 15, 14, 30).toString(),
+                List.of(
+                    new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), 2),
+                    new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), 1)
+                )
+            );
+            PaymentFailRequest request = new PaymentFailRequest(
+                EXTERNAL_ORDER_ID, "STOCK_FAIL", "stock shortage");
+
+            given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderWithItems);
+            given(paymentRepository.findByOrderId(orderWithItems.id())).willReturn(Optional.of(payment));
+            given(paymentRepository.save(any())).willAnswer(i -> i.getArgument(0));
+
+            // when
+            paymentService.failPgPayment(USER_ID, request);
+
+            // then
+            verify(outboxService).save(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("orderItems가 null이면 빈 리스트로 매핑")
+        void orderItems_null이면_빈_리스트() {
+            // given
+            Payment payment = createReadyPayment();
+            InternalOrderInfoResponse orderWithNullItems = new InternalOrderInfoResponse(
+                ORDER_ID, USER_ID, "ORD-001", 130000, "PAYMENT_PENDING",
+                LocalDateTime.of(2025, 8, 15, 14, 30).toString(),
+                null
+            );
+            PaymentFailRequest request = new PaymentFailRequest(
+                EXTERNAL_ORDER_ID, "ERROR", "internal error");
+
+            given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderWithNullItems);
+            given(paymentRepository.findByOrderId(orderWithNullItems.id())).willReturn(Optional.of(payment));
+            given(paymentRepository.save(any())).willAnswer(i -> i.getArgument(0));
+
+            // when
+            paymentService.failPgPayment(USER_ID, request);
+
+            // then
+            verify(outboxService).save(any(), any(), any(), any(), any());
         }
     }
 

--- a/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
@@ -301,7 +301,7 @@ class WalletServiceTest {
 
             // then
             then(walletRepository).should(times(1)).useBalanceAtomic(USER_ID, 50_000);
-            then(outboxService).should(times(1)).save(anyString(), anyLong(), eq(KafkaTopics.PAYMENT_COMPLETED), any());
+            then(outboxService).should(times(1)).save(anyString(), eq(KafkaTopics.PAYMENT_COMPLETED), eq(KafkaTopics.PAYMENT_COMPLETED), anyString(), any());
         }
 
         @Test
@@ -314,7 +314,7 @@ class WalletServiceTest {
 
             // then: atomic update 및 이벤트 발행 없음
             then(walletRepository).should(never()).useBalanceAtomic(any(), anyInt());
-            then(outboxService).should(never()).save(anyString(), anyLong(), anyString(), any());
+            then(outboxService).should(never()).save(anyString(), anyString(), anyString(), anyString(), any());
         }
 
         @Test
@@ -330,7 +330,7 @@ class WalletServiceTest {
                 .extracting(e -> ((WalletException) e).getErrorCode())
                 .isEqualTo(WalletErrorCode.INSUFFICIENT_BALANCE);
 
-            then(outboxService).should(never()).save(anyString(), anyLong(), anyString(), any());
+            then(outboxService).should(never()).save(anyString(), anyString(), anyString(), anyString(), any());
         }
 
         @Test
@@ -444,6 +444,7 @@ class WalletServiceTest {
             UUID chargeId = UUID.randomUUID();
             WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
             given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+
             given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
                 .willThrow(new RuntimeException("PG timeout"));
 
@@ -461,6 +462,7 @@ class WalletServiceTest {
             UUID chargeId = UUID.randomUUID();
             WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
             given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+
             given(pgPaymentClient.findPaymentByOrderId(chargeId.toString())).willReturn(Optional.empty());
 
             // when
@@ -480,6 +482,7 @@ class WalletServiceTest {
             Wallet wallet = walletWithBalance(60_000); // 충전 후 잔액
 
             given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+
             given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
                 .willReturn(Optional.of(new TossPaymentStatusResponse(
                     paymentKey, chargeId.toString(), "DONE", 10_000, "2024-01-01T12:00:00")));
@@ -506,6 +509,7 @@ class WalletServiceTest {
             WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
 
             given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+
             given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
                 .willReturn(Optional.of(new TossPaymentStatusResponse(
                     paymentKey, chargeId.toString(), "DONE", 10_000, "2024-01-01T12:00:00")));
@@ -526,6 +530,7 @@ class WalletServiceTest {
             UUID chargeId = UUID.randomUUID();
             WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
             given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+
             given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
                 .willReturn(Optional.of(new TossPaymentStatusResponse(
                     null, chargeId.toString(), "CANCELED", 10_000, null)));
@@ -544,6 +549,7 @@ class WalletServiceTest {
             UUID chargeId = UUID.randomUUID();
             WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
             given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+
             given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
                 .willReturn(Optional.of(new TossPaymentStatusResponse(
                     null, chargeId.toString(), "ABORTED", 10_000, null)));

--- a/payment/src/test/java/com/devticket/payment/common/messaging/KafkaTopicsTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/messaging/KafkaTopicsTest.java
@@ -1,0 +1,88 @@
+package com.devticket.payment.common.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("KafkaTopics 상수 검증")
+class KafkaTopicsTest {
+
+    @Nested
+    @DisplayName("Saga 흐름 토픽")
+    class SagaTopics {
+
+        @Test
+        void payment_completed_토픽명() {
+            assertThat(KafkaTopics.PAYMENT_COMPLETED).isEqualTo("payment.completed");
+        }
+
+        @Test
+        void payment_failed_토픽명() {
+            assertThat(KafkaTopics.PAYMENT_FAILED).isEqualTo("payment.failed");
+        }
+
+        @Test
+        void ticket_issue_failed_토픽명() {
+            assertThat(KafkaTopics.TICKET_ISSUE_FAILED).isEqualTo("ticket.issue-failed");
+        }
+    }
+
+    @Nested
+    @DisplayName("환불 Orchestration 토픽")
+    class RefundSagaTopics {
+
+        @Test
+        void refund_completed_토픽명() {
+            assertThat(KafkaTopics.REFUND_COMPLETED).isEqualTo("refund.completed");
+        }
+
+        @Test
+        void refund_requested_토픽명() {
+            assertThat(KafkaTopics.REFUND_REQUESTED).isEqualTo("refund.requested");
+        }
+
+        @Test
+        void refund_order_cancel_done_failed_토픽명() {
+            assertThat(KafkaTopics.REFUND_ORDER_CANCEL).isEqualTo("refund.order.cancel");
+            assertThat(KafkaTopics.REFUND_ORDER_DONE).isEqualTo("refund.order.done");
+            assertThat(KafkaTopics.REFUND_ORDER_FAILED).isEqualTo("refund.order.failed");
+        }
+
+        @Test
+        void refund_ticket_cancel_done_failed_토픽명() {
+            assertThat(KafkaTopics.REFUND_TICKET_CANCEL).isEqualTo("refund.ticket.cancel");
+            assertThat(KafkaTopics.REFUND_TICKET_DONE).isEqualTo("refund.ticket.done");
+            assertThat(KafkaTopics.REFUND_TICKET_FAILED).isEqualTo("refund.ticket.failed");
+        }
+
+        @Test
+        void refund_stock_restore_done_failed_토픽명() {
+            assertThat(KafkaTopics.REFUND_STOCK_RESTORE).isEqualTo("refund.stock.restore");
+            assertThat(KafkaTopics.REFUND_STOCK_DONE).isEqualTo("refund.stock.done");
+            assertThat(KafkaTopics.REFUND_STOCK_FAILED).isEqualTo("refund.stock.failed");
+        }
+
+        @Test
+        void refund_보상_토픽명() {
+            assertThat(KafkaTopics.REFUND_ORDER_COMPENSATE).isEqualTo("refund.order.compensate");
+            assertThat(KafkaTopics.REFUND_TICKET_COMPENSATE).isEqualTo("refund.ticket.compensate");
+        }
+    }
+
+    @Nested
+    @DisplayName("이벤트 관리 토픽")
+    class EventTopics {
+
+        @Test
+        void event_force_cancelled_토픽명() {
+            assertThat(KafkaTopics.EVENT_FORCE_CANCELLED).isEqualTo("event.force-cancelled");
+        }
+
+        @Test
+        void event_sale_stopped_토픽명() {
+            assertThat(KafkaTopics.EVENT_SALE_STOPPED).isEqualTo("event.sale-stopped");
+        }
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxSchedulerTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxSchedulerTest.java
@@ -1,0 +1,221 @@
+package com.devticket.payment.common.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Outbox 스케줄러 (OutboxScheduler)")
+class OutboxSchedulerTest {
+
+    @Mock
+    private OutboxRepository outboxRepository;
+
+    @Mock
+    private OutboxEventProducer outboxEventProducer;
+
+    @InjectMocks
+    private OutboxScheduler scheduler;
+
+    private Outbox createOutbox(String topic, String partitionKey) {
+        return Outbox.create(
+            "agg-id-001",
+            "payment.completed",
+            topic,
+            partitionKey,
+            "{\"orderId\":\"order-uuid-001\"}"
+        );
+    }
+
+    // =====================================================================
+    // PENDING 조회
+    // =====================================================================
+
+    @Nested
+    @DisplayName("PENDING 조회")
+    class FindPending {
+
+        @Test
+        void PENDING_없으면_producer_미호출() {
+            // given
+            given(outboxRepository.findPendingForRetry(any(), any())).willReturn(List.of());
+
+            // when
+            scheduler.publishPendingEvents();
+
+            // then
+            then(outboxEventProducer).should(never()).send(any(), any(), any());
+        }
+    }
+
+    // =====================================================================
+    // 발행 성공
+    // =====================================================================
+
+    @Nested
+    @DisplayName("발행 성공")
+    class PublishSuccess {
+
+        @Test
+        void topic과_partitionKey_기반으로_발행() {
+            // given
+            Outbox outbox = createOutbox("payment.completed", "order-uuid-001");
+            given(outboxRepository.findPendingForRetry(any(), any())).willReturn(List.of(outbox));
+
+            // when
+            scheduler.publishPendingEvents();
+
+            // then
+            then(outboxEventProducer).should(times(1))
+                .send(eq("payment.completed"), eq("order-uuid-001"), any());
+        }
+
+        @Test
+        void 발행_성공_후_status가_SENT() {
+            // given
+            Outbox outbox = createOutbox("payment.completed", "order-uuid-001");
+            given(outboxRepository.findPendingForRetry(any(), any())).willReturn(List.of(outbox));
+
+            // when
+            scheduler.publishPendingEvents();
+
+            // then
+            assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.SENT);
+        }
+
+        @Test
+        void 발행_성공_후_sentAt_채워짐() {
+            // given
+            Outbox outbox = createOutbox("payment.completed", "order-uuid-001");
+            given(outboxRepository.findPendingForRetry(any(), any())).willReturn(List.of(outbox));
+
+            // when
+            scheduler.publishPendingEvents();
+
+            // then
+            assertThat(outbox.getSentAt()).isNotNull();
+        }
+
+        @Test
+        void partitionKey_null이면_aggregateId를_key로_사용() {
+            // given
+            Outbox outbox = createOutbox("payment.completed", null);
+            given(outboxRepository.findPendingForRetry(any(), any())).willReturn(List.of(outbox));
+
+            // when
+            scheduler.publishPendingEvents();
+
+            // then
+            then(outboxEventProducer).should(times(1))
+                .send(eq("payment.completed"), eq("agg-id-001"), any());
+        }
+
+        @Test
+        void 여러_건_모두_발행() {
+            // given
+            Outbox outbox1 = createOutbox("payment.completed", "order-001");
+            Outbox outbox2 = createOutbox("payment.completed", "order-002");
+            Outbox outbox3 = createOutbox("payment.completed", "order-003");
+            given(outboxRepository.findPendingForRetry(any(), any()))
+                .willReturn(List.of(outbox1, outbox2, outbox3));
+
+            // when
+            scheduler.publishPendingEvents();
+
+            // then
+            then(outboxEventProducer).should(times(3)).send(any(), any(), any());
+            assertThat(outbox1.getStatus()).isEqualTo(OutboxStatus.SENT);
+            assertThat(outbox2.getStatus()).isEqualTo(OutboxStatus.SENT);
+            assertThat(outbox3.getStatus()).isEqualTo(OutboxStatus.SENT);
+        }
+    }
+
+    // =====================================================================
+    // 발행 실패 / 오류 격리
+    // =====================================================================
+
+    @Nested
+    @DisplayName("발행 실패 — 오류 격리")
+    class PublishFailure {
+
+        @Test
+        void 발행_실패_시_retryCount_증가() {
+            // given
+            Outbox outbox = createOutbox("payment.completed", "order-uuid-001");
+            given(outboxRepository.findPendingForRetry(any(), any())).willReturn(List.of(outbox));
+            willThrow(new OutboxPublishException("Kafka 연결 실패", new RuntimeException()))
+                .given(outboxEventProducer).send(any(), any(), any());
+
+            // when
+            scheduler.publishPendingEvents();
+
+            // then
+            assertThat(outbox.getRetryCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 발행_실패_시_nextRetryAt_설정() {
+            // given
+            Outbox outbox = createOutbox("payment.completed", "order-uuid-001");
+            given(outboxRepository.findPendingForRetry(any(), any())).willReturn(List.of(outbox));
+            willThrow(new OutboxPublishException("Kafka 연결 실패", new RuntimeException()))
+                .given(outboxEventProducer).send(any(), any(), any());
+
+            // when
+            scheduler.publishPendingEvents();
+
+            // then
+            assertThat(outbox.getNextRetryAt()).isNotNull();
+        }
+
+        @Test
+        void 특정_건_실패해도_나머지_건_계속_처리() {
+            // given: outbox2 발행 시 예외
+            Outbox outbox1 = createOutbox("payment.completed", "order-001");
+            Outbox outbox2 = createOutbox("payment.completed", "order-002");
+            Outbox outbox3 = createOutbox("payment.completed", "order-003");
+            given(outboxRepository.findPendingForRetry(any(), any()))
+                .willReturn(List.of(outbox1, outbox2, outbox3));
+            lenient().doThrow(new OutboxPublishException("Kafka 오류", new RuntimeException()))
+                .when(outboxEventProducer).send(any(), eq("order-002"), any());
+
+            // when
+            scheduler.publishPendingEvents();
+
+            // then
+            assertThat(outbox1.getStatus()).isEqualTo(OutboxStatus.SENT);
+            assertThat(outbox2.getRetryCount()).isEqualTo(1);
+            assertThat(outbox3.getStatus()).isEqualTo(OutboxStatus.SENT);
+        }
+
+        @Test
+        void 모든_건_실패해도_스케줄러_예외_미전파() {
+            // given
+            Outbox outbox1 = createOutbox("payment.completed", "order-001");
+            Outbox outbox2 = createOutbox("payment.completed", "order-002");
+            given(outboxRepository.findPendingForRetry(any(), any()))
+                .willReturn(List.of(outbox1, outbox2));
+            willThrow(new OutboxPublishException("전체 오류", new RuntimeException()))
+                .given(outboxEventProducer).send(any(), any(), any());
+
+            // when & then: 스케줄러 자체는 예외 없이 정상 종료
+            org.assertj.core.api.Assertions.assertThatCode(scheduler::publishPendingEvents)
+                .doesNotThrowAnyException();
+        }
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxTest.java
@@ -1,0 +1,198 @@
+package com.devticket.payment.common.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Outbox 엔티티")
+class OutboxTest {
+
+    private Outbox outbox;
+
+    @BeforeEach
+    void setUp() {
+        outbox = Outbox.create(
+            "payment-uuid-001",
+            "payment.completed",
+            "payment.completed",
+            "order-uuid-001",
+            "{\"orderId\":\"order-uuid-001\"}"
+        );
+    }
+
+    // =====================================================================
+    // 생성
+    // =====================================================================
+
+    @Nested
+    @DisplayName("생성")
+    class Create {
+
+        @Test
+        void 생성_후_초기_status는_PENDING() {
+            assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PENDING);
+        }
+
+        @Test
+        void 생성_후_retryCount는_0() {
+            assertThat(outbox.getRetryCount()).isZero();
+        }
+
+        @Test
+        void 생성_후_sentAt과_nextRetryAt은_null() {
+            assertThat(outbox.getSentAt()).isNull();
+            assertThat(outbox.getNextRetryAt()).isNull();
+        }
+
+        @Test
+        void 생성_후_isPending_true() {
+            assertThat(outbox.isPending()).isTrue();
+        }
+
+        @Test
+        void 생성_시_전달한_topic과_partitionKey_저장() {
+            assertThat(outbox.getTopic()).isEqualTo("payment.completed");
+            assertThat(outbox.getPartitionKey()).isEqualTo("order-uuid-001");
+        }
+    }
+
+    // =====================================================================
+    // 발행 성공 — markSent()
+    // =====================================================================
+
+    @Nested
+    @DisplayName("발행 성공 — markSent()")
+    class MarkSent {
+
+        @Test
+        void markSent_호출_후_status가_SENT() {
+            // when
+            outbox.markSent();
+
+            // then
+            assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.SENT);
+        }
+
+        @Test
+        void markSent_호출_후_sentAt_채워짐() {
+            // given
+            Instant before = Instant.now();
+
+            // when
+            outbox.markSent();
+
+            // then
+            assertThat(outbox.getSentAt())
+                .isNotNull()
+                .isAfterOrEqualTo(before);
+        }
+
+        @Test
+        void markSent_후_isPending_false() {
+            // when
+            outbox.markSent();
+
+            // then
+            assertThat(outbox.isPending()).isFalse();
+        }
+    }
+
+    // =====================================================================
+    // 재시도 — increaseRetryCount()
+    // =====================================================================
+
+    @Nested
+    @DisplayName("재시도 — increaseRetryCount()")
+    class IncreaseRetryCount {
+
+        @Test
+        void 재시도_호출_시_retryCount_1_증가() {
+            // when
+            outbox.increaseRetryCount();
+
+            // then
+            assertThat(outbox.getRetryCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 재시도_시_nextRetryAt이_현재_이후로_설정() {
+            // given
+            Instant before = Instant.now();
+
+            // when
+            outbox.increaseRetryCount();
+
+            // then
+            assertThat(outbox.getNextRetryAt())
+                .isNotNull()
+                .isAfterOrEqualTo(before);
+        }
+
+        @Test
+        void MAX_RETRY_미만이면_status_PENDING_유지() {
+            // when: 4회 재시도 (MAX_RETRY = 5)
+            for (int i = 0; i < 4; i++) {
+                outbox.increaseRetryCount();
+            }
+
+            // then
+            assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PENDING);
+            assertThat(outbox.getRetryCount()).isEqualTo(4);
+        }
+
+        @Test
+        void MAX_RETRY_도달_시_status가_FAILED() {
+            // when: 5회 재시도
+            for (int i = 0; i < 5; i++) {
+                outbox.increaseRetryCount();
+            }
+
+            // then
+            assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
+            assertThat(outbox.getRetryCount()).isEqualTo(5);
+        }
+
+        @Test
+        void 재시도_횟수에_따른_백오프_간격_증가() {
+            // 1차 재시도: 60초, 2차: 120초, 3차: 180초
+            Instant before1 = Instant.now();
+            outbox.increaseRetryCount(); // retryCount=1
+            Instant after1 = outbox.getNextRetryAt();
+
+            Instant before2 = Instant.now();
+            outbox.increaseRetryCount(); // retryCount=2
+            Instant after2 = outbox.getNextRetryAt();
+
+            // 2차 nextRetryAt이 1차보다 더 먼 미래
+            assertThat(after2).isAfter(after1);
+        }
+
+        @Test
+        void markSent_후_sentAt이_Instant_타입() {
+            // when
+            outbox.markSent();
+
+            // then
+            assertThat(outbox.getSentAt()).isInstanceOf(Instant.class);
+        }
+
+        @Test
+        void MAX_RETRY_도달_시_nextRetryAt_갱신_안됨() {
+            // given: 4회까지 nextRetryAt 설정
+            for (int i = 0; i < 4; i++) {
+                outbox.increaseRetryCount();
+            }
+            Instant nextRetryAtBefore = outbox.getNextRetryAt();
+
+            // when: 5회째 → FAILED 전환, nextRetryAt 갱신 없음
+            outbox.increaseRetryCount();
+
+            // then
+            assertThat(outbox.getNextRetryAt()).isEqualTo(nextRetryAtBefore);
+        }
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/integration/PaymentKafkaIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/integration/PaymentKafkaIntegrationTest.java
@@ -1,0 +1,340 @@
+package com.devticket.payment.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.devticket.payment.common.outbox.Outbox;
+import com.devticket.payment.common.outbox.OutboxRepository;
+import com.devticket.payment.common.outbox.OutboxStatus;
+import com.devticket.payment.payment.domain.enums.PaymentMethod;
+import com.devticket.payment.payment.domain.enums.PaymentStatus;
+import com.devticket.payment.payment.domain.model.Payment;
+import com.devticket.payment.payment.domain.repository.PaymentRepository;
+import com.devticket.payment.wallet.domain.model.Wallet;
+import com.devticket.payment.wallet.domain.model.WalletTransaction;
+import com.devticket.payment.wallet.domain.repository.WalletRepository;
+import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
+import com.devticket.payment.wallet.application.service.WalletService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Payment 단독 통합 테스트 — Commerce/PG 의존 없이 Kafka + Outbox + 트랜잭션 + 스케줄러 검증.
+ *
+ * 검증 범위:
+ * 1. PG 결제 승인 → Outbox INSERT → 스케줄러 → Kafka payment.completed 발행
+ * 2. PG 결제 실패 → Outbox INSERT → 스케줄러 → Kafka payment.failed 발행
+ * 3. Wallet 결제 → 원자적 잔액 차감 + Outbox INSERT → Kafka payment.completed 발행
+ * 4. Wallet 충전 비관적 락 동시성 (일일 한도 체크 직렬화)
+ * 5. Payment 상태 전이 가드 (canTransitionTo)
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(
+    partitions = 1,
+    topics = {"payment.completed", "payment.failed", "refund.completed",
+              "event.force-cancelled", "event.sale-stopped"}
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class PaymentKafkaIntegrationTest {
+
+    @Autowired private PaymentRepository paymentRepository;
+    @Autowired private OutboxRepository outboxRepository;
+    @Autowired private WalletRepository walletRepository;
+    @Autowired private WalletTransactionRepository walletTransactionRepository;
+    @Autowired private WalletService walletService;
+    @Autowired private ObjectMapper objectMapper;
+
+    private static final List<ConsumerRecord<String, String>> completedRecords =
+        Collections.synchronizedList(new ArrayList<>());
+    private static final List<ConsumerRecord<String, String>> failedRecords =
+        Collections.synchronizedList(new ArrayList<>());
+
+    @KafkaListener(topics = "payment.completed", groupId = "test-completed")
+    void listenCompleted(ConsumerRecord<String, String> record) {
+        completedRecords.add(record);
+    }
+
+    @KafkaListener(topics = "payment.failed", groupId = "test-failed")
+    void listenFailed(ConsumerRecord<String, String> record) {
+        failedRecords.add(record);
+    }
+
+    @BeforeEach
+    void setUp() {
+        completedRecords.clear();
+        failedRecords.clear();
+    }
+
+    // =========================================================
+    // 1. Outbox → 스케줄러 → Kafka 발행 E2E
+    // =========================================================
+
+    @Nested
+    @DisplayName("Outbox → Kafka 발행 E2E")
+    class OutboxToKafkaTest {
+
+        @Test
+        @DisplayName("payment.completed Outbox 레코드 → 스케줄러가 Kafka로 발행")
+        void payment_completed_outbox_to_kafka() throws Exception {
+            // given: Payment 생성 + 승인 + Outbox 직접 INSERT (Commerce/PG 우회)
+            UUID orderId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            Payment payment = Payment.create(orderId, userId, PaymentMethod.PG, 50_000);
+            payment.approve("test-payment-key");
+            paymentRepository.save(payment);
+
+            String payload = objectMapper.writeValueAsString(new java.util.LinkedHashMap<>() {{
+                put("orderId", orderId.toString());
+                put("userId", userId.toString());
+                put("paymentId", payment.getPaymentId().toString());
+                put("paymentMethod", "PG");
+                put("totalAmount", 50_000);
+                put("timestamp", java.time.Instant.now().toString());
+            }});
+
+            Outbox outbox = Outbox.create(
+                payment.getPaymentId().toString(),
+                "payment.completed",
+                "payment.completed",
+                orderId.toString(),
+                payload
+            );
+            outboxRepository.save(outbox);
+
+            // then: 스케줄러가 3초 내에 발행, Kafka에서 수신 확인
+            await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+                assertThat(completedRecords).isNotEmpty();
+                String value = completedRecords.get(completedRecords.size() - 1).value();
+                JsonNode node = objectMapper.readTree(value);
+                JsonNode payloadNode = objectMapper.readTree(node.get("payload").asText());
+                assertThat(payloadNode.get("orderId").asText()).isEqualTo(orderId.toString());
+                assertThat(payloadNode.get("paymentMethod").asText()).isEqualTo("PG");
+            });
+
+            // Outbox 상태 SENT 확인
+            Outbox sent = outboxRepository.findById(outbox.getId()).orElseThrow();
+            assertThat(sent.getStatus()).isEqualTo(OutboxStatus.SENT);
+        }
+
+        @Test
+        @DisplayName("payment.failed Outbox 레코드 → 스케줄러가 Kafka로 발행")
+        void payment_failed_outbox_to_kafka() throws Exception {
+            // given
+            UUID orderId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            Payment payment = Payment.create(orderId, userId, PaymentMethod.PG, 30_000);
+            payment.fail("잔액 부족");
+            paymentRepository.save(payment);
+
+            String payload = objectMapper.writeValueAsString(new java.util.LinkedHashMap<>() {{
+                put("orderId", orderId.toString());
+                put("userId", userId.toString());
+                put("reason", "잔액 부족");
+                put("timestamp", java.time.Instant.now().toString());
+            }});
+
+            Outbox outbox = Outbox.create(
+                payment.getPaymentId().toString(),
+                "payment.failed",
+                "payment.failed",
+                orderId.toString(),
+                payload
+            );
+            outboxRepository.save(outbox);
+
+            // then
+            await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+                assertThat(failedRecords).isNotEmpty();
+                String value = failedRecords.get(failedRecords.size() - 1).value();
+                JsonNode node = objectMapper.readTree(value);
+                JsonNode payloadNode = objectMapper.readTree(node.get("payload").asText());
+                assertThat(payloadNode.get("reason").asText()).isEqualTo("잔액 부족");
+            });
+
+            Outbox sent = outboxRepository.findById(outbox.getId()).orElseThrow();
+            assertThat(sent.getStatus()).isEqualTo(OutboxStatus.SENT);
+        }
+    }
+
+    // =========================================================
+    // 2. Wallet 결제 → 원자적 차감 + Outbox + Kafka
+    // =========================================================
+
+    @Nested
+    @DisplayName("Wallet 결제 → Outbox → Kafka")
+    class WalletPaymentTest {
+
+        @Test
+        @DisplayName("Wallet 결제 성공 → 잔액 차감 + Outbox INSERT + Kafka 발행")
+        void wallet_payment_outbox_to_kafka() throws Exception {
+            // given: Wallet + Payment(READY) 준비
+            UUID userId = UUID.randomUUID();
+            UUID orderId = UUID.randomUUID();
+
+            Wallet wallet = Wallet.create(userId);
+            wallet.charge(100_000);
+            walletRepository.save(wallet);
+
+            Payment payment = Payment.create(orderId, userId, PaymentMethod.WALLET, 30_000);
+            paymentRepository.save(payment);
+
+            // when: WalletService.processWalletPayment 호출 (Commerce 우회, 직접 호출)
+            walletService.processWalletPayment(userId, orderId, 30_000);
+
+            // then: 잔액 차감 확인
+            Wallet updated = walletRepository.findByUserId(userId).orElseThrow();
+            assertThat(updated.getBalance()).isEqualTo(70_000);
+
+            // Payment 상태 확인
+            Payment completedPayment = paymentRepository.findByOrderId(orderId).orElseThrow();
+            assertThat(completedPayment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+
+            // Outbox INSERT 확인
+            List<Outbox> outboxes = outboxRepository.findPendingForRetry(
+                OutboxStatus.PENDING, java.time.Instant.now().plusSeconds(60));
+            assertThat(outboxes).anyMatch(o ->
+                "payment.completed".equals(o.getEventType())
+                && o.getPartitionKey().equals(orderId.toString())
+            );
+
+            // Kafka 발행 확인 (스케줄러 대기)
+            await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+                assertThat(completedRecords).anyMatch(r -> {
+                    try {
+                        JsonNode node = objectMapper.readTree(r.value());
+                        JsonNode p = objectMapper.readTree(node.get("payload").asText());
+                        return orderId.toString().equals(p.get("orderId").asText())
+                            && "WALLET".equals(p.get("paymentMethod").asText());
+                    } catch (Exception e) { return false; }
+                });
+            });
+        }
+    }
+
+    // =========================================================
+    // 3. Payment 상태 전이 가드
+    // =========================================================
+
+    @Nested
+    @DisplayName("Payment 상태 전이 가드")
+    class StatusTransitionTest {
+
+        @Test
+        @DisplayName("READY → SUCCESS 허용")
+        void ready_to_success() {
+            Payment payment = Payment.create(UUID.randomUUID(), UUID.randomUUID(), PaymentMethod.PG, 10_000);
+            assertThat(payment.canTransitionTo(PaymentStatus.SUCCESS)).isTrue();
+            payment.approve("key");
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+        }
+
+        @Test
+        @DisplayName("SUCCESS → REFUNDED 허용")
+        void success_to_refunded() {
+            Payment payment = Payment.create(UUID.randomUUID(), UUID.randomUUID(), PaymentMethod.PG, 10_000);
+            payment.approve("key");
+            assertThat(payment.canTransitionTo(PaymentStatus.REFUNDED)).isTrue();
+            payment.refund();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+        }
+
+        @Test
+        @DisplayName("FAILED → SUCCESS 금지 (종단 상태)")
+        void failed_to_success_blocked() {
+            Payment payment = Payment.create(UUID.randomUUID(), UUID.randomUUID(), PaymentMethod.PG, 10_000);
+            payment.fail("test");
+            assertThat(payment.canTransitionTo(PaymentStatus.SUCCESS)).isFalse();
+            org.junit.jupiter.api.Assertions.assertThrows(
+                com.devticket.payment.payment.domain.exception.PaymentException.class,
+                () -> payment.approve("key")
+            );
+        }
+
+        @Test
+        @DisplayName("SUCCESS → FAILED 금지")
+        void success_to_failed_blocked() {
+            Payment payment = Payment.create(UUID.randomUUID(), UUID.randomUUID(), PaymentMethod.PG, 10_000);
+            payment.approve("key");
+            assertThat(payment.canTransitionTo(PaymentStatus.FAILED)).isFalse();
+            org.junit.jupiter.api.Assertions.assertThrows(
+                com.devticket.payment.payment.domain.exception.PaymentException.class,
+                () -> payment.fail("test")
+            );
+        }
+    }
+
+    // =========================================================
+    // 4. Wallet 충전 비관적 락 동시성
+    // =========================================================
+
+    @Nested
+    @DisplayName("Wallet 충전 비관적 락 동시성")
+    class WalletChargeConcurrencyTest {
+
+        @Test
+        @DisplayName("동시 충전 요청 시 일일 한도 초과 방지 (비관적 락 직렬화)")
+        void concurrent_charge_daily_limit() throws Exception {
+            // given: 일일 한도 1,000,000원, 50,000원씩 25번 동시 요청 = 1,250,000원
+            // 20번만 성공해야 함 (20 * 50,000 = 1,000,000)
+            UUID userId = UUID.randomUUID();
+            Wallet wallet = Wallet.create(userId);
+            walletRepository.save(wallet);
+
+            int threadCount = 25;
+            int chargeAmount = 50_000;
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // when: 동시 충전 요청
+            for (int i = 0; i < threadCount; i++) {
+                final String idempotencyKey = "concurrent-charge-" + i;
+                executor.submit(() -> {
+                    try {
+                        walletService.charge(
+                            userId,
+                            new com.devticket.payment.wallet.presentation.dto.WalletChargeRequest(chargeAmount),
+                            idempotencyKey
+                        );
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        failCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+            executor.shutdown();
+
+            // then: 일일 한도(1,000,000) 이내만 성공
+            assertThat(successCount.get()).isLessThanOrEqualTo(20);
+            assertThat(failCount.get()).isGreaterThanOrEqualTo(5);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Outbox `nextRetryAt`/`sentAt` LocalDateTime → Instant 전환 (kafka-design.md §4 일치)
- `@SchedulerLock` 적용 — 분산 환경 Outbox 스케줄러 중복 실행 방지 (shedlock)
- KafkaTopics Saga 토픽 12개 추가, `member.suspended`/`action.log` 제거
- `PaymentServiceImpl`: REST 동기 호출(`completePayment`/`failOrder`) 제거 → Outbox `payment.completed`/`payment.failed` 발행
- `PaymentServiceImpl`: `processWalletPayment` 제거 → `WalletService` 위임 (원자적 UPDATE)
- `Payment` 상태 전이 가드 (`canTransitionTo` + `validateTransition`)
- DTO 계약 kafka-design.md §3 일치: UUID + Instant + PaymentMethod enum
- `PaymentFailedEvent` orderItems 포함 (Event 서비스 재고 복구 대상)
- `InternalOrderInfoResponse` orderItems 필드 추가 (Commerce Internal API 연동)

## 변경 파일 (31개)
- Outbox 인프라: `Outbox`, `OutboxRepository`, `OutboxScheduler`, `OutboxEventProducer`, `OutboxEventMessage`, `OutboxService`, `ShedLockConfig`(신규)
- Kafka 전환: `PaymentServiceImpl`, `WalletServiceImpl`, `KafkaTopics`, `MockCommerceController`
- 상태 전이: `PaymentStatus`, `Payment`, `PaymentErrorCode`
- DTO: `PaymentCompletedEvent`, `PaymentFailedEvent`(신규), `RefundCompletedEvent`, `EventCancelledEvent`, `CancelledBy`(신규)
- 설정: `application-test.yml`, `build.gradle`
- 테스트: `PaymentKafkaIntegrationTest`(신규), `KafkaTopicsTest`(신규), `OutboxTest`(신규), `OutboxSchedulerTest`(신규), `PaymentServiceImplTest`, `WalletServiceTest`

## Test plan
- [x] JUnit 103개 전체 통과
- [x] 수동 테스트: Mock Commerce → PG 결제 준비/실패, Wallet 결제, 상태 전이 가드, 멱등성
- [ ] Commerce 서비스 연동 시 `InternalOrderInfoResponse.orderItems` 필드 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)