### PR TITLE
[Payment] Fix : Wallet생성시 하버네이트 세션 오염, Self-call이 프록시를 우회하는 문제

### DIFF
--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -10,6 +10,8 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -17,6 +19,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -66,6 +69,11 @@ public class WalletServiceImpl implements WalletService {
     private final OutboxService outboxService;
     private final CommerceInternalClient commerceInternalClient;
     private final PlatformTransactionManager txManager;
+
+    //this.claimChargeForProcessing() 같은 Self-call이 프록시를 우회하는 문제를 해결하려면 자기 참조 주입(self-injection) 이 필요
+    @Lazy
+    @Autowired
+    private WalletServiceImpl self;
 
     // =====================================================================
     // 충전 시작(결제인증에 필요한 WalletCharge생성-chargeId)
@@ -134,12 +142,14 @@ public class WalletServiceImpl implements WalletService {
     // 비관적 락 구간을 최소화하기 위해 3단계로 트랜잭션 분리:
     // 1) 락 + 선점(PENDING→PROCESSING)  2) PG 호출(락 없음)  3) 결과 반영
     @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)  //클래스 레벨에 @Transactional(readOnly = true)가 붙어 있는 상황에서, confirmCharge 메서드만 트랜잭션 없이 실행하도록 설정.
     public WalletChargeConfirmResponse confirmCharge(UUID userId,
         WalletChargeConfirmRequest request) {
 
         // ── 1단계: 비관적 락으로 상태 선점 (PENDING → PROCESSING) ──
+        // self를 통해 호출 → 프록시 경유 → @Transactional 실제 적용
         UUID chargeId = parseUUID(request.chargeId());
-        claimChargeForProcessing(userId, chargeId, request.amount());
+        self.claimChargeForProcessing(userId, chargeId, request.amount());
 
         // ── 2단계: 락 해제 후 PG 호출 (DB 커넥션 점유 없음) ──
         PgPaymentConfirmResult pgResult;
@@ -149,7 +159,7 @@ public class WalletServiceImpl implements WalletService {
             ));
         } catch (Exception e) {
             log.error("[WalletCharge] PG 승인 실패 — chargeId={}, error={}", chargeId, e.getMessage());
-            failProcessingCharge(chargeId);
+            self.failProcessingCharge(chargeId);
             return WalletChargeConfirmResponse.from(
                 chargeId.toString(), request.amount(),
                 null, "FAILED", null
@@ -157,7 +167,7 @@ public class WalletServiceImpl implements WalletService {
         }
 
         // ── 3단계: 새 트랜잭션에서 결과 반영 ──
-        return completeChargeAfterPg(userId, chargeId, pgResult);
+        return self.completeChargeAfterPg(userId, chargeId, pgResult);
     }
 
     /**

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -15,7 +15,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import com.devticket.payment.common.messaging.KafkaTopics;
 import com.devticket.payment.common.outbox.OutboxService;
@@ -62,6 +65,7 @@ public class WalletServiceImpl implements WalletService {
     private final PgPaymentClient pgPaymentClient;
     private final OutboxService outboxService;
     private final CommerceInternalClient commerceInternalClient;
+    private final PlatformTransactionManager txManager;
 
     // =====================================================================
     // 충전 시작(결제인증에 필요한 WalletCharge생성-chargeId)
@@ -73,7 +77,7 @@ public class WalletServiceImpl implements WalletService {
     public WalletChargeResponse charge(UUID userId, WalletChargeRequest request,
         String idempotencyKey) {
 
-        //멱등성 체크
+        //1차 멱등성 체크 : 이미 Wallet이 존재하는 경우(기존 사용자)
         Optional<WalletCharge> existing =
             walletChargeRepository.findByUserIdAndIdempotencyKey(userId, idempotencyKey);
         if (existing.isPresent()) {
@@ -81,14 +85,30 @@ public class WalletServiceImpl implements WalletService {
         }
 
         //예치금 지갑 조회 — 비관적 락으로 한도 체크 구간 직렬화
-        // 동일 사용자의 동시 충전 요청이 같은 todayTotal을 읽고 모두 한도를 통과하는 오류 수정
+        Optional<Wallet> existingWallet = walletRepository.findByUserIdForUpdate(userId);
         Wallet wallet;
-        try {
+        //Wallet이 존재
+        if (existingWallet.isPresent()) {
+            wallet = existingWallet.get();
+        } else {
+            //wallet이 존재하지 않는 경우 내부에서 새로운 세션으로 wallet생성 진행
+            //지갑중복생성 예외가 발행해도 메인 트랜잭션은 롤백되지 않고 로직을 이어갈수 있음.
+            TransactionTemplate requiresNew = new TransactionTemplate(txManager);
+            requiresNew.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+            try {
+                requiresNew.executeWithoutResult(s -> walletRepository.save(Wallet.create(userId)));
+            } catch (DataIntegrityViolationException ignored) {
+            }
+            //wallet생성시 중복오류가 발생한경우_외부 세션은 살아있으므로 wallet 조회 진행
             wallet = walletRepository.findByUserIdForUpdate(userId)
-                .orElseGet(() -> walletRepository.save(Wallet.create(userId)));
-        } catch (DataIntegrityViolationException e) {
-            wallet = walletRepository.findByUserIdForUpdate(userId)
-                .orElseThrow(() -> e);
+                .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
+        }
+
+        //2차 멱등성 체크 : 기존에 Wallet이 존재하지 않았고 이번에 새롭게 생성한 경우(신규사용자)
+        Optional<WalletCharge> reCheckExisting =
+            walletChargeRepository.findByUserIdAndIdempotencyKey(userId, idempotencyKey);
+        if (reCheckExisting.isPresent()) {
+            return WalletChargeResponse.from(reCheckExisting.get());
         }
 
         //일일 충전 한도 체크
@@ -98,18 +118,13 @@ public class WalletServiceImpl implements WalletService {
             throw new WalletException(WalletErrorCode.DAILY_CHARGE_LIMIT_EXCEEDED);
         }
 
-        //WalletCharge생성(PG결제를 위한 chargeId생성됨)
-        try {
-            WalletCharge walletCharge = WalletCharge.create(
-                wallet.getId(), userId, request.amount(), idempotencyKey);
-            walletChargeRepository.save(walletCharge);
-            return WalletChargeResponse.from(walletCharge);
-        } catch (DataIntegrityViolationException e) {
-            return walletChargeRepository.findByUserIdAndIdempotencyKey(userId, idempotencyKey)
-                .map(WalletChargeResponse::from)
-                .orElseThrow(() -> e);
-        }
+        // WalletCharge 생성
+        WalletCharge walletCharge = WalletCharge.create(
+            wallet.getId(), userId, request.amount(), idempotencyKey);
+        walletChargeRepository.save(walletCharge);
+        return WalletChargeResponse.from(walletCharge);
     }
+
 
     // =====================================================================
     // 충전 승인

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletChargeJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletChargeJpaRepository.java
@@ -21,6 +21,7 @@ public interface WalletChargeJpaRepository extends JpaRepository<WalletCharge, L
     @Query("SELECT COALESCE(SUM(wc.amount), 0) FROM WalletCharge wc "
         + "WHERE wc.userId = :userId "
         + "AND wc.status IN (com.devticket.payment.wallet.domain.enums.WalletChargeStatus.PENDING, "
+        + "com.devticket.payment.wallet.domain.enums.WalletChargeStatus.PROCESSING, "
         + "com.devticket.payment.wallet.domain.enums.WalletChargeStatus.COMPLETED) "
         + "AND wc.createdAt >= :startOfDay")
     int sumTodayChargeAmount(@Param("userId") UUID userId,

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletJpaRepository.java
@@ -20,19 +20,19 @@ public interface WalletJpaRepository extends JpaRepository<Wallet, Long> {
 
     // 충전 (입금)
     //원자적 업데이트는 JPA의 자동 버전 관리를 타지 않음 -> 수동으로 버전을 올려주기.
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Wallet w SET w.balance = w.balance + :amount, w.version = w.version + 1 " +
            "WHERE w.userId = :userId")
     int chargeBalanceAtomic(@Param("userId") UUID userId, @Param("amount") int amount);
 
     // 사용/출금 (차감) - 잔액 검증 포함
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Wallet w SET w.balance = w.balance - :amount, w.version = w.version + 1 " +
            "WHERE w.userId = :userId AND w.balance >= :amount")
     int useBalanceAtomic(@Param("userId") UUID userId, @Param("amount") int amount);
 
     // 환불 (복구)
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Wallet w SET w.balance = w.balance + :amount, w.version = w.version + 1 " +
            "WHERE w.userId = :userId")
     int refundBalanceAtomic(@Param("userId") UUID userId, @Param("amount") int amount);

--- a/payment/src/test/java/com/devticket/payment/integration/WalletChargeConcurrencyIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/integration/WalletChargeConcurrencyIntegrationTest.java
@@ -494,4 +494,91 @@ class WalletChargeConcurrencyIntegrationTest {
 
         executor.shutdown();
     }
+
+    // =========================================================================
+    // 테스트 confirm-2: 기존 유저 — 다른 chargeId들 동시 confirm (여러 기기)
+    //
+    // 시나리오: 기존 Wallet 유저가 5건의 충전 인증을 각기 다른 기기에서 동시에 confirm
+    // 방어: 각 chargeId별 비관적 락 → 서로 독립적 처리
+    // 검증: 5건 모두 COMPLETED + 잔액 = 5 × 충전금액 + WalletTransaction 5건
+    // =========================================================================
+    @Test
+    @DisplayName(" 다른 chargeId로 동시 confirm 5건 시 모두 잔액에 반영된다")
+    void 다른_chargeId_동시_confirm_모두_반영() throws InterruptedException {
+        // given — PENDING 상태 WalletCharge 5건 생성
+        int threadCount = 5;
+        int chargeAmount = 20_000;
+
+        List<String> chargeIds = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            WalletChargeResponse r = walletService.charge(
+                userId, new WalletChargeRequest(chargeAmount), "confirm2-" + i + "-" + UUID.randomUUID()
+            );
+            chargeIds.add(r.chargeId());
+        }
+
+        // PG Mock: 호출마다 고유한 paymentKey 반환
+        Mockito.when(pgPaymentClient.confirm(Mockito.any()))
+            .thenAnswer(inv -> new PgPaymentConfirmResult(
+                "pk_" + UUID.randomUUID(), null, "카드", "DONE", chargeAmount, "2026-04-15T15:00:00"
+            ));
+
+        int beforeBalance = walletRepository.findByUserId(userId).orElseThrow().getBalance();
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+
+        AtomicInteger completedCount = new AtomicInteger(0);
+        AtomicInteger failedCount = new AtomicInteger(0);
+        AtomicInteger errorCount = new AtomicInteger(0);
+
+        // when — 각 스레드가 서로 다른 chargeId를 confirm
+        for (int i = 0; i < threadCount; i++) {
+            final String chargeId = chargeIds.get(i);
+            executor.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    WalletChargeConfirmResponse response = walletService.confirmCharge(
+                        userId,
+                        new WalletChargeConfirmRequest("dummy_pk_" + chargeId, chargeId, chargeAmount)
+                    );
+                    if ("COMPLETED".equals(response.status())) {
+                        completedCount.incrementAndGet();
+                    } else {
+                        failedCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    errorCount.incrementAndGet();
+                    System.out.println("  에러: " + e.getMessage());
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+
+        // then
+        int afterBalance = walletRepository.findByUserId(userId).orElseThrow().getBalance();
+        int increased = afterBalance - beforeBalance;
+
+        System.out.println("========== 기존 유저 다른 chargeId 동시 confirm 테스트 결과 ==========");
+        System.out.println("COMPLETED: " + completedCount.get() + "건");
+        System.out.println("FAILED: " + failedCount.get() + "건");
+        System.out.println("에러: " + errorCount.get() + "건");
+        System.out.println("잔액 변화: " + beforeBalance + " → " + afterBalance + " (+" + increased + "원)");
+
+        assertThat(completedCount.get()).isEqualTo(threadCount);
+        assertThat(errorCount.get()).isEqualTo(0);
+        assertThat(increased).isEqualTo(chargeAmount * threadCount);
+
+        executor.shutdown();
+    }
+
+
 }

--- a/payment/src/test/java/com/devticket/payment/integration/WalletChargeConcurrencyIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/integration/WalletChargeConcurrencyIntegrationTest.java
@@ -200,7 +200,217 @@ class WalletChargeConcurrencyIntegrationTest {
     }
 
     // =========================================================================
-    // 테스트 3: confirm 중복 — 같은 chargeId로 동시 confirm 10건
+    // 테스트 3: 신규 유저 — 지갑 미생성 상태에서 다기기 동시 충전 (각기 다른 멱등성 키)
+    //
+    // 시나리오: 신규 사용자가 여러 기기에서 동시에 첫 충전 시도
+    // 공격: Wallet이 없는 상태에서 N개 스레드가 동시에 charge() 진입
+    //        → 모두 findByUserIdForUpdate 빈값 → 모두 Wallet INSERT 시도 → DIVE 발생 가능
+    // 방어: REQUIRES_NEW로 Wallet INSERT 격리 → 외부 세션 유지 → 재조회로 복구
+    // 검증: Wallet 1개만 생성 + 에러 없이 N건 모두 성공 + WalletCharge N건 생성
+    // =========================================================================
+    @Test
+    @DisplayName("신규 유저: 지갑 없는 상태에서 다기기 동시 충전(다른 멱등성 키) — Wallet 1개, WalletCharge N건 생성")
+    void 신규유저_지갑미생성_다기기_동시충전_각기다른멱등성키() throws InterruptedException {
+        // given — 지갑이 없는 신규 유저 (setUp의 walletRepository.save 적용 안 됨)
+        UUID newUserId = UUID.randomUUID();
+        int threadCount = 5;
+        int amount = 10_000;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+
+        List<String> chargeIds = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when — 각 스레드는 서로 다른 멱등성 키 사용 (다기기 시나리오)
+        for (int i = 0; i < threadCount; i++) {
+            String uniqueKey = "new-user-device-" + i + "-" + UUID.randomUUID();
+            executor.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    WalletChargeResponse response = walletService.charge(
+                        newUserId, new WalletChargeRequest(amount), uniqueKey);
+                    chargeIds.add(response.chargeId());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    System.out.println("  에러: " + e.getMessage());
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+
+        // then
+        long walletCount = walletRepository.findByUserId(newUserId).stream().count();
+        long uniqueChargeIds = chargeIds.stream().distinct().count();
+        int todayTotal = walletChargeRepository.sumTodayChargeAmount(
+            newUserId, LocalDate.now().atStartOfDay()
+        );
+
+        System.out.println("========== 신규 유저 다기기 동시 충전 테스트 결과 ==========");
+        System.out.println("성공 응답: " + successCount.get() + " / " + threadCount);
+        System.out.println("실패 응답: " + failCount.get());
+        System.out.println("생성된 Wallet 수: " + walletCount);
+        System.out.println("고유 chargeId 수: " + uniqueChargeIds);
+        System.out.println("DB 오늘 충전 총액: " + todayTotal + "원");
+
+        assertThat(failCount.get()).isEqualTo(0);
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(walletCount).isEqualTo(1);                           // Wallet은 1개만 생성
+        assertThat(uniqueChargeIds).isEqualTo(threadCount);             // 각기 다른 chargeId
+        assertThat(todayTotal).isEqualTo(amount * threadCount);         // 전체 충전액 합산
+
+        executor.shutdown();
+    }
+
+    // =========================================================================
+    // 테스트 5: 기존 유저 — 동일 멱등성 키로 동시 100건
+    //
+    // 공격: 기존 Wallet이 있는 사용자가 네트워크 재전송 등으로 같은 키로 100건 동시 요청
+    // 방어: 1차 멱등성 체크 + SELECT FOR UPDATE 후 2차 멱등성 체크 + UNIQUE 제약
+    // 검증: 모든 응답의 chargeId 동일 + DB 충전 총액 = 1건 금액 + 성공 100건
+    // =========================================================================
+    @Test
+    @DisplayName("기존 유저: 동일 멱등성 키로 동시 100건 요청 시 WalletCharge는 1건만 생성된다")
+    void 기존유저_동일_멱등성키_동시100건_1건만_생성() throws InterruptedException {
+        // given
+        int threadCount = 100;
+        int amount = 10_000;
+        String idempotencyKey = "idem-existing-" + UUID.randomUUID();
+        WalletChargeRequest request = new WalletChargeRequest(amount);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+
+        List<String> chargeIds = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    WalletChargeResponse response = walletService.charge(userId, request, idempotencyKey);
+                    chargeIds.add(response.chargeId());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    System.out.println("  에러: " + e.getMessage());
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+
+        // then
+        long uniqueChargeIds = chargeIds.stream().distinct().count();
+        int todayTotal = walletChargeRepository.sumTodayChargeAmount(
+            userId, LocalDate.now().atStartOfDay()
+        );
+        boolean chargeExists = walletChargeRepository
+            .findByUserIdAndIdempotencyKey(userId, idempotencyKey)
+            .isPresent();
+
+        System.out.println("========== 기존 유저 동일 멱등성 키 100건 테스트 결과 ==========");
+        System.out.println("성공 응답: " + successCount.get() + " / " + threadCount);
+        System.out.println("실패 응답: " + failCount.get());
+        System.out.println("고유 chargeId 수: " + uniqueChargeIds);
+        System.out.println("DB 오늘 충전 총액: " + todayTotal + "원");
+
+        assertThat(uniqueChargeIds).isEqualTo(1);
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(todayTotal).isEqualTo(amount);
+        assertThat(chargeExists).isTrue();
+
+        executor.shutdown();
+    }
+
+    // =========================================================================
+    // 테스트 6: 기존 유저 — 다기기(다른 멱등성 키)로 동시 100건
+    //
+    // 시나리오: 기존 Wallet이 있는 사용자가 100개 기기에서 동시에 충전 요청
+    // 방어: SELECT FOR UPDATE 비관적 락으로 한도 체크 직렬화
+    // 검증: 에러 없이 100건 전부 성공 + DB 충전 총액 = 100 × 5,000원
+    // =========================================================================
+    @Test
+    @DisplayName("기존 유저: 다기기(다른 멱등성 키)로 동시 100건 요청 시 모두 성공하고 총액이 정확하다")
+    void 기존유저_다기기_동시100건_모두_성공() throws InterruptedException {
+        // given — 100건 × 5,000원 = 500,000원 (일일 한도 100만원 이내)
+        int threadCount = 100;
+        int amountPerRequest = 5_000;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+
+        List<String> chargeIds = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when — 각 스레드는 서로 다른 멱등성 키 사용
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    String uniqueKey = "multi-device-" + UUID.randomUUID();
+                    WalletChargeResponse response = walletService.charge(
+                        userId, new WalletChargeRequest(amountPerRequest), uniqueKey);
+                    chargeIds.add(response.chargeId());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    System.out.println("  에러: " + e.getMessage());
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+
+        // then
+        long uniqueChargeIds = chargeIds.stream().distinct().count();
+        int todayTotal = walletChargeRepository.sumTodayChargeAmount(
+            userId, LocalDate.now().atStartOfDay()
+        );
+
+        System.out.println("========== 기존 유저 다기기 동시 100건 테스트 결과 ==========");
+        System.out.println("성공 응답: " + successCount.get() + " / " + threadCount);
+        System.out.println("실패 응답: " + failCount.get());
+        System.out.println("고유 chargeId 수: " + uniqueChargeIds);
+        System.out.println("DB 오늘 충전 총액: " + todayTotal + "원");
+
+        assertThat(failCount.get()).isEqualTo(0);
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(uniqueChargeIds).isEqualTo(threadCount);          // 각기 다른 chargeId
+        assertThat(todayTotal).isEqualTo(amountPerRequest * threadCount); // 500,000원
+
+        executor.shutdown();
+    }
+
+    // =========================================================================
+    // 테스트 4: confirm 중복 — 같은 chargeId로 동시 confirm 10건
     //
     // 공격: 결제 성공 콜백이 네트워크 이슈로 중복 도달
     // 방어: findByChargeIdForUpdate 비관적 락 → 첫 요청이 COMPLETED로 변경 → 나머지 isPending() false

--- a/payment/src/test/java/com/devticket/payment/integration/WalletChargeConcurrencyIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/integration/WalletChargeConcurrencyIntegrationTest.java
@@ -1,0 +1,287 @@
+package com.devticket.payment.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
+import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
+import com.devticket.payment.wallet.application.service.WalletService;
+import com.devticket.payment.wallet.domain.model.Wallet;
+import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
+import com.devticket.payment.wallet.domain.repository.WalletRepository;
+import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
+import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmRequest;
+import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmResponse;
+import com.devticket.payment.wallet.presentation.dto.WalletChargeRequest;
+import com.devticket.payment.wallet.presentation.dto.WalletChargeResponse;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * 예치금 충전 멱등성 & 동시성 통합 테스트
+ *
+ * 실제 DB(PostgreSQL) 비관적 락 + UNIQUE 제약 + atomic update 검증.
+ * PgPaymentClient만 Mock (외부 PG 호출 차단).
+ */
+@SpringBootTest
+class WalletChargeConcurrencyIntegrationTest {
+
+    @Autowired
+    private WalletService walletService;
+
+    @Autowired
+    private WalletRepository walletRepository;
+
+    @Autowired
+    private WalletChargeRepository walletChargeRepository;
+
+    @Autowired
+    private WalletTransactionRepository walletTransactionRepository;
+
+    @MockitoBean
+    private PgPaymentClient pgPaymentClient;
+
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        walletRepository.save(Wallet.create(userId));
+    }
+
+    // =========================================================================
+    // 테스트 1: 멱등성 — 같은 idempotencyKey로 동시 10건
+    //
+    // 공격: 프론트 더블클릭 / 네트워크 재전송 시뮬레이션
+    // 방어: findByUserIdAndIdempotencyKey + UNIQUE(user_id, idempotency_key) + DataIntegrityViolationException catch
+    // 검증: 모든 응답의 chargeId 동일 + DB 충전 총액 = 1건 금액
+    // =========================================================================
+    @Test
+    @DisplayName("같은 멱등성 키로 동시 10건 요청 시 WalletCharge는 1건만 생성된다")
+    void 동일_멱등성키_동시요청_1건만_생성() throws InterruptedException {
+        // given
+        int threadCount = 10;
+        int amount = 10_000;
+        String idempotencyKey = "idem-" + UUID.randomUUID();
+        WalletChargeRequest request = new WalletChargeRequest(amount);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+
+        List<String> chargeIds = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    WalletChargeResponse response = walletService.charge(userId, request, idempotencyKey);
+                    chargeIds.add(response.chargeId());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    System.out.println("  에러: " + e.getMessage());
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+
+        // then
+        long uniqueChargeIds = chargeIds.stream().distinct().count();
+        int todayTotal = walletChargeRepository.sumTodayChargeAmount(
+            userId, LocalDate.now().atStartOfDay()
+        );
+        boolean chargeExists = walletChargeRepository
+            .findByUserIdAndIdempotencyKey(userId, idempotencyKey)
+            .isPresent();
+
+        System.out.println("========== 멱등성 테스트 결과 ==========");
+        System.out.println("성공 응답: " + successCount.get() + " / " + threadCount);
+        System.out.println("실패 응답: " + failCount.get());
+        System.out.println("고유 chargeId 수: " + uniqueChargeIds);
+        System.out.println("DB 오늘 충전 총액: " + todayTotal + "원");
+
+        assertThat(uniqueChargeIds).isEqualTo(1);
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(todayTotal).isEqualTo(amount);
+        assertThat(chargeExists).isTrue();
+
+        executor.shutdown();
+    }
+
+    // =========================================================================
+    // 테스트 2: 일일 한도 동시성 — 5만원 × 30건 (한도 100만원)
+    //
+    // 공격: 30개 스레드가 동시에 charge() 진입 → 모두 todayTotal=0 읽으면 한도 뚫림
+    // 방어: findByUserIdForUpdate 비관적 락 → 한 번에 1개만 한도 체크 통과
+    // 검증: DB 충전 총액 = 정확히 1,000,000원
+    // =========================================================================
+    @Test
+    @DisplayName("서로 다른 충전 요청 동시 30건 시 일일 한도(100만원)를 정확히 지킨다")
+    void 동시_충전요청_일일한도_정확히_100만원() throws InterruptedException {
+        // given
+        int threadCount = 30;
+        int amountPerRequest = 50_000;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger limitExceededCount = new AtomicInteger(0);
+        AtomicInteger otherErrorCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    String uniqueKey = "limit-" + UUID.randomUUID();
+                    walletService.charge(userId, new WalletChargeRequest(amountPerRequest), uniqueKey);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    if (e.getMessage() != null && e.getMessage().contains("한도")) {
+                        limitExceededCount.incrementAndGet();
+                    } else {
+                        otherErrorCount.incrementAndGet();
+                        System.out.println("  기타 에러: " + e.getMessage());
+                    }
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+
+        // then
+        int todayTotal = walletChargeRepository.sumTodayChargeAmount(
+            userId, LocalDate.now().atStartOfDay()
+        );
+
+        System.out.println("========== 일일 한도 동시성 테스트 결과 ==========");
+        System.out.println("성공: " + successCount.get() + "건");
+        System.out.println("한도 초과 거부: " + limitExceededCount.get() + "건");
+        System.out.println("기타 에러: " + otherErrorCount.get() + "건");
+        System.out.println("DB 오늘 충전 총액: " + todayTotal + "원");
+
+        assertThat(todayTotal).isEqualTo(1_000_000);
+        assertThat(successCount.get()).isEqualTo(20);
+        assertThat(limitExceededCount.get()).isEqualTo(10);
+
+        executor.shutdown();
+    }
+
+    // =========================================================================
+    // 테스트 3: confirm 중복 — 같은 chargeId로 동시 confirm 10건
+    //
+    // 공격: 결제 성공 콜백이 네트워크 이슈로 중복 도달
+    // 방어: findByChargeIdForUpdate 비관적 락 → 첫 요청이 COMPLETED로 변경 → 나머지 isPending() false
+    //       + chargeBalanceAtomic + existsByTransactionKey
+    // 검증: 잔액 1회분만 증가 + WalletTransaction 1건
+    // =========================================================================
+    @Test
+    @DisplayName("같은 chargeId로 동시 confirm 10건 시 잔액은 1회분만 증가한다")
+    void 동시_confirm_요청_1건만_반영() throws InterruptedException {
+        // given — PENDING 상태 WalletCharge 생성
+        String idempotencyKey = "confirm-test-" + UUID.randomUUID();
+        int chargeAmount = 30_000;
+        WalletChargeResponse chargeResponse = walletService.charge(
+            userId, new WalletChargeRequest(chargeAmount), idempotencyKey
+        );
+        String chargeId = chargeResponse.chargeId();
+
+        // PG Mock: confirm 항상 성공
+        String fakePaymentKey = "test_pk_" + UUID.randomUUID();
+        Mockito.when(pgPaymentClient.confirm(Mockito.any()))
+            .thenReturn(new PgPaymentConfirmResult(
+                fakePaymentKey, chargeId, "카드", "DONE", chargeAmount, "2026-04-15T15:00:00"
+            ));
+
+        // 충전 전 잔액
+        int beforeBalance = walletRepository.findByUserId(userId).orElseThrow().getBalance();
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+
+        AtomicInteger completedCount = new AtomicInteger(0);
+        AtomicInteger notPendingCount = new AtomicInteger(0);
+        AtomicInteger failedCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    WalletChargeConfirmResponse response = walletService.confirmCharge(
+                        userId,
+                        new WalletChargeConfirmRequest(fakePaymentKey, chargeId, chargeAmount)
+                    );
+                    if ("COMPLETED".equals(response.status())) {
+                        completedCount.incrementAndGet();
+                    } else if ("FAILED".equals(response.status())) {
+                        failedCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    notPendingCount.incrementAndGet();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+
+        // then
+        int afterBalance = walletRepository.findByUserId(userId).orElseThrow().getBalance();
+        int increased = afterBalance - beforeBalance;
+        boolean txExists = walletTransactionRepository.existsByTransactionKey("CHARGE:" + fakePaymentKey);
+
+        System.out.println("========== confirm 동시성 테스트 결과 ==========");
+        System.out.println("COMPLETED 응답: " + completedCount.get() + "건");
+        System.out.println("NOT_PENDING 거부: " + notPendingCount.get() + "건");
+        System.out.println("FAILED 응답: " + failedCount.get() + "건");
+        System.out.println("잔액 변화: " + beforeBalance + " → " + afterBalance + " (+" + increased + "원)");
+        System.out.println("WalletTransaction 존재: " + txExists);
+
+        assertThat(increased).isEqualTo(chargeAmount);
+        assertThat(txExists).isTrue();
+        assertThat(completedCount.get()).isEqualTo(1);
+        assertThat(notPendingCount.get()).isEqualTo(threadCount - 1);
+
+        executor.shutdown();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #403

## 작업 내용
- WalletServiceImpl - charge메서드
신규사용자의 예치금 충전 동시요청시_Wallet생성과정에서 DataIntegrityViolationException에러 발생으로 세션 오염된 상태로 findByUserIdForUpdate조회시 미작동 -> Wallet 락 없이 바로 WalletCharge 저장하게되어 DB UNIQUE 제약에서 충돌발생
     - TransactionTemplate을 사용해 트랜잭션을 분리작업
   - findByUserIdForUpdate를 재호출해 반드시 락을 획득한 상태에서 2차 멱등성 체크로 진입하도록 수정하여 이 시점부터 직렬화가 보장됨
   - 2차 멱등성검사 추가

- WalletServiceImpl - confirmCharge메서드
claimChargeForProcessing() 같은 Self-call이 프록시 우회로 트랜잭션이 미적용되는 오류.
트랜잭션 분리를 의도했으나 메서드에 클래스레벨에 적용된 트랜잭션이 적용되고있는 오류.
    -  메서드레벨에 @Transactional(propagation = Propagation.NOT_SUPPORTED)적용
    -  자기참조주입 : claimChargeForProcessing() -> self.claimChargeForProcessing()

- WalletCharge.status 상태값 PROCESSING추가건
   -  예치금 충전 일일한도검증시에 수정반영
   - 복구스케줄러 : 기존 PENDING상태만 처리 + PROCESSING처리 추가 

- WalletJpaRepository : atomicUpdate메서드
  -  flushAutomatically 옵션 추가 

## 변경 사항
- WalletServiceImpl  : charge메서드 
- WalletServiceImpl :  confirmCharge메서드
- WalletJpaRepository : atomicUpdate메서드

## 테스트
- [ ] 단위 테스트 통과
- [x] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항