### PR TITLE
[Payment] fix: Kafka Consumer 설정 및 멱등성 보완 (#401)

### DIFF
--- a/payment/src/main/java/com/devticket/payment/common/config/KafkaConsumerConfig.java
+++ b/payment/src/main/java/com/devticket/payment/common/config/KafkaConsumerConfig.java
@@ -15,7 +15,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
-import org.springframework.util.backoff.FixedBackOff;
+import org.springframework.util.backoff.ExponentialBackOff;
 
 @Configuration
 public class KafkaConsumerConfig {
@@ -54,7 +54,8 @@ public class KafkaConsumerConfig {
             }
         );
 
-        FixedBackOff backOff = new FixedBackOff(2000L, 3L); // 2초 간격, 최대 3회
+        ExponentialBackOff backOff = new ExponentialBackOff(2000L, 2.0); // 2→4→8초
+        backOff.setMaxAttempts(3); // 최대 3회 재시도
         return new DefaultErrorHandler(recoverer, backOff);
     }
 

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxEventProducer.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxEventProducer.java
@@ -1,16 +1,18 @@
 package com.devticket.payment.common.outbox;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutionException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.kafka.common.KafkaException;
 
 @Slf4j
 @Component
@@ -28,7 +30,11 @@ public class OutboxEventProducer {
         try {
             String json = objectMapper.writeValueAsString(message);
 
-            var result = kafkaTemplate.send(topic, key, json).get();
+            ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, json);
+            record.headers().add("X-Message-Id",
+                message.messageId().toString().getBytes(StandardCharsets.UTF_8));
+
+            var result = kafkaTemplate.send(record).get();
 
             log.info("[Outbox] Kafka 발행 성공 — topic={}, messageId={}, offset={}",
                 topic, message.messageId(),

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
@@ -28,8 +28,6 @@ public interface WalletService {
 
     void restoreBalance(UUID userId, int amount, UUID refundId, UUID orderId);
 
-    void restoreBalanceWithDedup(UUID userId, int amount, UUID refundId, UUID orderId, UUID messageId);
-
     void processBatchRefund(UUID eventId);
 
     void recoverStalePendingCharge(UUID chargeId);

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
@@ -28,6 +28,8 @@ public interface WalletService {
 
     void restoreBalance(UUID userId, int amount, UUID refundId, UUID orderId);
 
+    void restoreBalanceWithDedup(UUID userId, int amount, UUID refundId, UUID orderId, UUID messageId);
+
     void processBatchRefund(UUID eventId);
 
     void recoverStalePendingCharge(UUID chargeId);

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.devticket.payment.common.messaging.KafkaTopics;
-import com.devticket.payment.common.messaging.MessageDeduplicationService;
 import com.devticket.payment.common.outbox.OutboxService;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmCommand;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
@@ -63,7 +62,6 @@ public class WalletServiceImpl implements WalletService {
     private final PgPaymentClient pgPaymentClient;
     private final OutboxService outboxService;
     private final CommerceInternalClient commerceInternalClient;
-    private final MessageDeduplicationService deduplicationService;
 
     // =====================================================================
     // 충전 시작(결제인증에 필요한 WalletCharge생성-chargeId)
@@ -394,12 +392,6 @@ public class WalletServiceImpl implements WalletService {
             refundId, amount, wallet.getBalance());
     }
 
-    @Override
-    @Transactional
-    public void restoreBalanceWithDedup(UUID userId, int amount, UUID refundId, UUID orderId, UUID messageId) {
-        restoreBalance(userId, amount, refundId, orderId);
-        deduplicationService.markProcessed(messageId, KafkaTopics.REFUND_COMPLETED);
-    }
 
     // =====================================================================
     // event.force-cancelled / event.sale-stopped — 일괄 환불

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.devticket.payment.common.messaging.KafkaTopics;
+import com.devticket.payment.common.messaging.MessageDeduplicationService;
 import com.devticket.payment.common.outbox.OutboxService;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmCommand;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
@@ -62,6 +63,7 @@ public class WalletServiceImpl implements WalletService {
     private final PgPaymentClient pgPaymentClient;
     private final OutboxService outboxService;
     private final CommerceInternalClient commerceInternalClient;
+    private final MessageDeduplicationService deduplicationService;
 
     // =====================================================================
     // 충전 시작(결제인증에 필요한 WalletCharge생성-chargeId)
@@ -390,6 +392,13 @@ public class WalletServiceImpl implements WalletService {
 
         log.info("[WalletRefund] 예치금 복구 완료 — refundId={}, amount={}, balanceAfter={}",
             refundId, amount, wallet.getBalance());
+    }
+
+    @Override
+    @Transactional
+    public void restoreBalanceWithDedup(UUID userId, int amount, UUID refundId, UUID orderId, UUID messageId) {
+        restoreBalance(userId, amount, refundId, orderId);
+        deduplicationService.markProcessed(messageId, KafkaTopics.REFUND_COMPLETED);
     }
 
     // =====================================================================

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/RefundCompletedHandler.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/RefundCompletedHandler.java
@@ -1,0 +1,33 @@
+package com.devticket.payment.wallet.infrastructure.kafka;
+
+import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.devticket.payment.common.messaging.MessageDeduplicationService;
+import com.devticket.payment.wallet.application.service.WalletService;
+
+@Service
+@RequiredArgsConstructor
+public class RefundCompletedHandler {
+
+    private final WalletService walletService;
+    private final MessageDeduplicationService deduplicationService;
+
+    @Transactional
+    public void restoreBalanceAndMarkProcessed(
+        UUID userId, int amount, UUID refundId, UUID orderId,
+        UUID messageId, String topic
+    ) {
+        walletService.restoreBalance(userId, amount, refundId, orderId);
+        deduplicationService.markProcessed(messageId, topic);
+    }
+
+    @Transactional
+    public void markProcessedOnly(UUID messageId, String topic) {
+        deduplicationService.markProcessed(messageId, topic);
+    }
+}

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/WalletEventConsumer.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/WalletEventConsumer.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
@@ -30,13 +31,13 @@ public class WalletEventConsumer {
      */
     @KafkaListener(
         topics = KafkaTopics.REFUND_COMPLETED,
-        groupId = "payment-wallet-group",
+        groupId = "payment-refund.completed",
         containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeRefundCompleted(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        String messageId = buildMessageId(record);
+        UUID messageUUID = extractMessageId(record);
 
-        if (deduplicationService.isDuplicate(toMessageUUID(messageId))) {
+        if (deduplicationService.isDuplicate(messageUUID)) {
             log.info("[Consumer] 중복 메시지 스킵 — topic={}, offset={}", record.topic(), record.offset());
             ack.acknowledge();
             return;
@@ -47,21 +48,24 @@ public class WalletEventConsumer {
 
             // 예치금 결제건만 복구 처리 (PG는 이미 PG 취소로 처리됨)
             if (PaymentMethod.WALLET == event.paymentMethod()) {
-                walletService.restoreBalance(
+                // restoreBalance + markProcessed를 하나의 @Transactional에서 처리
+                walletService.restoreBalanceWithDedup(
                     event.userId(),
                     event.refundAmount(),
                     event.refundId(),
-                    event.orderId()
+                    event.orderId(),
+                    messageUUID
                 );
+            } else {
+                // PG 결제건은 복구 불필요 — dedup만 기록
+                deduplicationService.markProcessed(messageUUID, record.topic());
             }
 
-            deduplicationService.markProcessed(toMessageUUID(messageId), record.topic());
             ack.acknowledge();
 
         } catch (Exception e) {
             log.error("[Consumer] refund.completed 처리 실패 — messageId={}, error={}",
-                messageId, e.getMessage(), e);
-            // DefaultErrorHandler가 3회 재시도 후 DLT(refund.completed.DLT)로 이동
+                messageUUID, e.getMessage(), e);
             throw new RuntimeException("refund.completed 처리 실패", e);
         }
     }
@@ -75,9 +79,9 @@ public class WalletEventConsumer {
         containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeEventCancelled(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        String messageId = buildMessageId(record);
+        UUID messageUUID = extractMessageId(record);
 
-        if (deduplicationService.isDuplicate(toMessageUUID(messageId))) {
+        if (deduplicationService.isDuplicate(messageUUID)) {
             log.info("[Consumer] 중복 메시지 스킵 — topic={}, offset={}", record.topic(), record.offset());
             ack.acknowledge();
             return;
@@ -95,25 +99,27 @@ public class WalletEventConsumer {
                 "event.cancelled 일괄 환불 미구현 — Refund 모듈 완성 후 처리 예정. eventId=" + event.eventId());
 
             // walletService.processBatchRefund(event.eventId());
-            // deduplicationService.markProcessed(toMessageUUID(messageId));
+            // deduplicationService.markProcessed(messageUUID);
             // ack.acknowledge();
 
         } catch (Exception e) {
             log.error("[Consumer] event.cancelled 처리 실패 — messageId={}, error={}",
-                messageId, e.getMessage(), e);
+                messageUUID, e.getMessage(), e);
             throw new RuntimeException("event.cancelled 처리 실패", e);
         }
     }
 
-    private String buildMessageId(ConsumerRecord<String, String> record) {
-        return record.topic() + ":" + record.partition() + ":" + record.offset();
-    }
-
     /**
-     * topic:partition:offset 형식의 messageId를 결정적 UUID로 변환 MessageDeduplicationService가 UUID를 요구하므로 name-based UUID(v3)
-     * 사용
+     * Kafka 헤더에서 X-Message-Id를 추출한다.
+     * 헤더가 없으면 topic:partition:offset 기반 결정적 UUID(v3)로 폴백한다.
      */
-    private UUID toMessageUUID(String messageId) {
-        return UUID.nameUUIDFromBytes(messageId.getBytes(StandardCharsets.UTF_8));
+    private UUID extractMessageId(ConsumerRecord<String, String> record) {
+        Header header = record.headers().lastHeader("X-Message-Id");
+        if (header != null) {
+            return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8));
+        }
+        // 폴백: 헤더 없는 레거시 메시지 대응
+        String fallback = record.topic() + ":" + record.partition() + ":" + record.offset();
+        return UUID.nameUUIDFromBytes(fallback.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/WalletEventConsumer.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/WalletEventConsumer.java
@@ -5,7 +5,6 @@ import com.devticket.payment.common.messaging.MessageDeduplicationService;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.wallet.application.event.EventCancelledEvent;
 import com.devticket.payment.wallet.application.event.RefundCompletedEvent;
-import com.devticket.payment.wallet.application.service.WalletService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
@@ -22,7 +21,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class WalletEventConsumer {
 
-    private final WalletService walletService;
+    private final RefundCompletedHandler refundCompletedHandler;
     private final MessageDeduplicationService deduplicationService;
     private final ObjectMapper objectMapper;
 
@@ -46,19 +45,19 @@ public class WalletEventConsumer {
         try {
             RefundCompletedEvent event = objectMapper.readValue(record.value(), RefundCompletedEvent.class);
 
-            // 예치금 결제건만 복구 처리 (PG는 이미 PG 취소로 처리됨)
             if (PaymentMethod.WALLET == event.paymentMethod()) {
                 // restoreBalance + markProcessed를 하나의 @Transactional에서 처리
-                walletService.restoreBalanceWithDedup(
+                refundCompletedHandler.restoreBalanceAndMarkProcessed(
                     event.userId(),
                     event.refundAmount(),
                     event.refundId(),
                     event.orderId(),
-                    messageUUID
+                    messageUUID,
+                    record.topic()
                 );
             } else {
                 // PG 결제건은 복구 불필요 — dedup만 기록
-                deduplicationService.markProcessed(messageUUID, record.topic());
+                refundCompletedHandler.markProcessedOnly(messageUUID, record.topic());
             }
 
             ack.acknowledge();
@@ -99,7 +98,7 @@ public class WalletEventConsumer {
                 "event.cancelled 일괄 환불 미구현 — Refund 모듈 완성 후 처리 예정. eventId=" + event.eventId());
 
             // walletService.processBatchRefund(event.eventId());
-            // deduplicationService.markProcessed(messageUUID);
+            // refundCompletedHandler.markProcessedOnly(messageUUID, record.topic());
             // ack.acknowledge();
 
         } catch (Exception e) {
@@ -111,14 +110,19 @@ public class WalletEventConsumer {
 
     /**
      * Kafka 헤더에서 X-Message-Id를 추출한다.
-     * 헤더가 없으면 topic:partition:offset 기반 결정적 UUID(v3)로 폴백한다.
+     * 헤더가 없거나 파싱 실패 시 topic:partition:offset 기반 결정적 UUID(v3)로 폴백한다.
      */
     private UUID extractMessageId(ConsumerRecord<String, String> record) {
         Header header = record.headers().lastHeader("X-Message-Id");
         if (header != null) {
-            return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8));
+            try {
+                return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8));
+            } catch (IllegalArgumentException e) {
+                log.warn("[Consumer] X-Message-Id 파싱 실패, 레거시 폴백 사용 — topic={}, offset={}",
+                    record.topic(), record.offset());
+            }
         }
-        // 폴백: 헤더 없는 레거시 메시지 대응
+        // 폴백: 헤더 없거나 파싱 실패 시 topic:partition:offset 기반 결정적 UUID
         String fallback = record.topic() + ":" + record.partition() + ":" + record.offset();
         return UUID.nameUUIDFromBytes(fallback.getBytes(StandardCharsets.UTF_8));
     }

--- a/payment/src/test/java/com/devticket/payment/domain/PaymentStatusTest.java
+++ b/payment/src/test/java/com/devticket/payment/domain/PaymentStatusTest.java
@@ -1,0 +1,88 @@
+package com.devticket.payment.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.devticket.payment.payment.domain.enums.PaymentStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PaymentStatus 상태 전이 규칙")
+class PaymentStatusTest {
+
+    @Nested
+    @DisplayName("READY 상태에서")
+    class ReadyState {
+
+        @Test
+        void SUCCESS로_전이_가능() {
+            assertThat(PaymentStatus.READY.canTransitionTo(PaymentStatus.SUCCESS)).isTrue();
+        }
+
+        @Test
+        void FAILED로_전이_가능() {
+            assertThat(PaymentStatus.READY.canTransitionTo(PaymentStatus.FAILED)).isTrue();
+        }
+
+        @Test
+        void CANCELLED로_전이_가능() {
+            assertThat(PaymentStatus.READY.canTransitionTo(PaymentStatus.CANCELLED)).isTrue();
+        }
+
+        @Test
+        void REFUNDED로_전이_불가() {
+            assertThat(PaymentStatus.READY.canTransitionTo(PaymentStatus.REFUNDED)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("SUCCESS 상태에서")
+    class SuccessState {
+
+        @Test
+        void REFUNDED로_전이_가능() {
+            assertThat(PaymentStatus.SUCCESS.canTransitionTo(PaymentStatus.REFUNDED)).isTrue();
+        }
+
+        @Test
+        void CANCELLED로_전이_가능() {
+            assertThat(PaymentStatus.SUCCESS.canTransitionTo(PaymentStatus.CANCELLED)).isTrue();
+        }
+
+        @Test
+        void READY로_전이_불가() {
+            assertThat(PaymentStatus.SUCCESS.canTransitionTo(PaymentStatus.READY)).isFalse();
+        }
+
+        @Test
+        void FAILED로_전이_불가() {
+            assertThat(PaymentStatus.SUCCESS.canTransitionTo(PaymentStatus.FAILED)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("종단 상태에서")
+    class TerminalStates {
+
+        @Test
+        void FAILED는_어디로도_전이_불가() {
+            for (PaymentStatus target : PaymentStatus.values()) {
+                assertThat(PaymentStatus.FAILED.canTransitionTo(target)).isFalse();
+            }
+        }
+
+        @Test
+        void CANCELLED는_어디로도_전이_불가() {
+            for (PaymentStatus target : PaymentStatus.values()) {
+                assertThat(PaymentStatus.CANCELLED.canTransitionTo(target)).isFalse();
+            }
+        }
+
+        @Test
+        void REFUNDED는_어디로도_전이_불가() {
+            for (PaymentStatus target : PaymentStatus.values()) {
+                assertThat(PaymentStatus.REFUNDED.canTransitionTo(target)).isFalse();
+            }
+        }
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/domain/PaymentTest.java
+++ b/payment/src/test/java/com/devticket/payment/domain/PaymentTest.java
@@ -1,0 +1,150 @@
+package com.devticket.payment.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.devticket.payment.payment.domain.enums.PaymentMethod;
+import com.devticket.payment.payment.domain.enums.PaymentStatus;
+import com.devticket.payment.payment.domain.exception.PaymentErrorCode;
+import com.devticket.payment.payment.domain.exception.PaymentException;
+import com.devticket.payment.payment.domain.model.Payment;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Payment 상태 전이 가드")
+class PaymentTest {
+
+    private Payment createReadyPayment() {
+        return Payment.create(UUID.randomUUID(), UUID.randomUUID(), PaymentMethod.PG, 10000);
+    }
+
+    @Nested
+    @DisplayName("approve()")
+    class ApproveTest {
+
+        @Test
+        void READY에서_SUCCESS로_전이_성공() {
+            // given
+            Payment payment = createReadyPayment();
+
+            // when
+            payment.approve("paymentKey-123", LocalDateTime.now());
+
+            // then
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+            assertThat(payment.getPaymentKey()).isEqualTo("paymentKey-123");
+        }
+
+        @Test
+        void SUCCESS에서_approve_호출시_예외() {
+            // given
+            Payment payment = createReadyPayment();
+            payment.approve("paymentKey-123");
+
+            // when & then
+            assertThatThrownBy(() -> payment.approve("paymentKey-456"))
+                .isInstanceOf(PaymentException.class)
+                .satisfies(ex -> assertThat(((PaymentException) ex).getErrorCode())
+                    .isEqualTo(PaymentErrorCode.INVALID_STATUS_TRANSITION));
+        }
+
+        @Test
+        void FAILED에서_approve_호출시_예외() {
+            // given
+            Payment payment = createReadyPayment();
+            payment.fail("테스트 실패");
+
+            // when & then
+            assertThatThrownBy(() -> payment.approve("paymentKey-123"))
+                .isInstanceOf(PaymentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("fail()")
+    class FailTest {
+
+        @Test
+        void READY에서_FAILED로_전이_성공() {
+            // given
+            Payment payment = createReadyPayment();
+
+            // when
+            payment.fail("PG 거절");
+
+            // then
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+            assertThat(payment.getFailureReason()).isEqualTo("PG 거절");
+        }
+
+        @Test
+        void SUCCESS에서_fail_호출시_예외() {
+            // given
+            Payment payment = createReadyPayment();
+            payment.approve("paymentKey-123");
+
+            // when & then
+            assertThatThrownBy(() -> payment.fail("이미 성공한 결제"))
+                .isInstanceOf(PaymentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("cancel()")
+    class CancelTest {
+
+        @Test
+        void READY에서_CANCELLED로_전이_성공() {
+            // given
+            Payment payment = createReadyPayment();
+
+            // when
+            payment.cancel();
+
+            // then
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+        }
+
+        @Test
+        void FAILED에서_cancel_호출시_예외() {
+            // given
+            Payment payment = createReadyPayment();
+            payment.fail("실패");
+
+            // when & then
+            assertThatThrownBy(() -> payment.cancel())
+                .isInstanceOf(PaymentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("refund()")
+    class RefundTest {
+
+        @Test
+        void SUCCESS에서_REFUNDED로_전이_성공() {
+            // given
+            Payment payment = createReadyPayment();
+            payment.approve("paymentKey-123");
+
+            // when
+            payment.refund();
+
+            // then
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+        }
+
+        @Test
+        void READY에서_refund_호출시_예외() {
+            // given
+            Payment payment = createReadyPayment();
+
+            // when & then
+            assertThatThrownBy(() -> payment.refund())
+                .isInstanceOf(PaymentException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- OutboxEventProducer에 X-Message-Id 헤더 추가 — Consumer dedup 연동을 위해 Outbox messageId를 Kafka 헤더로 전달
- KafkaConsumerConfig FixedBackOff → ExponentialBackOff(2→4→8초, 3회) 변경
- WalletEventConsumer groupId `payment-wallet-group` → `payment-refund.completed` 수정 (네이밍 규칙 준수)
- WalletEventConsumer에서 X-Message-Id 헤더 기반 messageId 추출로 전환 (레거시 폴백 포함)
- WalletService에 `restoreBalanceWithDedup()` 추가 — restoreBalance + markProcessed를 단일 @Transactional에서 처리
- PaymentStatus.canTransitionTo() / Payment 상태 전이 가드 단위 테스트 추가 (20건)

## Test plan

- [x] PaymentStatusTest 11건 통과 (READY/SUCCESS/종단 상태 전이 규칙 검증)
- [x] PaymentTest 9건 통과 (approve/fail/cancel/refund 가드 검증)
- [x] 메인 소스 컴파일 성공
- [ ] Kafka 관련 변경(X-Message-Id 헤더, ExponentialBackOff, groupId)은 배포 환경에서 검증 필요

## 배포 시 주의사항

- WalletEventConsumer groupId 변경으로 새 consumer group이 생성됨 → offset 리셋 → `AUTO_OFFSET_RESET=earliest`로 처음부터 재소비하지만 `isDuplicate` 체크로 중복 처리 방지됨

close #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)