### PR TITLE
[Payment] fix: readyPayment메서드_동일 orderId의 Payment가 이미 존재하면 기존 레코드 재사용

### DIFF
--- a/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
@@ -61,9 +61,9 @@ public class PaymentServiceImpl implements PaymentService {
         validateOrderOwner(userId, order.userId());
         validateOrderPayable(order);
 
-        // 중복 요청: 동일 orderId의 Payment가 이미 존재하면 기존 레코드 재사용
+        // 중복 요청: 동일 orderId + 동일 결제수단의 Payment가 이미 존재하면 기존 레코드 재사용
         Optional<Payment> existing = paymentRepository.findByOrderId(order.id());
-        if (existing.isPresent()) {
+        if (existing.isPresent() && existing.get().getPaymentMethod() == request.paymentMethod()) {
             return PaymentReadyResponse.from(
                 existing.get(), request.orderId(), order.orderNumber(), order.status());
         }

--- a/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
@@ -59,6 +60,13 @@ public class PaymentServiceImpl implements PaymentService {
         InternalOrderInfoResponse order = commerceInternalClient.getOrderInfo(request.orderId());
         validateOrderOwner(userId, order.userId());
         validateOrderPayable(order);
+
+        // 중복 요청: 동일 orderId의 Payment가 이미 존재하면 기존 레코드 재사용
+        Optional<Payment> existing = paymentRepository.findByOrderId(order.id());
+        if (existing.isPresent()) {
+            return PaymentReadyResponse.from(
+                existing.get(), request.orderId(), order.orderNumber(), order.status());
+        }
 
         //Payment 생성
         Payment payment = Payment.create(


### PR DESCRIPTION
## 관련 이슈
- close #395

## 작업 내용
- readyPayment메서드_동일 orderId의 Payment가 이미 존재하면 기존 레코드 재사용 처리

## 변경 사항
- PayemntServiceImpl - readyPayment메서드

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항