### PR TITLE
[Commerce] feat : 종료된 이벤트의 정산용 집계데이터 전송 api

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
@@ -150,11 +150,11 @@ public class TicketService implements TicketUsecase {
     }
 
     /**
-     * 호출 Settlement -> Commerce ㅎgig*
+     * 호출 Settlement -> Commerce
      */
     @Override
     public InternalTicketSettlementDataResponse getSettlementData(List<UUID> eventIds) {
-        if (eventIds.isEmpty()) {
+        if (eventIds == null || eventIds.isEmpty()) {
             return new InternalTicketSettlementDataResponse(List.of());
         }
 
@@ -183,9 +183,9 @@ public class TicketService implements TicketUsecase {
                 UUID orderItemId = entry.getKey().getValue();
                 List<Ticket> group = entry.getValue();
 
-                int price = priceByOrderItemId.getOrDefault(orderItemId, 0);
-                int salesAmount = price * group.size();
-                int refundAmount = price * (int) group.stream()
+                Long price = Long.valueOf(priceByOrderItemId.getOrDefault(orderItemId, 0));
+                Long salesAmount = price * group.size();
+                Long refundAmount = price * (int) group.stream()
                     .filter(t -> t.getStatus() == TicketStatus.REFUNDED)
                     .count();
 

--- a/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
@@ -8,6 +8,7 @@ import com.devticket.commerce.order.domain.model.OrderItem;
 import com.devticket.commerce.order.domain.repository.OrderItemRepository;
 import com.devticket.commerce.order.domain.repository.OrderRepository;
 import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
+import com.devticket.commerce.ticket.domain.enums.TicketStatus;
 import com.devticket.commerce.ticket.domain.exception.TicketErrorCode;
 import com.devticket.commerce.ticket.domain.model.Ticket;
 import com.devticket.commerce.ticket.domain.repository.TicketRepository;
@@ -19,11 +20,14 @@ import com.devticket.commerce.ticket.infrastructure.external.client.dto.Internal
 import com.devticket.commerce.ticket.presentation.dto.req.SellerEventParticipantListRequest;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketListRequest;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
+import com.devticket.commerce.ticket.presentation.dto.res.InternalTicketSettlementDataResponse;
+import com.devticket.commerce.ticket.presentation.dto.res.InternalTicketSettlementItemResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.SellerEventParticipantListResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.SellerEventParticipantResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketDetailResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketListResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketResponse;
+import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -143,6 +147,53 @@ public class TicketService implements TicketUsecase {
 
         //응답데이터 구성
         return TicketResponse.of(request.orderId(), savedTickets);
+    }
+
+    /**
+     * 호출 Settlement -> Commerce ㅎgig*
+     */
+    @Override
+    public InternalTicketSettlementDataResponse getSettlementData(List<UUID> eventIds) {
+        if (eventIds.isEmpty()) {
+            return new InternalTicketSettlementDataResponse(List.of());
+        }
+
+        // eventIds로 티켓 전체 조회
+        List<Ticket> tickets = ticketRepository.findAllByEventIdIn(eventIds);
+        if (tickets.isEmpty()) {
+            return new InternalTicketSettlementDataResponse(List.of());
+        }
+
+        // eventIds로 OrderItem 조회 → orderItemId별 단가 맵
+        Map<UUID, Integer> priceByOrderItemId = orderItemRepository.findSettlementItems(eventIds).stream()
+            .collect(Collectors.toMap(
+                OrderItem::getOrderItemId,
+                OrderItem::getPrice,
+                (existing, duplicate) -> existing
+            ));
+
+        // (eventId, orderItemId) 기준으로 티켓 그룹핑 후 정산 집계
+        List<InternalTicketSettlementItemResponse> items = tickets.stream()
+            .collect(Collectors.groupingBy(
+                t -> new AbstractMap.SimpleEntry<>(t.getEventId(), t.getOrderItemId())
+            ))
+            .entrySet().stream()
+            .map(entry -> {
+                UUID eventId = entry.getKey().getKey();
+                UUID orderItemId = entry.getKey().getValue();
+                List<Ticket> group = entry.getValue();
+
+                int price = priceByOrderItemId.getOrDefault(orderItemId, 0);
+                int salesAmount = price * group.size();
+                int refundAmount = price * (int) group.stream()
+                    .filter(t -> t.getStatus() == TicketStatus.REFUNDED)
+                    .count();
+
+                return new InternalTicketSettlementItemResponse(eventId, orderItemId, salesAmount, refundAmount);
+            })
+            .toList();
+
+        return new InternalTicketSettlementDataResponse(items);
     }
 
     public SellerEventParticipantListResponse getParticipantList(UUID userId, UUID eventId,

--- a/commerce/src/main/java/com/devticket/commerce/ticket/application/usecase/TicketUsecase.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/application/usecase/TicketUsecase.java
@@ -3,10 +3,12 @@ package com.devticket.commerce.ticket.application.usecase;
 import com.devticket.commerce.ticket.presentation.dto.req.SellerEventParticipantListRequest;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketListRequest;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
+import com.devticket.commerce.ticket.presentation.dto.res.InternalTicketSettlementDataResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.SellerEventParticipantListResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketDetailResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketListResponse;
 import com.devticket.commerce.ticket.presentation.dto.res.TicketResponse;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -22,4 +24,7 @@ public interface TicketUsecase {
     // 이벤트 참가자 조회
     SellerEventParticipantListResponse getParticipantList(UUID userId, UUID eventId,
         SellerEventParticipantListRequest request);
+
+    // 정산 데이터 조회
+    InternalTicketSettlementDataResponse getSettlementData(List<UUID> eventIds);
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
@@ -21,4 +21,6 @@ public interface TicketRepository {
     Optional<Ticket> findByTicketId(UUID ticketId);
 
     Page<Ticket> findAllByEventId(UUID eventId, SellerEventParticipantListRequest request);
+
+    List<Ticket> findAllByEventIdIn(List<UUID> eventIds);
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketJpaRepository.java
@@ -1,6 +1,7 @@
 package com.devticket.commerce.ticket.infrastructure.persistence;
 
 import com.devticket.commerce.ticket.domain.model.Ticket;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -16,4 +17,6 @@ public interface TicketJpaRepository extends JpaRepository<Ticket, Long> {
 
     @Query
     Page<Ticket> findAllByEventId(UUID eventId, Pageable pageable);
+
+    List<Ticket> findAllByEventIdIn(List<UUID> eventIds);
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Repository;
 
+
 @Repository
 @RequiredArgsConstructor
 public class TicketRepositoryAdapter implements TicketRepository {
@@ -45,5 +46,10 @@ public class TicketRepositoryAdapter implements TicketRepository {
     @Override
     public Page<Ticket> findAllByEventId(UUID eventId, SellerEventParticipantListRequest request) {
         return ticketJpaRepository.findAllByEventId(eventId, request.toPageable());
+    }
+
+    @Override
+    public List<Ticket> findAllByEventIdIn(List<UUID> eventIds) {
+        return ticketJpaRepository.findAllByEventIdIn(eventIds);
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/InternalTicketController.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/InternalTicketController.java
@@ -1,0 +1,29 @@
+package com.devticket.commerce.ticket.presentation.controller;
+
+import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
+import com.devticket.commerce.ticket.presentation.dto.res.InternalTicketSettlementDataResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "Ticket Internal API")
+@RequestMapping("/internal/tickets")
+@RequiredArgsConstructor
+public class InternalTicketController {
+
+    private final TicketUsecase ticketUsecase;
+
+    // Settlement -> Commerce : eventIds별 티켓 정산 데이터 조회
+    @PostMapping("/settlement-data")
+    public ResponseEntity<InternalTicketSettlementDataResponse> getSettlementData(
+        @RequestBody List<UUID> eventIds) {
+        return ResponseEntity.ok(ticketUsecase.getSettlementData(eventIds));
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/InternalTicketSettlementDataResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/InternalTicketSettlementDataResponse.java
@@ -1,0 +1,9 @@
+package com.devticket.commerce.ticket.presentation.dto.res;
+
+import java.util.List;
+
+public record InternalTicketSettlementDataResponse(
+    List<InternalTicketSettlementItemResponse> items
+) {
+
+}

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/InternalTicketSettlementItemResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/InternalTicketSettlementItemResponse.java
@@ -5,8 +5,8 @@ import java.util.UUID;
 public record InternalTicketSettlementItemResponse(
     UUID eventId,
     UUID orderItemId,
-    int salesAmount,
-    int refundAmount
+    Long salesAmount,
+    Long refundAmount
 ) {
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/InternalTicketSettlementItemResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/InternalTicketSettlementItemResponse.java
@@ -1,0 +1,12 @@
+package com.devticket.commerce.ticket.presentation.dto.res;
+
+import java.util.UUID;
+
+public record InternalTicketSettlementItemResponse(
+    UUID eventId,
+    UUID orderItemId,
+    int salesAmount,
+    int refundAmount
+) {
+
+}


### PR DESCRIPTION
## 관련 이슈
- close #399

## 작업 내용
- Settlement에서 호출_종료된 이벤트의 정산용 집계데이터 요청 API

## 변경 사항
- TicketUsecase : getSettlementData추가 
- TicketService : getSettlementData추가 
- TicketRepository : findAllByEventIdIn 추가
- TicketJpaRepository : findAllByEventIdIn 추가
- TicketRepositoryAdapter : findAllByEventIdIn 추가
- InternalTicketController :  /internal/tickets//settlement-data 엔드포이트 추가
- DTO 
   - InternalTicketSettlementDataResponse
   - InternalTicketSettlementItemResponse

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인

## 스크린샷

## 참고 사항