### PR TITLE
[Commerce] feat: 주문 생성 흐름을 Kafka Saga 패턴으로 전환 및 중복 주문 방지

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/cart/domain/exception/CartErrorCode.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/domain/exception/CartErrorCode.java
@@ -14,7 +14,10 @@ public enum CartErrorCode implements ErrorCode {
     EXCEED_MAX_PURCHASE(400, "CART_004", "인당 최대 구매 수량을 초과했습니다."),
     ITEM_NOT_FOUND(404, "CART_005", "장바구니에 해당 항목이 없습니다."),
     CART_EMPTY(400, "CART_006", "장바구니가 비어 있습니다."),
-    EVENT_PURCHASE_VALID_UNAVAILABLE(500, "CART_007", "현재 이벤트 정보를 불러올 수 없어 장바구니 담기가 일시적으로 제한됩니다. 잠시 후 다시 시도해주세요.");
+    EVENT_PURCHASE_VALID_UNAVAILABLE(500, "CART_007", "현재 이벤트 정보를 불러올 수 없어 장바구니 담기가 일시적으로 제한됩니다. 잠시 후 다시 시도해주세요."),
+    CART_NOT_FOUND(404, "CART_008", "장바구니를 찾을 수 없습니다."),
+    CART_ITEM_NOT_FOUND(404, "CART_009", "선택한 티켓이 장바구니에 없습니다."),
+    DUPLICATE_CART_ITEM_ID(400, "CART_010", "중복된 상품이 포함되어 있습니다.");
     
     private final int status;
     private final String code;

--- a/commerce/src/main/java/com/devticket/commerce/cart/domain/repository/CartItemRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/domain/repository/CartItemRepository.java
@@ -13,6 +13,9 @@ public interface CartItemRepository {
 
     List<CartItem> findAllByCartItemId(List<UUID> cartItemIds);
 
+    // 주문 생성 시 CartItem 동시 변경 차단용 — @Transactional 안에서만 호출, ORDER BY cartItemId로 락 순서 고정
+    List<CartItem> findAllByCartItemIdWithLock(List<UUID> cartItemIds);
+
     Optional<CartItem> findByCartIdAndEventId(Long cartId, UUID eventId);
 
     //장바구니 아이템 삭제

--- a/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemJpaRepository.java
@@ -1,14 +1,22 @@
 package com.devticket.commerce.cart.infrastructure.persistence;
 
 import com.devticket.commerce.cart.domain.model.CartItem;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CartItemJpaRepository extends JpaRepository<CartItem, Long> {
 
     List<CartItem> findAllByCartItemIdIn(List<UUID> cartItemIds);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT ci FROM CartItem ci WHERE ci.cartItemId IN :cartItemIds ORDER BY ci.cartItemId")
+    List<CartItem> findAllByCartItemIdInWithLock(@Param("cartItemIds") List<UUID> cartItemIds);
 
     Optional<CartItem> findByCartIdAndEventId(Long cartId, UUID eventId);
 

--- a/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemRepositoryAdapter.java
@@ -30,6 +30,11 @@ public class CartItemRepositoryAdapter implements CartItemRepository {
     }
 
     @Override
+    public List<CartItem> findAllByCartItemIdWithLock(List<UUID> cartItemIds) {
+        return cartItemJpaRepository.findAllByCartItemIdInWithLock(cartItemIds);
+    }
+
+    @Override
     public Optional<CartItem> findByCartIdAndEventId(Long cartId, UUID eventId) {
         return cartItemJpaRepository.findByCartIdAndEventId(cartId, eventId);
     }

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -1,19 +1,28 @@
 package com.devticket.commerce.order.application.service;
 
+import com.devticket.commerce.cart.domain.exception.CartErrorCode;
 import com.devticket.commerce.cart.domain.exception.EventErrorCode;
+import com.devticket.commerce.cart.domain.model.Cart;
 import com.devticket.commerce.cart.domain.model.CartItem;
 import com.devticket.commerce.cart.domain.repository.CartItemRepository;
+import com.devticket.commerce.cart.domain.repository.CartRepository;
 import com.devticket.commerce.common.enums.OrderStatus;
 import com.devticket.commerce.common.exception.BusinessException;
+import com.devticket.commerce.common.messaging.MessageDeduplicationService;
+import com.devticket.commerce.common.messaging.event.StockDeductedEvent;
+import com.devticket.commerce.common.messaging.event.StockFailedEvent;
 import com.devticket.commerce.order.application.usecase.OrderUsecase;
 import com.devticket.commerce.order.domain.exception.OrderErrorCode;
 import com.devticket.commerce.order.domain.model.Order;
 import com.devticket.commerce.order.domain.model.OrderItem;
 import com.devticket.commerce.order.domain.repository.OrderItemRepository;
 import com.devticket.commerce.order.domain.repository.OrderRepository;
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.common.messaging.event.OrderCreatedEvent;
+import com.devticket.commerce.common.outbox.OutboxService;
+import com.devticket.commerce.order.domain.util.CartHashUtil;
 import com.devticket.commerce.order.infrastructure.external.client.OrderToEventClient;
 import com.devticket.commerce.order.infrastructure.external.client.dto.InternalBulkStockAdjustmentRequest;
-import com.devticket.commerce.order.infrastructure.external.client.dto.InternalStockAdjustmentResponse;
 import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
 import com.devticket.commerce.order.presentation.dto.req.OrderListRequest;
 import com.devticket.commerce.order.presentation.dto.res.InternalOrderInfoResponse;
@@ -31,8 +40,13 @@ import com.devticket.commerce.ticket.domain.model.Ticket;
 import com.devticket.commerce.ticket.domain.repository.TicketRepository;
 import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalEventInfoResponse;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -49,11 +63,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderService implements OrderUsecase {
 
     private final OrderToEventClient orderToEventClient;
+    private final CartRepository cartRepository;
     private final CartItemRepository cartItemRepository;
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final TicketUsecase ticketUsecase;
     private final TicketRepository ticketRepository;
+    private final OutboxService outboxService;
+    private final MessageDeduplicationService deduplicationService;
+    private final ObjectMapper objectMapper;
 
     // ==== Public Methods (Main Flow) ====================================
 
@@ -61,38 +79,85 @@ public class OrderService implements OrderUsecase {
     @Transactional
     @Override
     public OrderResponse createOrderByCart(UUID userId, CartOrderRequest request) {
-        //장바구니 아이템 조회
-        List<CartItem> cartItems = cartItemRepository.findAllByCartItemId(request.cartItemIds());
-        //재고 선차감 : Event API호출
-        List<InternalStockAdjustmentResponse> eventResults = orderToEventClient.adjustStocks(
-            InternalBulkStockAdjustmentRequest.createForOrder(cartItems));
+        // 1. Cart 조회 — cartId 확보 (소유자 검증용)
+        Cart cart = cartRepository.findByUserId(userId)
+            .orElseThrow(() -> new BusinessException(CartErrorCode.CART_NOT_FOUND));
 
-        try {
-            //총 주문 금액 계산
-            int totalAmount = calculateTotalAmount(cartItems, eventResults);
-            //재고 선차감 성공시 Order생성
-            Order order = Order.create(userId, totalAmount);
-            orderRepository.save(order);
-            //OrderItem생성
-            List<OrderItem> savedOrderItems = createOrderItem(order.getId(), userId, cartItems, eventResults);
-            //주문완료건 장바구니에서 삭제처리
-            if (!cartItems.isEmpty()) {
-                cartItemRepository.deleteAllInBatch(cartItems);
-            }
-            //응답데이터 변환
-            Map<UUID, String> eventTitles = eventResults.stream()
-                .collect(Collectors.toMap(
-                    InternalStockAdjustmentResponse::eventId,
-                    InternalStockAdjustmentResponse::eventTitle
-                ));
-            return OrderResponse.of(order, savedOrderItems, eventTitles);
-
-        } catch (Exception e) {
-            //주문 생성 실패시 선차감한 재고를 원복하는 api호출
-            List<InternalStockAdjustmentResponse> rollbackEventResults = orderToEventClient.adjustStocks(
-                InternalBulkStockAdjustmentRequest.createForCancel(cartItems));
-            throw new BusinessException(OrderErrorCode.ORDER_CREATION_FAILED);
+        // 2-0. 중복 ID 검사 — DB 조회 전에 먼저 차단
+        if (request.cartItemIds().size() != new HashSet<>(request.cartItemIds()).size()) {
+            throw new BusinessException(CartErrorCode.DUPLICATE_CART_ITEM_ID);
         }
+
+        // 2. 장바구니 아이템 조회 — 비관적 락으로 주문 처리 중 CartItem 변경 차단 및 동시 요청 직렬화
+        // ORDER BY cartItemId로 락 순서 고정 — 부분 겹침 요청 간 데드락 방지
+        List<CartItem> cartItems = cartItemRepository.findAllByCartItemIdWithLock(request.cartItemIds());
+
+        // 2-1. 개수 불일치 검사 — 존재하지 않거나 삭제된 ID 방어
+        if (cartItems.size() != request.cartItemIds().size()) {
+            throw new BusinessException(CartErrorCode.CART_ITEM_NOT_FOUND);
+        }
+
+        // 2-2. 소유자 검증 — 다른 유저의 CartItem 방어
+        boolean allBelongToCart = cartItems.stream()
+            .allMatch(item -> item.getCartId().equals(cart.getId()));
+        if (!allBelongToCart) {
+            throw new BusinessException(CartErrorCode.CART_ITEM_NOT_FOUND);
+        }
+
+        // 3. cartHash 계산 — (eventId, quantity) 기준 서버 사이드 계산
+        String cartHash = CartHashUtil.compute(cartItems);
+
+        // 4. 활성 주문 중복 체크 — 같은 장바구니 내용의 처리 중 주문이 있으면 기존 주문 반환
+        List<OrderStatus> activeStatuses = List.of(
+            OrderStatus.CREATED, OrderStatus.PAYMENT_PENDING
+        );
+        Optional<Order> existingOrder = orderRepository.findActiveOrder(userId, cartHash, activeStatuses);
+        if (existingOrder.isPresent()) {
+            Order active = existingOrder.get();
+            List<OrderItem> existingItems = orderItemRepository.findAllByOrderId(active.getId());
+            List<UUID> existingEventIds = existingItems.stream().map(OrderItem::getEventId).distinct().toList();
+            Map<UUID, String> existingEventTitles = orderToEventClient.getBulkEventInfo(existingEventIds).stream()
+                .collect(Collectors.toMap(InternalEventInfoResponse::eventId, InternalEventInfoResponse::title));
+            return OrderResponse.of(active, existingItems, existingEventTitles);
+        }
+
+        // 5. 이벤트 정보 조회 (가격·maxQuantity·제목) — 읽기 전용, 재고 차감 없음
+        List<UUID> eventIds = cartItems.stream().map(CartItem::getEventId).distinct().toList();
+        List<InternalEventInfoResponse> eventInfos = orderToEventClient.getBulkEventInfo(eventIds);
+
+        // 6. 총 주문 금액 계산
+        int totalAmount = calculateTotalAmount(cartItems, eventInfos);
+
+        // 7. Order 생성 (CREATED — 재고 확인 대기 중)
+        Order order = Order.create(userId, totalAmount, cartHash);
+        orderRepository.save(order);
+
+        // 8. OrderItem 생성
+        List<OrderItem> savedOrderItems = createOrderItem(order.getId(), userId, cartItems, eventInfos);
+
+        // 9. order.created 발행 (Outbox) — Event 서비스가 수신하여 재고 차감 처리
+        OrderCreatedEvent event = new OrderCreatedEvent(
+            order.getOrderId(),
+            userId,
+            savedOrderItems.stream()
+                .map(item -> new OrderCreatedEvent.OrderItem(item.getEventId(), item.getQuantity()))
+                .toList(),
+            totalAmount,
+            Instant.now()
+        );
+        outboxService.save(
+            order.getOrderId().toString(),
+            order.getOrderId().toString(),
+            "OrderCreated",
+            KafkaTopics.ORDER_CREATED,
+            event
+        );
+
+        // 10. 응답 반환
+        Map<UUID, String> eventTitles = eventInfos.stream()
+            .collect(Collectors.toMap(InternalEventInfoResponse::eventId, InternalEventInfoResponse::title));
+
+        return OrderResponse.of(order, savedOrderItems, eventTitles);
     }
 
     @Override
@@ -307,48 +372,167 @@ public class OrderService implements OrderUsecase {
 //        return InternalEventOrdersResponse.from(eventId, orderItems);
 //    }
 
+    // ==== Kafka Consumer Handlers =======================================
+
+    /**
+     * stock.deducted 수신 처리: Order CREATED → PAYMENT_PENDING 전이
+     *
+     * 처리 순서 :
+     * isDuplicate → canTransitionTo(3분류) → pendingPayment() → markProcessed
+     */
+    @Transactional
+    public void processStockDeducted(UUID messageId, String topic, String payload) {
+        // Step 1. Dedup 체크
+        if (deduplicationService.isDuplicate(messageId)) {
+            log.debug("[stock.deducted] 중복 메시지 스킵. messageId={}", messageId);
+            return;
+        }
+
+        StockDeductedEvent event = parsePayload(payload, StockDeductedEvent.class);
+
+        Order order = orderRepository.findByOrderId(event.orderId())
+            .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        // Step 2. 상태 전이 유효성 검증 (3분류)
+        if (order.getStatus() == OrderStatus.PAYMENT_PENDING) {
+            // 1. 멱등 스킵: 이미 목표 상태
+            log.info("[stock.deducted] 멱등 스킵 — 이미 PAYMENT_PENDING. orderId={}", event.orderId());
+            deduplicationService.markProcessed(messageId, topic);
+            return;
+        }
+        if (!order.canTransitionTo(OrderStatus.PAYMENT_PENDING)) {
+            if (isExplainableSkipForStock(order.getStatus())) {
+                // 2. 정책적 스킵: 만료 스케줄러 또는 사용자 취소로 이미 종단 상태
+                log.warn("[stock.deducted] 정책적 스킵 — 주문 상태={}. orderId={}",
+                    order.getStatus(), event.orderId());
+                deduplicationService.markProcessed(messageId, topic);
+                return;
+            }
+            // 3. 이상 상태: 설명 불가능 → throw → 재시도 → DLT
+            log.error("[stock.deducted] 이상 상태 — {} → PAYMENT_PENDING 불가. orderId={}",
+                order.getStatus(), event.orderId());
+            throw new IllegalStateException(String.format(
+                "[stock.deducted] 허용되지 않는 상태 전이: %s → PAYMENT_PENDING, orderId=%s",
+                order.getStatus(), event.orderId()));
+        }
+
+        // Step 3. 비즈니스 로직: CREATED → PAYMENT_PENDING
+        order.pendingPayment();
+
+        // Step 4. Dedup 기록 저장 (같은 트랜잭션)
+        deduplicationService.markProcessed(messageId, topic);
+    }
+
+    /**
+     * stock.failed 수신 처리: Order CREATED → FAILED 전이 (재고 부족 보상)
+     *
+     * <p>처리 순서 (kafka-idempotency-guide.md §4):
+     * isDuplicate → canTransitionTo(3분류) → failByStock() → markProcessed
+     */
+    @Transactional
+    public void processStockFailed(UUID messageId, String topic, String payload) {
+        // Step 1. Dedup 체크
+        if (deduplicationService.isDuplicate(messageId)) {
+            log.debug("[stock.failed] 중복 메시지 스킵. messageId={}", messageId);
+            return;
+        }
+
+        StockFailedEvent event = parsePayload(payload, StockFailedEvent.class);
+
+        Order order = orderRepository.findByOrderId(event.orderId())
+            .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        // Step 2. 상태 전이 유효성 검증 (3분류)
+        if (order.getStatus() == OrderStatus.FAILED) {
+            // ① 멱등 스킵: 이미 목표 상태
+            log.info("[stock.failed] 멱등 스킵 — 이미 FAILED. orderId={}", event.orderId());
+            deduplicationService.markProcessed(messageId, topic);
+            return;
+        }
+        if (order.getStatus() == OrderStatus.PAYMENT_PENDING) {
+            // ③ 이상 상태: stock.deducted 처리 완료 후 stock.failed 재도달
+            // canTransitionTo(FAILED)가 PAYMENT_PENDING에서도 true를 반환하므로 명시적으로 차단
+            log.error("[stock.failed] 이상 상태 — stock.deducted 이미 처리됨(PAYMENT_PENDING)에서 stock.failed 재도달. orderId={}",
+                event.orderId());
+            throw new IllegalStateException(String.format(
+                "[stock.failed] PAYMENT_PENDING 상태에서 재고 실패 이벤트 수신 불가. orderId=%s", event.orderId()));
+        }
+        if (!order.canTransitionTo(OrderStatus.FAILED)) {
+            if (order.getStatus() == OrderStatus.CANCELLED) {
+                // ② 정책적 스킵: 재고 결과 도착 전에 사용자가 먼저 취소
+                log.warn("[stock.failed] 정책적 스킵 — 주문 이미 CANCELLED. orderId={}", event.orderId());
+                deduplicationService.markProcessed(messageId, topic);
+                return;
+            }
+            // ③ 이상 상태: 설명 불가능 → throw → 재시도 → DLT
+            log.error("[stock.failed] 이상 상태 — {} → FAILED 불가. reason={}, orderId={}",
+                order.getStatus(), event.reason(), event.orderId());
+            throw new IllegalStateException(String.format(
+                "[stock.failed] 허용되지 않는 상태 전이: %s → FAILED, orderId=%s",
+                order.getStatus(), event.orderId()));
+        }
+
+        // Step 3. 비즈니스 로직: CREATED → FAILED
+        order.failByStock();
+        log.info("[stock.failed] Order FAILED 전이 완료. reason={}, orderId={}",
+            event.reason(), event.orderId());
+
+        // Step 4. Dedup 기록 저장 (같은 트랜잭션)
+        deduplicationService.markProcessed(messageId, topic);
+    }
+
     // ==== Private Helpers (Logic & Validation) ==========================
 
-    private int calculateTotalAmount(List<CartItem> cartItems, List<InternalStockAdjustmentResponse> eventItems) {
-        int totalAmount = 0;
-        Map<UUID, Integer> priceMap = eventItems.stream()
-            .collect(
-                Collectors.toMap(InternalStockAdjustmentResponse::eventId, InternalStockAdjustmentResponse::price));
+    /**
+     * stock 이벤트 수신 시 정책적 스킵 가능한 상태 — 만료 스케줄러 또는 사용자 취소로 이미 종단 도달
+     */
+    private boolean isExplainableSkipForStock(OrderStatus current) {
+        return current == OrderStatus.CANCELLED || current == OrderStatus.FAILED;
+    }
+
+
+    private <T> T parsePayload(String payload, Class<T> clazz) {
+        try {
+            return objectMapper.readValue(payload, clazz);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Kafka 페이로드 역직렬화 실패: " + e.getMessage(), e);
+        }
+    }
+
+    private int calculateTotalAmount(List<CartItem> cartItems, List<InternalEventInfoResponse> eventInfos) {
+        Map<UUID, Integer> priceMap = eventInfos.stream()
+            .collect(Collectors.toMap(InternalEventInfoResponse::eventId, InternalEventInfoResponse::price));
 
         return cartItems.stream()
             .mapToInt(cartItem -> {
                 Integer currentPrice = priceMap.get(cartItem.getEventId());
-
                 if (currentPrice == null) {
                     throw new BusinessException(EventErrorCode.EVENT_NOT_FOUND);
                 }
-
                 return currentPrice * cartItem.getQuantity();
             })
             .sum();
     }
 
     private List<OrderItem> createOrderItem(Long orderId, UUID userId, List<CartItem> cartItems,
-        List<InternalStockAdjustmentResponse> eventItems) {
+        List<InternalEventInfoResponse> eventInfos) {
 
-        Map<UUID, InternalStockAdjustmentResponse> eventMap = eventItems.stream()
-            .collect(Collectors.toMap(InternalStockAdjustmentResponse::eventId, r -> r));
+        Map<UUID, InternalEventInfoResponse> eventMap = eventInfos.stream()
+            .collect(Collectors.toMap(InternalEventInfoResponse::eventId, r -> r));
 
         List<OrderItem> orderItems = cartItems.stream()
             .map(cartItem -> {
-                InternalStockAdjustmentResponse detail = eventMap.get(cartItem.getEventId());
-
+                InternalEventInfoResponse detail = eventMap.get(cartItem.getEventId());
                 if (detail == null) {
                     throw new BusinessException(EventErrorCode.EVENT_NOT_FOUND);
                 }
-
                 return OrderItem.create(
-                    orderId,         // 발급된 부모 ID 주입
-                    userId,                // 유저 식별값
-                    cartItem.getEventId(), // 이벤트 ID
-                    detail.price(),        // 최신 가격 스냅샷
-                    cartItem.getQuantity(),// 주문 수량
-                    detail.maxQuantity()   // 인당 제한 수량 검증용
+                    orderId,
+                    userId,
+                    cartItem.getEventId(),
+                    detail.price(),
+                    cartItem.getQuantity(),
+                    detail.maxQuantity()
                 );
             })
             .toList();

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/exception/OrderErrorCode.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/exception/OrderErrorCode.java
@@ -22,7 +22,8 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_QUANTITY(400, "ORDER_011", "유효하지 않은 주문 수량입니다."),
     EMPTY_ORDER_ITEMS(400, "ORDER_012", "주문한 상품이 존재하지 않습니다."),
     INVALID_TOTAL_AMOUNT(400, "ORDER_013", "총 주문 금액이 유효하지 않습니다."),
-    ORDER_CREATION_FAILED(500, "ORDER_014", "주문 생성 중 내부 오류가 발생했습니다.");
+    ORDER_CREATION_FAILED(500, "ORDER_014", "주문 생성 중 내부 오류가 발생했습니다."),
+    INVALID_ORDER_STATUS_TRANSITION(400, "ORDER_015", "현재 주문 상태에서 허용되지 않는 전이입니다.");
 
 
     private final int status;

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/model/Order.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/model/Order.java
@@ -12,7 +12,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
@@ -25,7 +27,11 @@ import lombok.experimental.SuperBuilder;
 @Entity
 @SuperBuilder
 @Getter
-@Table(name = "order", schema = "commerce")
+@Table(
+        name = "order",
+        schema = "commerce",
+        indexes = @Index(name = "idx_order_user_cart_hash", columnList = "user_id, cart_hash")
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Order extends BaseEntity {
@@ -60,13 +66,22 @@ public class Order extends BaseEntity {
     @Column(name = "deleted_at")
     LocalDateTime deletedAt;
 
+    // 장바구니 내용 해시 — (itemId, quantity) itemId 정렬 후 SHA-256, 중복 주문 판단 기준
+    // UNIQUE 제약 없음 — 이력 주문(CANCELLED/FAILED)은 동일 해시 존재 가능
+    @Column(name = "cart_hash", length = 64, nullable = false )
+    String cartHash;
+
+    // 낙관적 락 — Consumer/스케줄러 동시 상태 전이 충돌 방어
+    @Version
+    @Column(name = "version", nullable = false)
+    Long version;
+
     //---- 정적 팩토리 메서드 ------------------------------
 
     public static Order create(
         UUID userId,
-        int totalAmount
-        //List<OrderItem> items
-
+        int totalAmount,
+        String cartHash
     ) {
         LocalDateTime now = LocalDateTime.now();
 
@@ -93,8 +108,9 @@ public class Order extends BaseEntity {
             .orderNumber(generatedOrderNumber)
             .paymentMethod(null)
             .totalAmount(totalAmount)
-            .status(OrderStatus.PAYMENT_PENDING)
+            .status(OrderStatus.CREATED)
             .orderedAt(now)
+            .cartHash(cartHash)
             .deletedAt(null)
             .build();
 
@@ -114,29 +130,56 @@ public class Order extends BaseEntity {
         this.totalAmount = newTotalAmount;
     }
 
-    //주문 상태 변경 : 결제 대기중 PAYMENT_PENDING
-    public void pendingPayment(PaymentMethod method) {
-        if (this.status != OrderStatus.CREATED) {
-            throw new BusinessException(OrderErrorCode.CANNOT_CHANGE_TO_PENDING);
+    // stock.deducted 수신: CREATED → PAYMENT_PENDING
+    public void pendingPayment() {
+        if (!canTransitionTo(OrderStatus.PAYMENT_PENDING)) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS_TRANSITION);
         }
         this.status = OrderStatus.PAYMENT_PENDING;
     }
 
-    //주문 상태 변경 : 결제완료 PAID
+    // payment.completed 수신: PAYMENT_PENDING → PAID
     public void completePayment() {
         if (this.status == OrderStatus.PAID) {
             throw new BusinessException(OrderErrorCode.ALREADY_PAID_ORDER);
         }
-        if (this.status != OrderStatus.PAYMENT_PENDING) {
+        if (!canTransitionTo(OrderStatus.PAID)) {
             throw new BusinessException(OrderErrorCode.CANNOT_COMPLETE_PAYMENT);
         }
         this.status = OrderStatus.PAID;
     }
 
-    //주문 상태 변경 : 주문취소 CANCELLED
+    // stock.failed 수신: CREATED → FAILED
+    public void failByStock() {
+        if (!canTransitionTo(OrderStatus.FAILED)) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS_TRANSITION);
+        }
+        this.status = OrderStatus.FAILED;
+    }
+
+    // 스케줄러 만료: CREATED 상태로 10분 초과 시 → FAILED
+    public void expire() {
+        if (!canTransitionTo(OrderStatus.FAILED)) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS_TRANSITION);
+        }
+        this.status = OrderStatus.FAILED;
+    }
+
+    // payment.failed 수신: PAYMENT_PENDING → FAILED
+    public void failPayment() {
+        if (!canTransitionTo(OrderStatus.FAILED)) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS_TRANSITION);
+        }
+        this.status = OrderStatus.FAILED;
+    }
+
+    // 주문 취소: PAYMENT_PENDING → CANCELLED / PAID → CANCELLED
     public void cancel() {
         if (this.status == OrderStatus.CANCELLED) {
             throw new BusinessException(OrderErrorCode.ALREADY_CANCELLED_ORDER);
+        }
+        if (!canTransitionTo(OrderStatus.CANCELLED)) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS_TRANSITION);
         }
         this.status = OrderStatus.CANCELLED;
     }
@@ -149,12 +192,21 @@ public class Order extends BaseEntity {
         this.totalAmount -= refundAmount;
     }
 
-    //주문 상태 변경 : 결제실패 FAILED
-    public void failPayment() {
-        if (this.status == OrderStatus.PAID) {
-            throw new BusinessException(OrderErrorCode.ALREADY_PAID_ORDER);
-        }
-        this.status = OrderStatus.FAILED;
+    // Consumer 멱등 처리 및 상태 전이 방어용 — canTransitionTo() 기반으로 모든 도메인 메서드 가드 구현
+    public boolean canTransitionTo(OrderStatus target) {
+        return switch (this.status) {
+            // CREATED: 재고 확인 대기 중 — stock.deducted(→PAYMENT_PENDING) 또는 stock.failed(→FAILED)만 허용
+            case CREATED         -> target == OrderStatus.PAYMENT_PENDING
+                                 || target == OrderStatus.FAILED;
+            // PAYMENT_PENDING: 결제 대기 중 — 결제 완료/실패/취소 허용
+            case PAYMENT_PENDING -> target == OrderStatus.PAID
+                                 || target == OrderStatus.FAILED
+                                 || target == OrderStatus.CANCELLED;
+            // PAID: 결제 완료 — 취소(환불 흐름)만 허용
+            case PAID            -> target == OrderStatus.CANCELLED;
+            // FAILED, CANCELLED, REFUND_PENDING, REFUNDED: 종단 상태 — 전이 불가
+            default              -> false;
+        };
     }
 
     //-------------------

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/model/Order.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/model/Order.java
@@ -68,7 +68,7 @@ public class Order extends BaseEntity {
 
     // 장바구니 내용 해시 — (itemId, quantity) itemId 정렬 후 SHA-256, 중복 주문 판단 기준
     // UNIQUE 제약 없음 — 이력 주문(CANCELLED/FAILED)은 동일 해시 존재 가능
-    @Column(name = "cart_hash", length = 64, nullable = false )
+    @Column(name = "cart_hash", length = 64)
     String cartHash;
 
     // 낙관적 락 — Consumer/스케줄러 동시 상태 전이 충돌 방어

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderRepository.java
@@ -22,4 +22,7 @@ public interface OrderRepository {
 
     Page<Order> findAllByUserId(UUID userId, OrderStatus status, Pageable pageable);
 
+    // 중복 주문 방어 — userId + cartHash 기준 활성 주문 조회
+    Optional<Order> findActiveOrder(UUID userId, String cartHash, List<OrderStatus> activeStatuses);
+
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/util/CartHashUtil.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/util/CartHashUtil.java
@@ -1,0 +1,35 @@
+package com.devticket.commerce.order.domain.util;
+
+import com.devticket.commerce.cart.domain.model.CartItem;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CartHashUtil {
+
+    private CartHashUtil() {}
+
+    // (eventId, quantity) 리스트를 eventId 기준 오름차순 정렬 후 SHA-256
+    // unitPrice 미포함 — 팀 합의
+    public static String compute(List<CartItem> cartItems) {
+        String serialized = cartItems.stream()
+            .sorted(Comparator.comparing(item -> item.getEventId().toString()))
+            .map(item -> item.getEventId() + ":" + item.getQuantity())
+            .collect(Collectors.joining(","));
+
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(serialized.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder();
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 알고리즘을 찾을 수 없습니다.", e);
+        }
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/kafka/StockEventConsumer.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/kafka/StockEventConsumer.java
@@ -1,0 +1,70 @@
+package com.devticket.commerce.order.infrastructure.kafka;
+
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.order.application.service.OrderService;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockEventConsumer {
+
+    private final OrderService orderService;
+
+    /**
+     * stock.deducted 수신: Order CREATED → PAYMENT_PENDING 전이
+     * groupId: commerce-stock.deducted
+     */
+    @KafkaListener(
+        topics = KafkaTopics.STOCK_DEDUCTED,
+        groupId = "commerce-stock.deducted"
+    )
+    public void consumeStockDeducted(ConsumerRecord<String, String> record, Acknowledgment ack) {
+        UUID messageId = extractMessageId(record.headers());
+        try {
+            orderService.processStockDeducted(messageId, record.topic(), record.value());
+        } catch (DataIntegrityViolationException e) {
+            // processed_message UNIQUE 충돌: 다른 요청이 이미 처리 완료 → 스킵
+            log.warn("[stock.deducted] messageId={} UNIQUE 충돌 — 이미 처리 완료, 스킵", messageId);
+        }
+        ack.acknowledge();
+    }
+
+    /**
+     * stock.failed 수신: Order CREATED → FAILED 전이 (재고 부족 보상)
+     * groupId: commerce-stock.failed
+     */
+    @KafkaListener(
+        topics = KafkaTopics.STOCK_FAILED,
+        groupId = "commerce-stock.failed"
+    )
+    public void consumeStockFailed(ConsumerRecord<String, String> record, Acknowledgment ack) {
+        UUID messageId = extractMessageId(record.headers());
+        try {
+            orderService.processStockFailed(messageId, record.topic(), record.value());
+        } catch (DataIntegrityViolationException e) {
+            // processed_message UNIQUE 충돌: 다른 요청이 이미 처리 완료 → 스킵
+            log.warn("[stock.failed] messageId={} UNIQUE 충돌 — 이미 처리 완료, 스킵", messageId);
+        }
+        ack.acknowledge();
+    }
+
+    private UUID extractMessageId(Headers headers) {
+        Header header = headers.lastHeader("X-Message-Id");
+        if (header == null) {
+            throw new IllegalArgumentException(
+                "X-Message-Id 헤더 누락 — Outbox Producer 설정 확인 필요 (kafka-idempotency-guide.md §3-5)");
+        }
+        return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8));
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderJpaRepository.java
@@ -8,6 +8,8 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
 
@@ -22,5 +24,17 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
     Page<Order> findAllByUserId(UUID userId, Pageable pageable);
 
     Page<Order> findAllByUserIdAndStatus(UUID userId, OrderStatus status, Pageable pageable);
+
+    @Query("""
+            SELECT o FROM Order o
+            WHERE o.userId = :userId
+              AND o.cartHash = :cartHash
+              AND o.status IN :activeStatuses
+            """)
+    Optional<Order> findActiveOrder(
+            @Param("userId") UUID userId,
+            @Param("cartHash") String cartHash,
+            @Param("activeStatuses") List<OrderStatus> activeStatuses
+    );
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderRepositoryAdapter.java
@@ -50,4 +50,9 @@ public class OrderRepositoryAdapter implements OrderRepository {
         return orderJpaRepository.findAllByUserIdAndStatus(userId, status, pageable);
     }
 
+    @Override
+    public Optional<Order> findActiveOrder(UUID userId, String cartHash, List<OrderStatus> activeStatuses) {
+        return orderJpaRepository.findActiveOrder(userId, cartHash, activeStatuses);
+    }
+
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/consumer/StockEventConsumer.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/consumer/StockEventConsumer.java
@@ -1,4 +1,4 @@
-package com.devticket.commerce.order.infrastructure.kafka;
+package com.devticket.commerce.order.presentation.consumer;
 
 import com.devticket.commerce.common.messaging.KafkaTopics;
 import com.devticket.commerce.order.application.service.OrderService;
@@ -33,11 +33,15 @@ public class StockEventConsumer {
         UUID messageId = extractMessageId(record.headers());
         try {
             orderService.processStockDeducted(messageId, record.topic(), record.value());
+            ack.acknowledge();
         } catch (DataIntegrityViolationException e) {
-            // processed_message UNIQUE 충돌: 다른 요청이 이미 처리 완료 → 스킵
-            log.warn("[stock.deducted] messageId={} UNIQUE 충돌 — 이미 처리 완료, 스킵", messageId);
+            if (isProcessedMessageUniqueConflict(e)) {
+                log.warn("[stock.deducted] messageId={} processed_message UNIQUE 충돌 — 이미 처리 완료, 스킵", messageId);
+                ack.acknowledge();
+                return;
+            }
+            throw e;
         }
-        ack.acknowledge();
     }
 
     /**
@@ -52,11 +56,15 @@ public class StockEventConsumer {
         UUID messageId = extractMessageId(record.headers());
         try {
             orderService.processStockFailed(messageId, record.topic(), record.value());
+            ack.acknowledge();
         } catch (DataIntegrityViolationException e) {
-            // processed_message UNIQUE 충돌: 다른 요청이 이미 처리 완료 → 스킵
-            log.warn("[stock.failed] messageId={} UNIQUE 충돌 — 이미 처리 완료, 스킵", messageId);
+            if (isProcessedMessageUniqueConflict(e)) {
+                log.warn("[stock.failed] messageId={} processed_message UNIQUE 충돌 — 이미 처리 완료, 스킵", messageId);
+                ack.acknowledge();
+                return;
+            }
+            throw e;
         }
-        ack.acknowledge();
     }
 
     private UUID extractMessageId(Headers headers) {
@@ -66,5 +74,19 @@ public class StockEventConsumer {
                 "X-Message-Id 헤더 누락 — Outbox Producer 설정 확인 필요 (kafka-idempotency-guide.md §3-5)");
         }
         return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8));
+    }
+
+    private boolean isProcessedMessageUniqueConflict(DataIntegrityViolationException e) {
+        Throwable cause = e.getCause();
+
+        while (cause != null) {
+            if (cause instanceof org.hibernate.exception.ConstraintViolationException constraintViolation) {
+                String constraintName = constraintViolation.getConstraintName();
+                return "uk_processed_message_message_id_topic".equals(constraintName);
+            }
+            cause = cause.getCause();
+        }
+
+        return false;
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,7 +36,7 @@ public class OrderController {
     @Operation(description = "주문하기 : 장바구니에 저장된 상품 단건,다건 주문하기")
     public ResponseEntity<OrderResponse> createOrderByCart(
         @RequestHeader("X-User-Id") UUID userId,
-        @RequestBody CartOrderRequest request
+        @Valid @RequestBody CartOrderRequest request
     ) {
         OrderResponse response = orderUsecase.createOrderByCart(userId, request);
         return ResponseEntity

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/CartOrderRequest.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/CartOrderRequest.java
@@ -1,11 +1,12 @@
 package com.devticket.commerce.order.presentation.dto.req;
 
-
+import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 import java.util.UUID;
 
 //장바구니에서 주문요청
 public record CartOrderRequest(
+    @NotEmpty(message = "주문할 장바구니 아이템을 1개 이상 선택해야 합니다.")
     List<UUID> cartItemIds
 ) {
 

--- a/commerce/src/test/java/com/devticket/commerce/order/application/service/OrderServiceTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/order/application/service/OrderServiceTest.java
@@ -1,0 +1,586 @@
+package com.devticket.commerce.order.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.devticket.commerce.cart.domain.exception.CartErrorCode;
+import com.devticket.commerce.cart.domain.model.Cart;
+import com.devticket.commerce.cart.domain.model.CartItem;
+import com.devticket.commerce.cart.domain.repository.CartItemRepository;
+import com.devticket.commerce.cart.domain.repository.CartRepository;
+import com.devticket.commerce.common.enums.OrderStatus;
+import com.devticket.commerce.common.exception.BusinessException;
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.common.messaging.MessageDeduplicationService;
+import com.devticket.commerce.common.messaging.event.StockDeductedEvent;
+import com.devticket.commerce.common.messaging.event.StockFailedEvent;
+import com.devticket.commerce.common.outbox.OutboxService;
+import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.model.OrderItem;
+import com.devticket.commerce.order.domain.repository.OrderItemRepository;
+import com.devticket.commerce.order.domain.repository.OrderRepository;
+import com.devticket.commerce.order.infrastructure.external.client.OrderToEventClient;
+import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
+import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
+import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
+import com.devticket.commerce.ticket.domain.repository.TicketRepository;
+import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalEventInfoResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock private OrderToEventClient orderToEventClient;
+    @Mock private CartRepository cartRepository;
+    @Mock private CartItemRepository cartItemRepository;
+    @Mock private OrderRepository orderRepository;
+    @Mock private OrderItemRepository orderItemRepository;
+    @Mock private TicketUsecase ticketUsecase;
+    @Mock private TicketRepository ticketRepository;
+    @Mock private OutboxService outboxService;
+    @Mock private MessageDeduplicationService deduplicationService;
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .addModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+    private OrderService orderService;
+
+    @BeforeEach
+    void setUp() {
+        orderService = new OrderService(
+                orderToEventClient, cartRepository, cartItemRepository,
+                orderRepository, orderItemRepository, ticketUsecase,
+                ticketRepository, outboxService, deduplicationService, objectMapper
+        );
+    }
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────
+
+    private static final Long CART_ID = 1L;
+
+    private Cart cart(UUID userId) {
+        return Cart.builder()
+                .id(CART_ID)
+                .userId(userId)
+                .build();
+    }
+
+    private CartItem cartItem(Long cartId, UUID eventId, int quantity) {
+        return CartItem.create(cartId, eventId, quantity);
+    }
+
+    private InternalEventInfoResponse eventInfo(UUID eventId, int price, int maxQuantity) {
+        return new InternalEventInfoResponse(
+                eventId, UUID.randomUUID(), "테스트 이벤트", price,
+                null, null, 100, maxQuantity, 50,
+                null, null, null
+        );
+    }
+
+    private OrderItem orderItem(Long orderId, UUID userId, UUID eventId, int price, int quantity) {
+        return OrderItem.create(orderId, userId, eventId, price, quantity, quantity + 10);
+    }
+
+    private Order savedOrder(UUID userId, int totalAmount, String cartHash) {
+        return Order.create(userId, totalAmount, cartHash);
+    }
+
+    private Order createdOrder() {
+        return Order.create(UUID.randomUUID(), 10_000, "hash");
+    }
+
+    private Order paymentPendingOrder() {
+        Order order = createdOrder();
+        order.pendingPayment();
+        return order;
+    }
+
+    private Order failedOrder() {
+        Order order = createdOrder();
+        order.failByStock();
+        return order;
+    }
+
+    private Order cancelledOrder() {
+        Order order = paymentPendingOrder();
+        order.cancel();
+        return order;
+    }
+
+    private Order paidOrder() {
+        Order order = paymentPendingOrder();
+        order.completePayment();
+        return order;
+    }
+
+    private String toJson(Object event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String stockDeductedPayload(UUID orderId) {
+        return toJson(new StockDeductedEvent(orderId, UUID.randomUUID(), 2, Instant.now()));
+    }
+
+    private String stockFailedPayload(UUID orderId) {
+        return toJson(new StockFailedEvent(orderId, UUID.randomUUID(), "재고 부족", Instant.now()));
+    }
+
+    // ── 신규_주문_생성 ────────────────────────────────────────────────
+
+    @Nested
+    class 신규_주문_생성 {
+
+        @Test
+        void 정상_흐름_신규_주문을_생성하고_Outbox에_저장한다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            UUID cartItemId = UUID.randomUUID();
+
+            CartItem item = cartItem(1L, eventId, 2);
+            InternalEventInfoResponse info = eventInfo(eventId, 5_000, 10);
+            Order order = savedOrder(userId, 10_000, "hash");
+            OrderItem savedItem = orderItem(order.getId(), userId, eventId, 5_000, 2);
+
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findAllByCartItemIdWithLock(anyList())).willReturn(List.of(item));
+            given(orderRepository.findActiveOrder(eq(userId), anyString(), anyList()))
+                    .willReturn(Optional.empty());
+            given(orderToEventClient.getBulkEventInfo(anyList())).willReturn(List.of(info));
+            given(orderRepository.save(any(Order.class))).willReturn(order);
+            given(orderItemRepository.saveAll(anyList())).willReturn(List.of(savedItem));
+
+            CartOrderRequest request = new CartOrderRequest(List.of(cartItemId));
+
+            OrderResponse response = orderService.createOrderByCart(userId, request);
+
+            assertThat(response).isNotNull();
+            assertThat(response.orderStatus()).isEqualTo(OrderStatus.CREATED);
+            then(orderRepository).should().save(any(Order.class));
+            then(orderItemRepository).should().saveAll(anyList());
+            then(outboxService).should().save(
+                    anyString(), anyString(),
+                    eq("OrderCreated"),
+                    eq(KafkaTopics.ORDER_CREATED),
+                    any()
+            );
+        }
+
+        @Test
+        void 총_주문_금액은_가격_곱하기_수량의_합계다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId1 = UUID.randomUUID();
+            UUID eventId2 = UUID.randomUUID();
+
+            CartItem item1 = cartItem(1L, eventId1, 2);
+            CartItem item2 = cartItem(1L, eventId2, 3);
+
+            List<InternalEventInfoResponse> infos = List.of(
+                    eventInfo(eventId1, 3_000, 10),
+                    eventInfo(eventId2, 4_000, 10)
+            );
+
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findAllByCartItemIdWithLock(anyList())).willReturn(List.of(item1, item2));
+            given(orderRepository.findActiveOrder(eq(userId), anyString(), anyList()))
+                    .willReturn(Optional.empty());
+            given(orderToEventClient.getBulkEventInfo(anyList())).willReturn(infos);
+            given(orderRepository.save(any(Order.class))).willAnswer(inv -> inv.getArgument(0));
+            given(orderItemRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
+
+            CartOrderRequest request = new CartOrderRequest(List.of(UUID.randomUUID(), UUID.randomUUID()));
+
+            OrderResponse response = orderService.createOrderByCart(userId, request);
+
+            assertThat(response.totalAmount()).isEqualTo(18_000L);
+        }
+
+        @Test
+        void order_created_토픽으로_Outbox를_저장한다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+
+            CartItem item = cartItem(1L, eventId, 1);
+            InternalEventInfoResponse info = eventInfo(eventId, 10_000, 5);
+            Order order = savedOrder(userId, 10_000, "hash");
+            OrderItem savedItem = orderItem(order.getId(), userId, eventId, 10_000, 1);
+
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findAllByCartItemIdWithLock(anyList())).willReturn(List.of(item));
+            given(orderRepository.findActiveOrder(eq(userId), anyString(), anyList()))
+                    .willReturn(Optional.empty());
+            given(orderToEventClient.getBulkEventInfo(anyList())).willReturn(List.of(info));
+            given(orderRepository.save(any(Order.class))).willReturn(order);
+            given(orderItemRepository.saveAll(anyList())).willReturn(List.of(savedItem));
+
+            orderService.createOrderByCart(userId, new CartOrderRequest(List.of(UUID.randomUUID())));
+
+            ArgumentCaptor<String> topicCaptor = ArgumentCaptor.forClass(String.class);
+            then(outboxService).should().save(anyString(), anyString(), anyString(), topicCaptor.capture(), any());
+            assertThat(topicCaptor.getValue()).isEqualTo(KafkaTopics.ORDER_CREATED);
+        }
+    }
+
+    // ── 중복_주문_반환 ────────────────────────────────────────────────
+
+    @Nested
+    class 중복_주문_반환 {
+
+        @Test
+        void CREATED_상태_활성_주문이_있으면_기존_주문을_반환한다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            CartItem item = cartItem(1L, eventId, 1);
+
+            Order existingOrder = savedOrder(userId, 5_000, "some-hash");
+            OrderItem existingItem = orderItem(existingOrder.getId(), userId, eventId, 5_000, 1);
+            InternalEventInfoResponse info = eventInfo(eventId, 5_000, 5);
+
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findAllByCartItemIdWithLock(anyList())).willReturn(List.of(item));
+            given(orderRepository.findActiveOrder(eq(userId), anyString(), anyList()))
+                    .willReturn(Optional.of(existingOrder));
+            given(orderItemRepository.findAllByOrderId(existingOrder.getId()))
+                    .willReturn(List.of(existingItem));
+            given(orderToEventClient.getBulkEventInfo(anyList())).willReturn(List.of(info));
+
+            OrderResponse response = orderService.createOrderByCart(userId, new CartOrderRequest(List.of(UUID.randomUUID())));
+
+            assertThat(response.orderId()).isEqualTo(existingOrder.getOrderId());
+            then(orderRepository).should(never()).save(any(Order.class));
+            then(outboxService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        void PAYMENT_PENDING_상태_활성_주문이_있으면_기존_주문을_반환한다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            CartItem item = cartItem(1L, eventId, 1);
+
+            Order existingOrder = savedOrder(userId, 5_000, "some-hash");
+            existingOrder.pendingPayment();
+            OrderItem existingItem = orderItem(existingOrder.getId(), userId, eventId, 5_000, 1);
+            InternalEventInfoResponse info = eventInfo(eventId, 5_000, 5);
+
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findAllByCartItemIdWithLock(anyList())).willReturn(List.of(item));
+            given(orderRepository.findActiveOrder(eq(userId), anyString(), anyList()))
+                    .willReturn(Optional.of(existingOrder));
+            given(orderItemRepository.findAllByOrderId(existingOrder.getId()))
+                    .willReturn(List.of(existingItem));
+            given(orderToEventClient.getBulkEventInfo(anyList())).willReturn(List.of(info));
+
+            OrderResponse response = orderService.createOrderByCart(userId, new CartOrderRequest(List.of(UUID.randomUUID())));
+
+            assertThat(response.orderId()).isEqualTo(existingOrder.getOrderId());
+            assertThat(response.orderStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+            then(orderRepository).should(never()).save(any(Order.class));
+            then(outboxService).shouldHaveNoInteractions();
+        }
+    }
+
+    // ── 예외_케이스 ────────────────────────────────────────────────────
+
+    @Nested
+    class 예외_케이스 {
+
+        @Test
+        void 장바구니가_없으면_BusinessException을_던진다() {
+            UUID userId = UUID.randomUUID();
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> orderService.createOrderByCart(userId, new CartOrderRequest(List.of(UUID.randomUUID()))))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(CartErrorCode.CART_NOT_FOUND));
+
+            then(cartItemRepository).shouldHaveNoInteractions();
+            then(orderRepository).shouldHaveNoInteractions();
+            then(outboxService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        void 중복된_cartItemId가_요청되면_DUPLICATE_CART_ITEM_ID_예외를_던진다() {
+            UUID userId = UUID.randomUUID();
+            UUID duplicateId = UUID.randomUUID();
+
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+
+            assertThatThrownBy(() -> orderService.createOrderByCart(userId, new CartOrderRequest(List.of(duplicateId, duplicateId))))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(CartErrorCode.DUPLICATE_CART_ITEM_ID));
+
+            then(cartItemRepository).shouldHaveNoInteractions();
+            then(orderRepository).shouldHaveNoInteractions();
+        }
+
+        @Test
+        void 요청한_cartItem이_DB에_없으면_CART_ITEM_NOT_FOUND_예외를_던진다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+
+            CartItem item = cartItem(CART_ID, eventId, 1);
+
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findAllByCartItemIdWithLock(anyList())).willReturn(List.of(item));
+
+            assertThatThrownBy(() -> orderService.createOrderByCart(userId, new CartOrderRequest(List.of(UUID.randomUUID(), UUID.randomUUID()))))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(CartErrorCode.CART_ITEM_NOT_FOUND));
+
+            then(orderRepository).shouldHaveNoInteractions();
+            then(outboxService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        void 다른_유저의_CartItem을_포함하면_CART_ITEM_NOT_FOUND_예외를_던진다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            UUID cartItemId = UUID.randomUUID();
+
+            CartItem otherUsersItem = cartItem(99L, eventId, 1);
+
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findAllByCartItemIdWithLock(anyList())).willReturn(List.of(otherUsersItem));
+
+            assertThatThrownBy(() -> orderService.createOrderByCart(userId, new CartOrderRequest(List.of(cartItemId))))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(CartErrorCode.CART_ITEM_NOT_FOUND));
+
+            then(orderRepository).shouldHaveNoInteractions();
+            then(outboxService).shouldHaveNoInteractions();
+        }
+    }
+
+    // ── ProcessStockDeducted ──────────────────────────────────────────
+
+    @Nested
+    class ProcessStockDeducted {
+
+        @Test
+        void CREATED_상태_주문을_PAYMENT_PENDING으로_전이한다() {
+            Order order = createdOrder();
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.of(order));
+
+            orderService.processStockDeducted(
+                    messageId, KafkaTopics.STOCK_DEDUCTED, stockDeductedPayload(order.getOrderId()));
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+            then(deduplicationService).should().markProcessed(messageId, KafkaTopics.STOCK_DEDUCTED);
+        }
+
+        @Test
+        void 중복_메시지면_주문_조회_없이_스킵한다() {
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(true);
+
+            orderService.processStockDeducted(
+                    messageId, KafkaTopics.STOCK_DEDUCTED, stockDeductedPayload(UUID.randomUUID()));
+
+            then(orderRepository).shouldHaveNoInteractions();
+            then(deduplicationService).should(never()).markProcessed(messageId, KafkaTopics.STOCK_DEDUCTED);
+        }
+
+        @Test
+        void 이미_PAYMENT_PENDING이면_멱등_스킵하고_markProcessed를_호출한다() {
+            Order order = paymentPendingOrder();
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.of(order));
+
+            orderService.processStockDeducted(
+                    messageId, KafkaTopics.STOCK_DEDUCTED, stockDeductedPayload(order.getOrderId()));
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+            then(deduplicationService).should().markProcessed(messageId, KafkaTopics.STOCK_DEDUCTED);
+        }
+
+        @Test
+        void CANCELLED_상태면_정책적_스킵하고_markProcessed를_호출한다() {
+            Order order = cancelledOrder();
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.of(order));
+
+            orderService.processStockDeducted(
+                    messageId, KafkaTopics.STOCK_DEDUCTED, stockDeductedPayload(order.getOrderId()));
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+            then(deduplicationService).should().markProcessed(messageId, KafkaTopics.STOCK_DEDUCTED);
+        }
+
+        @Test
+        void FAILED_상태면_정책적_스킵하고_markProcessed를_호출한다() {
+            Order order = failedOrder();
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.of(order));
+
+            orderService.processStockDeducted(
+                    messageId, KafkaTopics.STOCK_DEDUCTED, stockDeductedPayload(order.getOrderId()));
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.FAILED);
+            then(deduplicationService).should().markProcessed(messageId, KafkaTopics.STOCK_DEDUCTED);
+        }
+
+        @Test
+        void PAID_상태면_이상_상태_예외를_던진다() {
+            Order order = paidOrder();
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> orderService.processStockDeducted(
+                    messageId, KafkaTopics.STOCK_DEDUCTED, stockDeductedPayload(order.getOrderId())))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("PAID");
+
+            then(deduplicationService).should(never()).markProcessed(messageId, KafkaTopics.STOCK_DEDUCTED);
+        }
+
+        @Test
+        void 주문이_없으면_BusinessException을_던진다() {
+            UUID orderId = UUID.randomUUID();
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+            given(orderRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> orderService.processStockDeducted(
+                    messageId, KafkaTopics.STOCK_DEDUCTED, stockDeductedPayload(orderId)))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    // ── ProcessStockFailed ────────────────────────────────────────────
+
+    @Nested
+    class ProcessStockFailed {
+
+        @Test
+        void CREATED_상태_주문을_FAILED로_전이한다() {
+            Order order = createdOrder();
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.of(order));
+
+            orderService.processStockFailed(
+                    messageId, KafkaTopics.STOCK_FAILED, stockFailedPayload(order.getOrderId()));
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.FAILED);
+            then(deduplicationService).should().markProcessed(messageId, KafkaTopics.STOCK_FAILED);
+        }
+
+        @Test
+        void 중복_메시지면_주문_조회_없이_스킵한다() {
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(true);
+
+            orderService.processStockFailed(
+                    messageId, KafkaTopics.STOCK_FAILED, stockFailedPayload(UUID.randomUUID()));
+
+            then(orderRepository).shouldHaveNoInteractions();
+            then(deduplicationService).should(never()).markProcessed(messageId, KafkaTopics.STOCK_FAILED);
+        }
+
+        @Test
+        void 이미_FAILED면_멱등_스킵하고_markProcessed를_호출한다() {
+            Order order = failedOrder();
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.of(order));
+
+            orderService.processStockFailed(
+                    messageId, KafkaTopics.STOCK_FAILED, stockFailedPayload(order.getOrderId()));
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.FAILED);
+            then(deduplicationService).should().markProcessed(messageId, KafkaTopics.STOCK_FAILED);
+        }
+
+        @Test
+        void CANCELLED_상태면_정책적_스킵하고_markProcessed를_호출한다() {
+            Order order = cancelledOrder();
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.of(order));
+
+            orderService.processStockFailed(
+                    messageId, KafkaTopics.STOCK_FAILED, stockFailedPayload(order.getOrderId()));
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+            then(deduplicationService).should().markProcessed(messageId, KafkaTopics.STOCK_FAILED);
+        }
+
+        @Test
+        void PAYMENT_PENDING_상태면_이상_상태_예외를_던진다() {
+            Order order = paymentPendingOrder();
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> orderService.processStockFailed(
+                    messageId, KafkaTopics.STOCK_FAILED, stockFailedPayload(order.getOrderId())))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("PAYMENT_PENDING");
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+            then(deduplicationService).should(never()).markProcessed(messageId, KafkaTopics.STOCK_FAILED);
+        }
+
+        @Test
+        void PAID_상태면_이상_상태_예외를_던진다() {
+            Order order = paidOrder();
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> orderService.processStockFailed(
+                    messageId, KafkaTopics.STOCK_FAILED, stockFailedPayload(order.getOrderId())))
+                    .isInstanceOf(IllegalStateException.class);
+
+            then(deduplicationService).should(never()).markProcessed(messageId, KafkaTopics.STOCK_FAILED);
+        }
+
+        @Test
+        void 주문이_없으면_BusinessException을_던진다() {
+            UUID orderId = UUID.randomUUID();
+            UUID messageId = UUID.randomUUID();
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+            given(orderRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> orderService.processStockFailed(
+                    messageId, KafkaTopics.STOCK_FAILED, stockFailedPayload(orderId)))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/order/infrastructure/kafka/StockEventConsumerTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/order/infrastructure/kafka/StockEventConsumerTest.java
@@ -71,7 +71,10 @@ class StockEventConsumerTest {
             UUID messageId = UUID.randomUUID();
             ConsumerRecord<String, String> record =
                     recordWith(KafkaTopics.STOCK_DEDUCTED, messageId, "{}");
-            willThrow(new DataIntegrityViolationException("duplicate key"))
+            org.hibernate.exception.ConstraintViolationException hibernateCause =
+                    new org.hibernate.exception.ConstraintViolationException(
+                            "duplicate key", null, "uk_processed_message_message_id_topic");
+            willThrow(new DataIntegrityViolationException("duplicate key", hibernateCause))
                     .given(orderService).processStockDeducted(any(), any(), any());
 
             // when
@@ -124,7 +127,10 @@ class StockEventConsumerTest {
             UUID messageId = UUID.randomUUID();
             ConsumerRecord<String, String> record =
                     recordWith(KafkaTopics.STOCK_FAILED, messageId, "{}");
-            willThrow(new DataIntegrityViolationException("duplicate key"))
+            org.hibernate.exception.ConstraintViolationException hibernateCause =
+                    new org.hibernate.exception.ConstraintViolationException(
+                            "duplicate key", null, "uk_processed_message_message_id_topic");
+            willThrow(new DataIntegrityViolationException("duplicate key", hibernateCause))
                     .given(orderService).processStockFailed(any(), any(), any());
 
             // when

--- a/commerce/src/test/java/com/devticket/commerce/order/infrastructure/kafka/StockEventConsumerTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/order/infrastructure/kafka/StockEventConsumerTest.java
@@ -1,0 +1,150 @@
+package com.devticket.commerce.order.infrastructure.kafka;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.order.application.service.OrderService;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class StockEventConsumerTest {
+
+    @Mock private OrderService orderService;
+    @Mock private Acknowledgment ack;
+
+    @InjectMocks private StockEventConsumer consumer;
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────
+
+    private ConsumerRecord<String, String> recordWith(String topic, UUID messageId, String payload) {
+        ConsumerRecord<String, String> record = new ConsumerRecord<>(topic, 0, 0L, null, payload);
+        record.headers().add(new RecordHeader(
+                "X-Message-Id", messageId.toString().getBytes(StandardCharsets.UTF_8)));
+        return record;
+    }
+
+    private ConsumerRecord<String, String> recordWithoutHeader(String topic) {
+        return new ConsumerRecord<>(topic, 0, 0L, null, "{}");
+    }
+
+    // ── consumeStockDeducted ──────────────────────────────────────────
+
+    @Nested
+    class ConsumeStockDeducted {
+
+        @Test
+        void 정상_처리시_서비스를_호출하고_ACK한다() {
+            // given
+            UUID messageId = UUID.randomUUID();
+            String payload = "{\"orderId\":\"" + UUID.randomUUID() + "\"}";
+            ConsumerRecord<String, String> record =
+                    recordWith(KafkaTopics.STOCK_DEDUCTED, messageId, payload);
+
+            // when
+            consumer.consumeStockDeducted(record, ack);
+
+            // then
+            then(orderService).should()
+                    .processStockDeducted(messageId, KafkaTopics.STOCK_DEDUCTED, payload);
+            then(ack).should().acknowledge();
+        }
+
+        @Test
+        void DataIntegrityViolation_발생시에도_ACK를_호출한다() {
+            // given — processed_message UNIQUE 충돌 시나리오
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record =
+                    recordWith(KafkaTopics.STOCK_DEDUCTED, messageId, "{}");
+            willThrow(new DataIntegrityViolationException("duplicate key"))
+                    .given(orderService).processStockDeducted(any(), any(), any());
+
+            // when
+            consumer.consumeStockDeducted(record, ack);
+
+            // then
+            then(ack).should().acknowledge();
+        }
+
+        @Test
+        void X_Message_Id_헤더가_없으면_예외를_던지고_ACK하지_않는다() {
+            // given — Outbox Producer가 헤더를 누락한 케이스
+            ConsumerRecord<String, String> record = recordWithoutHeader(KafkaTopics.STOCK_DEDUCTED);
+
+            // when & then
+            assertThatThrownBy(() -> consumer.consumeStockDeducted(record, ack))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("X-Message-Id");
+
+            then(ack).should(never()).acknowledge();
+            then(orderService).shouldHaveNoInteractions();
+        }
+    }
+
+    // ── consumeStockFailed ────────────────────────────────────────────
+
+    @Nested
+    class ConsumeStockFailed {
+
+        @Test
+        void 정상_처리시_서비스를_호출하고_ACK한다() {
+            // given
+            UUID messageId = UUID.randomUUID();
+            String payload = "{\"orderId\":\"" + UUID.randomUUID() + "\"}";
+            ConsumerRecord<String, String> record =
+                    recordWith(KafkaTopics.STOCK_FAILED, messageId, payload);
+
+            // when
+            consumer.consumeStockFailed(record, ack);
+
+            // then
+            then(orderService).should()
+                    .processStockFailed(messageId, KafkaTopics.STOCK_FAILED, payload);
+            then(ack).should().acknowledge();
+        }
+
+        @Test
+        void DataIntegrityViolation_발생시에도_ACK를_호출한다() {
+            // given — processed_message UNIQUE 충돌 시나리오
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record =
+                    recordWith(KafkaTopics.STOCK_FAILED, messageId, "{}");
+            willThrow(new DataIntegrityViolationException("duplicate key"))
+                    .given(orderService).processStockFailed(any(), any(), any());
+
+            // when
+            consumer.consumeStockFailed(record, ack);
+
+            // then
+            then(ack).should().acknowledge();
+        }
+
+        @Test
+        void X_Message_Id_헤더가_없으면_예외를_던지고_ACK하지_않는다() {
+            // given
+            ConsumerRecord<String, String> record = recordWithoutHeader(KafkaTopics.STOCK_FAILED);
+
+            // when & then
+            assertThatThrownBy(() -> consumer.consumeStockFailed(record, ack))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("X-Message-Id");
+
+            then(ack).should(never()).acknowledge();
+            then(orderService).shouldHaveNoInteractions();
+        }
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/order/infrastructure/kafka/StockEventConsumerTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/order/infrastructure/kafka/StockEventConsumerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.never;
 
 import com.devticket.commerce.common.messaging.KafkaTopics;
 import com.devticket.commerce.order.application.service.OrderService;
+import com.devticket.commerce.order.presentation.consumer.StockEventConsumer;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.apache.kafka.clients.consumer.ConsumerRecord;


### PR DESCRIPTION
## 변경 배경

기존 주문 생성은 동기 API로 재고를 선차감한 뒤 Order를 생성하는 방식이었습니다.
이 방식은 재고 차감 후 Order 생성 실패 시 보상 트랜잭션을 try-catch로 직접 처리해야 했고,
동시 요청에 대한 중복 주문 방어 로직이 없었습니다.

이번 PR에서는 주문 생성을 Kafka 기반 비동기 Saga 패턴으로 전환하고,
cartHash 기반 중복 주문 방지와 비관적 락을 통한 동시 요청 직렬화를 도입합니다.

---

## 주요 변경 사항

### 1. 주문 생성 흐름 전환 (동기 → Kafka Saga)

**기존 흐름**
```
주문 요청 → Event API 재고 선차감 → Order 생성 → 실패 시 try-catch로 재고 복구
```

**변경 후 흐름**
```
주문 요청 → Order 생성(CREATED) → order.created 발행(Outbox)
         → stock.deducted 수신 → PAYMENT_PENDING 전이
         → stock.failed 수신  → FAILED 전이
```

- `OutboxService`를 통해 `order.created` 이벤트를 발행하여 Event 서비스가 재고를 차감하도록 위임
- 재고 결과를 `stock.deducted` / `stock.failed` Kafka 이벤트로 수신하여 상태 전이 처리
- `StockEventConsumer` 추가: `stock.deducted`, `stock.failed` 토픽 구독

### 2. cartHash 기반 중복 주문 방지

- 선택한 CartItem의 `(eventId, quantity)` 조합을 eventId 기준 정렬 후 SHA-256으로 해시
- 같은 내용의 처리 중 주문(CREATED / PAYMENT_PENDING)이 존재하면 새 주문 생성 없이 기존 주문 반환
- `Order` 테이블에 `cart_hash` 컬럼 추가 및 `(user_id, cart_hash)` 복합 인덱스 추가
- `CartHashUtil` 유틸 클래스 추가

### 3. CartItem 비관적 락으로 동시 요청 직렬화

- `findAllByCartItemIdWithLock`: `PESSIMISTIC_WRITE` 락 + `ORDER BY cartItemId` 정렬
- 부분 겹침 요청(A,B / B,C) 간 데드락 방지를 위해 락 획득 순서 고정
- 같은 cartItemIds의 동시 요청이 직렬화되므로 cartHash 중복 체크의 레이스 컨디션 차단

### 4. Order 상태 머신 정비

- `canTransitionTo(OrderStatus target)` 도입: 모든 상태 전이를 단일 메서드로 관리

| 현재 상태 | 허용 전이 |
|---|---|
| CREATED | PAYMENT_PENDING, FAILED |
| PAYMENT_PENDING | PAID, FAILED, CANCELLED |
| PAID | CANCELLED |
| FAILED / CANCELLED | 없음 (종단 상태) |

- 상태 전이 메서드 정비: `pendingPayment()`, `failByStock()`, `expire()`, `failPayment()`, `cancel()` 모두 `canTransitionTo` 기반 가드로 통일
- Order 초기 상태를 `PAYMENT_PENDING` → `CREATED`로 수정
- 낙관적 락(`@Version`) 추가: Kafka Consumer와 스케줄러의 동시 상태 전이 충돌 방어

### 5. Kafka Consumer 멱등 처리

`processStockDeducted` / `processStockFailed` 모두 동일한 3분류 패턴 적용:

1. **멱등 스킵**: 이미 목표 상태 → markProcessed 후 반환
2. **정책적 스킵**: 만료 또는 사용자 취소로 종단 상태 도달 → markProcessed 후 반환
3. **이상 상태**: 설명 불가능한 전이 → 예외 throw → Kafka 재시도 → DLT

### 6. 입력 검증 보완

- `CartOrderRequest`에 `@NotEmpty` 추가
- `OrderController`에 `@Valid` 추가

---

## 파일 변경 목록

| 파일 | 변경 유형 | 내용 |
|---|---|---|
| `Order.java` | 수정 | cartHash, version 필드 추가, canTransitionTo, 상태 전이 메서드 정비 |
| `OrderService.java` | 수정 | createOrderByCart Saga 전환, Kafka consumer 핸들러 추가 |
| `OrderErrorCode.java` | 수정 | INVALID_ORDER_STATUS_TRANSITION 추가 |
| `CartErrorCode.java` | 수정 | CART_NOT_FOUND, CART_ITEM_NOT_FOUND, DUPLICATE_CART_ITEM_ID 추가 |
| `CartOrderRequest.java` | 수정 | @NotEmpty 추가 |
| `OrderController.java` | 수정 | @Valid 추가 |
| `CartItemRepository.java` | 수정 | findAllByCartItemIdWithLock 추가 |
| `CartItemJpaRepository.java` | 수정 | 비관적 락 쿼리 추가 |
| `CartItemRepositoryAdapter.java` | 수정 | findAllByCartItemIdWithLock 위임 추가 |
| `OrderRepository.java` | 수정 | findActiveOrder 추가 |
| `OrderJpaRepository.java` | 수정 | findActiveOrder JPQL 쿼리 추가 |
| `OrderRepositoryAdapter.java` | 수정 | findActiveOrder 위임 추가 |
| `CartHashUtil.java` | 추가 | SHA-256 cartHash 계산 유틸 |
| `StockEventConsumer.java` | 추가 | stock.deducted, stock.failed Kafka consumer |
| `OrderServiceTest.java` | 추가 | 주문 생성 / 중복 주문 / Kafka consumer 통합 테스트 |
| `OrderServiceCreateOrderTest.java` | 삭제 | OrderServiceTest로 통합 |
| `OrderServiceStockEventTest.java` | 삭제 | OrderServiceTest로 통합 |

---

## 테스트

- `신규_주문_생성`: 정상 흐름, 금액 계산, Outbox 저장 검증
- `중복_주문_반환`: CREATED / PAYMENT_PENDING 활성 주문 존재 시 기존 주문 반환 검증
- `예외_케이스`: 장바구니 없음, 중복 cartItemId, CartItem 미존재, 소유자 불일치
- `ProcessStockDeducted`: 정상 전이, 중복 메시지 스킵, 멱등 스킵, 정책적 스킵, 이상 상태 예외
- `ProcessStockFailed`: 정상 전이, 중복 메시지 스킵, 멱등 스킵, 정책적 스킵, 이상 상태 예외