### PR TITLE
[AI] feat: 사용자 벡터 기반 이벤트 추천 API 구현

### DIFF
--- a/ai/src/main/java/org/example/ai/application/service/RecommendationService.java
+++ b/ai/src/main/java/org/example/ai/application/service/RecommendationService.java
@@ -1,0 +1,217 @@
+package org.example.ai.application.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.ai.domain.model.UserVector;
+import org.example.ai.domain.repository.UserVectorRepository;
+import org.example.ai.presentation.dto.req.RecommendationRequest;
+import org.example.ai.presentation.dto.res.RecommendationResponse;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RecommendationService {
+
+    private final UserVectorRepository userVectorRepository;
+    private final ElasticsearchClient elasticsearchClient;
+
+
+
+
+
+    public RecommendationResponse recommendByUserVector(RecommendationRequest request){
+
+        String userId = request.userId();
+        UserVector userVector = userVectorRepository.findById(userId)
+            .orElse(null);
+
+        if(userVector == null){
+            log.warn("[Recommendation] UserVector 없음 - userId: {}", userId);
+            return new RecommendationResponse(userId, List.of());
+        }
+
+        float[] combinedVector = combineVectorByWeight(
+            getOrEmpty(userVector.getPreferenceVector()),
+            getOrEmpty(userVector.getCartVector()),
+            getOrEmpty(userVector.getRecentVector())
+        );
+         float[] normalizedVector = normalize(combinedVector);
+
+        List<Map<String, Object>> candidates = searchKnn(normalizedVector);
+
+        List<ScoredEvent> listedScore = reRank(candidates, userVector);
+
+        List<String> topEventIds = listedScore.stream()
+            .sorted(Comparator.comparingDouble(ScoredEvent::score).reversed())
+            .limit(5)
+            .map(ScoredEvent::eventId)
+            .toList();
+
+        return new RecommendationResponse(userId, topEventIds);
+        }
+
+
+
+
+
+
+    // =============== 하위 함수 모음 =============== //
+    // 1. 가중치 기반 벡터합
+    private float[] combineVectorByWeight(float[] preferenceVector, float[] cartVector, float[] recentVector){
+        float[] combinedVector = new float[preferenceVector.length];
+
+        for(int i = 0; i < preferenceVector.length; i++){
+            combinedVector[i] =
+                preferenceVector[i] * 0.5f + cartVector[i] * 0.3f + recentVector[i] * 0.2f;
+        }
+        return combinedVector;
+    }
+
+    // 2. vector -> normalize
+    private float[] normalize(float[] combinedVector){
+
+        float sum = 0f;
+        float[] normalizedVector = new float[combinedVector.length];
+
+        // 크기 계산
+        for(int i = 0; i < combinedVector.length; i++){
+            sum += combinedVector[i] * combinedVector[i];
+        }
+
+        float norm = (float)Math.sqrt(sum);
+
+        // 0 나누기 방지
+        if(norm == 0f) return combinedVector;
+
+        // 각 요소를 크기로 나누기
+        for(int i = 0; i < combinedVector.length; i++){
+            normalizedVector[i] = combinedVector[i] / norm;
+        }
+
+        return normalizedVector;
+    }
+
+    // 3. normalize된 벡터 -> kNN 검색
+    public List<Map<String, Object>> searchKnn(float[] normalizedVector){
+
+        try{
+            List<Float> queryList = new ArrayList<>();
+            // 배열 -> List
+            for(float v :  normalizedVector){
+                queryList.add(v);
+            }
+
+            // kNN 쿼리문
+            SearchResponse<Map> response = elasticsearchClient.search(s -> s
+                    .index("event-index")
+                    .knn(k -> k
+                        .field("embedding")
+                        .queryVector(queryList)
+                        .numCandidates(100)
+                        .k(30)
+                        .filter(f -> f
+                            .term(t -> t
+                                .field("status")
+                                .value("ON_SALE"))))
+                    .source(src -> src
+                        .filter(f -> f
+                            .includes("eventId", "embedding")
+                        )
+                    ),
+                Map.class);
+
+            List<Map<String, Object>> result = new ArrayList<>();
+            for(Hit<Map> hit : response.hits().hits()){
+                if (hit.source() != null) {
+                    result.add(hit.source());
+                }
+            }
+            return result;
+        }
+        catch(Exception e){
+            log.error("[Recommendation] kNN 검색 실패", e);
+            return List.of();
+        }
+    }
+    // ================================================================ //
+    // ============== kNN 30 개 재정렬 및 cosine 유사도 연산 ============== //
+    private List<ScoredEvent> reRank(
+        List<Map<String, Object>> candidates,
+        UserVector userVector
+        ){
+        List<ScoredEvent> scoreList = new ArrayList<>();
+
+        for(Map<String, Object> candidate : candidates){
+            String eventId = candidate.get("eventId").toString();
+
+            List<Double> embeddingRaw = (List<Double>) candidate.get("embedding");
+            if (embeddingRaw == null) continue;
+
+            // ES가 Embedding을 double로 저장 -> 다시 float화 하기
+            float[] eventEmbedding = new float[embeddingRaw.size()];
+            for (int j = 0; j < embeddingRaw.size(); j++) {
+                eventEmbedding[j] = embeddingRaw.get(j).floatValue();
+            }
+
+            double score = sim(getOrEmpty(userVector.getPreferenceVector()), eventEmbedding) * 0.45
+                + sim(getOrEmpty(userVector.getCartVector()), eventEmbedding) * 0.25
+                + sim(getOrEmpty(userVector.getRecentVector()), eventEmbedding) * 0.25
+                - sim(getOrEmpty(userVector.getNegativeVector()), eventEmbedding) * 0.15;
+
+            scoreList.add(new ScoredEvent(eventId, score));
+
+        }
+        return scoreList;
+    }
+
+    private float[] getOrEmpty(float[] vector) {
+        return vector != null ? vector : new float[1536];
+    }
+
+    // consine 유사도 연산 메서드
+    private double sim(float[] tendencyVector, float[] eventVector){
+
+        // 내적
+        double dot = 0;
+        // tendencyVector 벡터 크기
+        double tvMag = 0;
+        //eventVector 벡터 크기
+        double evMag = 0;
+
+
+        // 내적, 경향성 및 이벤트 벡터 크기 연산
+        for(int i = 0; i < tendencyVector.length; i++){
+            dot += tendencyVector[i] * eventVector[i];
+            tvMag += tendencyVector[i] * tendencyVector[i];
+            evMag += eventVector[i] * eventVector[i];
+        }
+
+        if(tvMag == 0 || evMag == 0){
+            return 0;
+        }
+
+        //내적에서 크기 제거
+        return dot / (Math.sqrt(tvMag) * Math.sqrt(evMag));
+
+    }
+
+    record ScoredEvent(String eventId, double score) {
+
+    }
+    // ================================================================ //
+    // ================================================================ //
+
+
+
+}

--- a/ai/src/main/java/org/example/ai/domain/model/UserVector.java
+++ b/ai/src/main/java/org/example/ai/domain/model/UserVector.java
@@ -1,14 +1,17 @@
 package org.example.ai.domain.model;
 
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
-
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 @Builder
 @Document(indexName = "user-index", createIndex = false)

--- a/ai/src/main/java/org/example/ai/infrastructure/persistence/repository/UserVectorRepositoryImpl.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/persistence/repository/UserVectorRepositoryImpl.java
@@ -1,23 +1,51 @@
 package org.example.ai.infrastructure.persistence.repository;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.ai.domain.model.UserVector;
 import org.example.ai.domain.repository.UserVectorRepository;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class UserVectorRepositoryImpl implements UserVectorRepository {
 
 
+    private final ElasticsearchClient elasticsearchClient;
     private final UserVectorESRepository userVectorESRepository;
 
     @Override
     public Optional<UserVector> findById(String userId) {
-        return userVectorESRepository.findById(userId);
+        try{
+            var response = elasticsearchClient.get(g -> g
+                .index("user-index")
+                .id(userId)
+                .sourceIncludes(
+                    "userId",
+                    "preferenceVector", "preferenceWeightSum",
+                    "recentVector", "recentWeightSum",
+                    "cartVector", "cartWeightSum",
+                    "negativeVector", "negativeWeightSum",
+                    "updatedAt"
+                ),
+                UserVector.class
+            );
+
+            if(!response.found()){
+                return Optional.empty();
+            }
+            return Optional.ofNullable(response.source());
+        }
+        catch (Exception e){
+            log.error("[UserVector] findById 실패 - userId: {}", userId, e);
+            return Optional.empty();
+        }
+
     }
 
     @Override

--- a/ai/src/main/java/org/example/ai/presentation/controller/KafkaTestController.java
+++ b/ai/src/main/java/org/example/ai/presentation/controller/KafkaTestController.java
@@ -1,4 +1,4 @@
-package org.example.ai.presentation.dto.controller;
+package org.example.ai.presentation.controller;
 
 import lombok.RequiredArgsConstructor;
 

--- a/ai/src/main/java/org/example/ai/presentation/controller/RecommendationController.java
+++ b/ai/src/main/java/org/example/ai/presentation/controller/RecommendationController.java
@@ -1,5 +1,6 @@
 package org.example.ai.presentation.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.ai.application.service.RecommendationService;
 import org.example.ai.presentation.dto.req.RecommendationRequest;
@@ -16,7 +17,7 @@ public class RecommendationController {
     private final RecommendationService recommendationService;
 
     @PostMapping("/recommendation")
-    public RecommendationResponse recommend(@RequestBody RecommendationRequest request){
+    public RecommendationResponse recommend(@Valid @RequestBody RecommendationRequest request){
         return recommendationService.recommendByUserVector(request);
     }
 }

--- a/ai/src/main/java/org/example/ai/presentation/controller/RecommendationController.java
+++ b/ai/src/main/java/org/example/ai/presentation/controller/RecommendationController.java
@@ -1,0 +1,22 @@
+package org.example.ai.presentation.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.ai.application.service.RecommendationService;
+import org.example.ai.presentation.dto.req.RecommendationRequest;
+import org.example.ai.presentation.dto.res.RecommendationResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("internal/ai")
+public class RecommendationController {
+    private final RecommendationService recommendationService;
+
+    @PostMapping("/recommendation")
+    public RecommendationResponse recommend(@RequestBody RecommendationRequest request){
+        return recommendationService.recommendByUserVector(request);
+    }
+}

--- a/ai/src/main/java/org/example/ai/presentation/dto/req/RecommendationRequest.java
+++ b/ai/src/main/java/org/example/ai/presentation/dto/req/RecommendationRequest.java
@@ -1,0 +1,10 @@
+package org.example.ai.presentation.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RecommendationRequest(
+    @NotBlank
+    String userId
+) {
+
+}

--- a/ai/src/main/java/org/example/ai/presentation/dto/res/RecommendationResponse.java
+++ b/ai/src/main/java/org/example/ai/presentation/dto/res/RecommendationResponse.java
@@ -1,0 +1,10 @@
+package org.example.ai.presentation.dto.res;
+
+import java.util.List;
+
+public record RecommendationResponse(
+    String userId,
+    List<String> eventIdList
+) {
+
+}


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- 사용자 벡터 기반 이벤트 추천 API 구현
- Elasticsearch kNN 기반 후보 이벤트 검색
- 사용자 preference/cart/recent 벡터 가중합 + normalize 적용
- cosine 유사도 기반 rerank 로직 구현
- 추천 결과 상위 5개 이벤트 반환

## 변경 사항
- RecommendationController
  - `/internal/ai/recommendation` 내부 API 추가
- RecommendationService
  - 벡터 결합 및 정규화 로직 구현
  - Elasticsearch kNN 검색 로직 구현
  - cosine 유사도 기반 rerank 로직 추가
- UserVectorRepositoryImpl
  - Elasticsearch 기반 user-index 조회 로직 구현
- event-index / user-index 연동 구조 구성

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인

### 테스트 내용
- test-user-1 / test-user-2 추천 결과 비교
- 사용자별 추천 결과가 다르게 반환되는 것 확인
- event-index 데이터 확장 후 정상 추천 동작 확인
- 존재하지 않는 userId 요청 시 빈 리스트 반환 확인

## 스크린샷
- Swagger 추천 API 실행 결과 확인 (user별 다른 추천 리스트 반환)

## 참고 사항
- 현재 user vector 및 event embedding은 랜덤 데이터 기반 테스트 상태
- 실제 추천 품질 개선을 위해 Kafka 로그 기반 vector 업데이트 및 embedding 개선 필요
