### PR TITLE
[Event] feat: 정산대상 이벤트 목록조회

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventInternalService.java
+++ b/event/src/main/java/com/devticket/event/application/EventInternalService.java
@@ -11,6 +11,7 @@ import com.devticket.event.infrastructure.search.EventSearchRepository;
 import com.devticket.event.presentation.dto.internal.InternalAdminEventResponse;
 import com.devticket.event.presentation.dto.internal.InternalBulkEventInfoResponse;
 import com.devticket.event.presentation.dto.internal.InternalBulkStockAdjustmentRequest;
+import com.devticket.event.presentation.dto.internal.InternalEndedEventsResponse;
 import com.devticket.event.presentation.dto.internal.InternalEventInfoResponse;
 import com.devticket.event.presentation.dto.internal.InternalPagedEventResponse;
 import com.devticket.event.presentation.dto.internal.InternalPurchaseValidationResponse;
@@ -288,6 +289,21 @@ public class EventInternalService {
         return PurchaseUnavailableReason.INSUFFICIENT_STOCK;
     }
 
+    //종료 이벤트조회
+    public InternalEndedEventsResponse getEndedEventsByDate(LocalDate date) {
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime startOfNextDay = date.plusDays(1).atStartOfDay();
+
+        List<InternalEndedEventsResponse.EndedEventItem> items =
+            eventRepository.findAllByEventDate(startOfDay, startOfNextDay)
+                .stream()
+                .map(e -> new InternalEndedEventsResponse.EndedEventItem(
+                    e.getId(), e.getEventId(), e.getSellerId()
+                ))
+                .toList();
+
+        return new InternalEndedEventsResponse(items);
+    }
 
     // 기간 별 판매자 이벤트
     public List<InternalEventInfoResponse> getEventsBySellerForSettlement(UUID sellerId, String periodStart, String periodEnd) {

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
@@ -3,6 +3,7 @@ package com.devticket.event.infrastructure.persistence;
 import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.domain.model.Event;
 import jakarta.persistence.LockModeType;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -86,6 +87,14 @@ public interface EventRepository extends JpaRepository<Event, Long> {
         @Param("sellerId") UUID sellerId,
         @Param("periodStart") LocalDateTime periodStart,
         @Param("periodEnd") LocalDateTime periodEnd
+    );
+
+    @Query("SELECT e FROM Event e " +
+        "WHERE e.eventDateTime >= :startOfDay " +
+        "AND e.eventDateTime < :startOfNextDay")
+    List<Event> findAllByEventDate(
+        @Param("startOfDay") LocalDateTime startOfDay,
+        @Param("startOfNextDay") LocalDateTime startOfNextDay
     );
 
 }

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventInternalController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventInternalController.java
@@ -7,6 +7,7 @@ import com.devticket.event.presentation.dto.internal.InternalBulkEventInfoReques
 import com.devticket.event.presentation.dto.internal.InternalBulkEventInfoResponse;
 import com.devticket.event.presentation.dto.internal.InternalBulkStockAdjustmentRequest;
 import com.devticket.event.presentation.dto.internal.InternalPagedEventResponse;
+import com.devticket.event.presentation.dto.internal.InternalEndedEventsResponse;
 import com.devticket.event.presentation.dto.internal.InternalStockAdjustmentResponse;
 import com.devticket.event.presentation.dto.internal.InternalEventInfoResponse;
 import com.devticket.event.presentation.dto.internal.InternalPurchaseValidationResponse;
@@ -16,6 +17,7 @@ import com.devticket.event.presentation.dto.internal.InternalStockOperationRespo
 import com.devticket.event.presentation.dto.internal.InternalStockRestoreRequest;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -136,6 +138,18 @@ public class EventInternalController {
         @RequestParam(required = false) EventStatus status) {
         return ResponseEntity.ok(SuccessResponse.success(
             eventInternalService.getEventsBySeller(sellerId, status)
+        ));
+    }
+
+    /**
+     * API 8: 특정 날짜에 개최된 이벤트 목록 조회
+     * eventDateTime의 날짜가 date와 일치하는 이벤트의 id, eventId, sellerId 반환
+     */
+    @GetMapping("/ended")
+    public ResponseEntity<SuccessResponse<InternalEndedEventsResponse>> getEndedEventsByDate(
+        @RequestParam LocalDate date) {
+        return ResponseEntity.ok(SuccessResponse.success(
+            eventInternalService.getEndedEventsByDate(date)
         ));
     }
 

--- a/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalEndedEventsResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalEndedEventsResponse.java
@@ -1,0 +1,15 @@
+package com.devticket.event.presentation.dto.internal;
+
+import java.util.List;
+import java.util.UUID;
+
+public record InternalEndedEventsResponse(
+    List<EndedEventItem> events
+) {
+
+    public record EndedEventItem(
+        Long id,
+        UUID eventId,
+        UUID sellerId
+    ) {}
+}


### PR DESCRIPTION
## 관련 이슈
- close #398

## 작업 내용
- Internal Api : 정산용_종료된 이벤트 목록 조회

## 변경 사항
- EventInternalService : getEndedEventsByDate추가
- EventRepository : findAllByEventDate추가
- EventInternalController : getEndedEventsByDate추가
- DTO 
   - InternalEndedEventsResponse

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [v] Swagger 동작 확인

## 스크린샷

## 참고 사항