### PR TITLE
[Commerce] feat: payment 결과 Consumer + 주문 만료 스케줄러

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/common/enums/PaymentMethod.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/enums/PaymentMethod.java
@@ -1,5 +1,5 @@
 package com.devticket.commerce.common.enums;
 
 public enum PaymentMethod {
-    WALLET, PG
+    WALLET, PG, WALLET_PG
 }

--- a/commerce/src/main/java/com/devticket/commerce/common/messaging/event/TicketIssueFailedEvent.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/messaging/event/TicketIssueFailedEvent.java
@@ -1,15 +1,20 @@
 package com.devticket.commerce.common.messaging.event;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 public record TicketIssueFailedEvent(
         UUID orderId,
         UUID userId,
-        UUID eventId,
         UUID paymentId,
-        int quantity,
+        List<FailedItem> items,
         int totalAmount,
         String reason,
         Instant timestamp
-) {}
+) {
+    public record FailedItem(
+            UUID eventId,
+            int quantity
+    ) {}
+}

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderExpirationCancelService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderExpirationCancelService.java
@@ -1,0 +1,59 @@
+package com.devticket.commerce.order.application.service;
+
+import com.devticket.commerce.common.enums.OrderStatus;
+import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 주문 만료 취소 처리 — OrderExpirationScheduler의 per-Order 트랜잭션을 담당.
+ *
+ * <p>스케줄러와 별도 빈으로 분리한 이유:
+ * {@code OrderExpirationScheduler} 내부에서 같은 클래스 메서드를 직접 호출하면
+ * Spring AOP 프록시가 우회되어 {@code @Transactional}이 적용되지 않음.
+ * 별도 빈 주입 방식으로 호출해야 프록시를 통해 트랜잭션이 열림.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderExpirationCancelService {
+
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public void cancelOrder(Order order) {
+        try {
+            if (!order.canTransitionTo(OrderStatus.CANCELLED)) {
+                log.info("[OrderExpiration] 스킵 — orderId={}, 현재상태={}",
+                        order.getOrderId(), order.getStatus());
+                return;
+            }
+
+            order.cancel();
+            orderRepository.save(order);
+
+            log.info("[OrderExpiration] 만료 처리 완료 — orderId={}", order.getOrderId());
+        } catch (ObjectOptimisticLockingFailureException e) {
+            // Consumer와 동시 충돌 — 재조회 후 판단
+            Order refreshed = orderRepository.findByOrderId(order.getOrderId()).orElse(null);
+            if (refreshed == null) {
+                log.warn("[OrderExpiration] 재조회 실패 — orderId={}", order.getOrderId());
+                return;
+            }
+
+            if (refreshed.getStatus() == OrderStatus.PAID
+                    || refreshed.getStatus() == OrderStatus.FAILED
+                    || refreshed.getStatus() == OrderStatus.CANCELLED) {
+                log.info("[OrderExpiration] 충돌 후 스킵 — orderId={}, 현재상태={}",
+                        refreshed.getOrderId(), refreshed.getStatus());
+            } else {
+                log.warn("[OrderExpiration] 충돌 후 재시도 필요 — orderId={}, 현재상태={}",
+                        refreshed.getOrderId(), refreshed.getStatus());
+            }
+        }
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderExpirationCancelService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderExpirationCancelService.java
@@ -1,8 +1,15 @@
 package com.devticket.commerce.order.application.service;
 
 import com.devticket.commerce.common.enums.OrderStatus;
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.common.messaging.event.PaymentFailedEvent;
+import com.devticket.commerce.common.outbox.OutboxService;
 import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.model.OrderItem;
+import com.devticket.commerce.order.domain.repository.OrderItemRepository;
 import com.devticket.commerce.order.domain.repository.OrderRepository;
+import java.time.Instant;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -23,6 +30,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderExpirationCancelService {
 
     private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final OutboxService outboxService;
 
     @Transactional
     public void cancelOrder(Order order) {
@@ -36,7 +45,28 @@ public class OrderExpirationCancelService {
             order.cancel();
             orderRepository.save(order);
 
-            log.info("[OrderExpiration] 만료 처리 완료 — orderId={}", order.getOrderId());
+            // 재고 복구 트리거 — Event 모듈 PaymentFailedConsumer가 수신하여 DEDUCTED → RESTORED 전이
+            // 근거: docs/kafka-impl-plan.md §주문 만료 스케줄러, docs/kafka-idempotency-guide.md §10
+            List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(order.getId());
+            PaymentFailedEvent event = new PaymentFailedEvent(
+                    order.getOrderId(),
+                    order.getUserId(),
+                    orderItems.stream()
+                            .map(item -> new PaymentFailedEvent.OrderItem(item.getEventId(), item.getQuantity()))
+                            .toList(),
+                    "ORDER_TIMEOUT",
+                    Instant.now()
+            );
+            outboxService.save(
+                    order.getOrderId().toString(),
+                    order.getOrderId().toString(),
+                    "PaymentFailed",
+                    KafkaTopics.PAYMENT_FAILED,
+                    event
+            );
+
+            log.info("[OrderExpiration] 만료 처리 완료 — orderId={}, itemCount={}",
+                    order.getOrderId(), orderItems.size());
         } catch (ObjectOptimisticLockingFailureException e) {
             // Consumer와 동시 충돌 — 재조회 후 판단
             Order refreshed = orderRepository.findByOrderId(order.getOrderId()).orElse(null);

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -1,10 +1,18 @@
 package com.devticket.commerce.order.application.service;
 
 import com.devticket.commerce.cart.domain.exception.EventErrorCode;
+import com.devticket.commerce.cart.domain.model.Cart;
 import com.devticket.commerce.cart.domain.model.CartItem;
 import com.devticket.commerce.cart.domain.repository.CartItemRepository;
+import com.devticket.commerce.cart.domain.repository.CartRepository;
 import com.devticket.commerce.common.enums.OrderStatus;
 import com.devticket.commerce.common.exception.BusinessException;
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.common.messaging.MessageDeduplicationService;
+import com.devticket.commerce.common.messaging.event.PaymentCompletedEvent;
+import com.devticket.commerce.common.messaging.event.PaymentFailedEvent;
+import com.devticket.commerce.common.messaging.event.TicketIssueFailedEvent;
+import com.devticket.commerce.common.outbox.OutboxService;
 import com.devticket.commerce.order.application.usecase.OrderUsecase;
 import com.devticket.commerce.order.domain.exception.OrderErrorCode;
 import com.devticket.commerce.order.domain.model.Order;
@@ -31,8 +39,13 @@ import com.devticket.commerce.ticket.domain.model.Ticket;
 import com.devticket.commerce.ticket.domain.repository.TicketRepository;
 import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalEventInfoResponse;
 import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
+import java.util.stream.IntStream;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -50,10 +63,14 @@ public class OrderService implements OrderUsecase {
 
     private final OrderToEventClient orderToEventClient;
     private final CartItemRepository cartItemRepository;
+    private final CartRepository cartRepository;
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final TicketUsecase ticketUsecase;
     private final TicketRepository ticketRepository;
+    private final MessageDeduplicationService deduplicationService;
+    private final OutboxService outboxService;
+    private final ObjectMapper objectMapper;
 
     // ==== Public Methods (Main Flow) ====================================
 
@@ -75,10 +92,6 @@ public class OrderService implements OrderUsecase {
             orderRepository.save(order);
             //OrderItem생성
             List<OrderItem> savedOrderItems = createOrderItem(order.getId(), userId, cartItems, eventResults);
-            //주문완료건 장바구니에서 삭제처리
-            if (!cartItems.isEmpty()) {
-                cartItemRepository.deleteAllInBatch(cartItems);
-            }
             //응답데이터 변환
             Map<UUID, String> eventTitles = eventResults.stream()
                 .collect(Collectors.toMap(
@@ -306,6 +319,172 @@ public class OrderService implements OrderUsecase {
 //        List<OrderItem> orderItems = orderItemRepository.findAllByEventId(eventId);
 //        return InternalEventOrdersResponse.from(eventId, orderItems);
 //    }
+
+    // ==== Kafka Consumer 처리 ==========================================
+
+    @Override
+    @Transactional
+    public void processPaymentCompleted(UUID messageId, String topic, String payload) {
+        // Step 1. Dedup 체크
+        if (deduplicationService.isDuplicate(messageId)) {
+            return;
+        }
+
+        PaymentCompletedEvent event = deserialize(payload, PaymentCompletedEvent.class);
+
+        // Step 2. 상태 전이 유효성 검증 (3분류)
+        Order order = orderRepository.findByOrderId(event.orderId())
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.canTransitionTo(OrderStatus.PAID)) {
+            if (order.getStatus() == OrderStatus.PAID) {
+                // ① 멱등 스킵: 이미 목표 상태
+                deduplicationService.markProcessed(messageId, topic);
+                return;
+            }
+            if (order.getStatus() == OrderStatus.CANCELLED || order.getStatus() == OrderStatus.FAILED) {
+                // ② 정책적 스킵: 보상/만료가 먼저 처리됨
+                log.warn("[processPaymentCompleted] 정책적 스킵 — orderId={}, 현재상태={}",
+                        event.orderId(), order.getStatus());
+                deduplicationService.markProcessed(messageId, topic);
+                return;
+            }
+            // ③ 이상 상태 → throw → 재시도 → DLT
+            throw new IllegalStateException(
+                    "Invalid transition: " + order.getStatus() + " -> PAID, orderId=" + event.orderId());
+        }
+
+        // Step 3. 비즈니스 로직
+        order.completePayment();
+
+        // 티켓 발급 (직접 호출 — @Transactional 프록시 경유 시 rollback-only 오염 방지)
+        List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(order.getId());
+        if (orderItems.isEmpty()) {
+            // 영구 실패: OrderItem 없음 → Order CANCELLED + ticket.issue-failed Outbox 발행
+            log.error("[processPaymentCompleted] 티켓 발급 실패 — OrderItem 없음. orderId={}", event.orderId());
+            order.cancel();
+
+            List<TicketIssueFailedEvent.FailedItem> failedItems = List.of();
+
+            TicketIssueFailedEvent failedEvent = new TicketIssueFailedEvent(
+                    event.orderId(),
+                    event.userId(),
+                    event.paymentId(),
+                    failedItems,
+                    event.totalAmount(),
+                    "OrderItem not found",
+                    Instant.now()
+            );
+
+            outboxService.save(
+                    event.orderId().toString(),
+                    event.orderId().toString(),
+                    "TICKET_ISSUE_FAILED",
+                    KafkaTopics.TICKET_ISSUE_FAILED,
+                    failedEvent
+            );
+
+            deduplicationService.markProcessed(messageId, topic);
+            return;
+        }
+
+        try {
+            List<Ticket> tickets = orderItems.stream()
+                    .flatMap(item -> IntStream.range(0, item.getQuantity())
+                            .mapToObj(i -> Ticket.create(item.getOrderItemId(), item.getUserId(), item.getEventId())))
+                    .collect(Collectors.toList());
+            ticketRepository.saveAll(tickets);
+        } catch (Exception e) {
+            // 영구 실패: 티켓 발급 실패 → Order CANCELLED + ticket.issue-failed Outbox 발행
+            log.error("[processPaymentCompleted] 티켓 발급 실패 — orderId={}, error={}",
+                    event.orderId(), e.getMessage());
+            order.cancel();
+
+            List<TicketIssueFailedEvent.FailedItem> failedItems = orderItems.stream()
+                    .map(item -> new TicketIssueFailedEvent.FailedItem(item.getEventId(), item.getQuantity()))
+                    .toList();
+
+            TicketIssueFailedEvent failedEvent = new TicketIssueFailedEvent(
+                    event.orderId(),
+                    event.userId(),
+                    event.paymentId(),
+                    failedItems,
+                    event.totalAmount(),
+                    e.getMessage(),
+                    Instant.now()
+            );
+
+            outboxService.save(
+                    event.orderId().toString(),
+                    event.orderId().toString(),
+                    "TICKET_ISSUE_FAILED",
+                    KafkaTopics.TICKET_ISSUE_FAILED,
+                    failedEvent
+            );
+
+            deduplicationService.markProcessed(messageId, topic);
+            return;
+        }
+
+        // 장바구니 비우기 (카트가 없으면 무시)
+        Optional<Cart> cart = cartRepository.findByUserId(event.userId());
+        cart.ifPresent(c -> {
+            List<CartItem> cartItems = cartItemRepository.findAllByCartId(c.getId());
+            if (!cartItems.isEmpty()) {
+                cartItemRepository.deleteAllInBatch(cartItems);
+            }
+        });
+
+        // Step 4. Dedup 기록 (같은 트랜잭션)
+        deduplicationService.markProcessed(messageId, topic);
+    }
+
+    @Override
+    @Transactional
+    public void processPaymentFailed(UUID messageId, String topic, String payload) {
+        // Step 1. Dedup 체크
+        if (deduplicationService.isDuplicate(messageId)) {
+            return;
+        }
+
+        PaymentFailedEvent event = deserialize(payload, PaymentFailedEvent.class);
+
+        // Step 2. 상태 전이 유효성 검증 (3분류)
+        Order order = orderRepository.findByOrderId(event.orderId())
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.canTransitionTo(OrderStatus.FAILED)) {
+            if (order.getStatus() == OrderStatus.FAILED) {
+                // ① 멱등 스킵: 이미 목표 상태
+                deduplicationService.markProcessed(messageId, topic);
+                return;
+            }
+            if (order.getStatus() == OrderStatus.CANCELLED) {
+                // ② 정책적 스킵
+                log.warn("[processPaymentFailed] 정책적 스킵 — orderId={}, 현재상태={}",
+                        event.orderId(), order.getStatus());
+                deduplicationService.markProcessed(messageId, topic);
+                return;
+            }
+            // ③ 이상 상태 → throw → 재시도 → DLT
+            throw new IllegalStateException(
+                    "Invalid transition: " + order.getStatus() + " -> FAILED, orderId=" + event.orderId());
+        }
+
+        // Step 3. 비즈니스 로직
+        order.failPayment();
+
+        // Step 4. Dedup 기록 (같은 트랜잭션)
+        deduplicationService.markProcessed(messageId, topic);
+    }
+
+    private <T> T deserialize(String payload, Class<T> clazz) {
+        try {
+            return objectMapper.readValue(payload, clazz);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Kafka 메시지 역직렬화 실패: " + clazz.getSimpleName(), e);
+        }
+    }
 
     // ==== Private Helpers (Logic & Validation) ==========================
 

--- a/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
@@ -42,5 +42,10 @@ public interface OrderUsecase {
     // 결제 전 주문 취소
     OrderCancelResponse cancelOrder(UUID userId, UUID orderId);
 
+    // Kafka Consumer 처리용
+    void processPaymentCompleted(UUID messageId, String topic, String payload);
+
+    void processPaymentFailed(UUID messageId, String topic, String payload);
+
 }
 

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/model/Order.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/model/Order.java
@@ -118,8 +118,10 @@ public class Order extends BaseEntity {
 
     //---- 도메인 비즈니스 메서드 ------------------------------
 
-    //총 주문 금액 업데이트
-    //OrderItem의 구매수량이 변경되면 Order의 총 주문금액도 변경됩니다.
+    // ⚠️ 사용 금지 — OrderExpirationScheduler 만료 타이머가 BaseEntity.updated_at 에 의존함.
+    // PAYMENT_PENDING 상태에서 이 메서드를 호출하면 updated_at 이 갱신되어 만료 타이머가 리셋됨.
+    // 금액 변경이 필요하면 주문 재생성 경로 사용. 관련: docs/kafka-impl-plan.md §주문 만료 스케줄러
+    @Deprecated(forRemoval = true)
     public void updateTotalAmount(int newTotalAmount) {
         if (newTotalAmount < 0) {
             throw new BusinessException(OrderErrorCode.INVALID_ORDER_AMOUNT);

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/model/Order.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/model/Order.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
@@ -33,6 +34,9 @@ public class Order extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
+
+    @Version
+    Long version;
 
     @Column(name = "order_id", unique = true)
     UUID orderId;
@@ -155,6 +159,19 @@ public class Order extends BaseEntity {
             throw new BusinessException(OrderErrorCode.ALREADY_PAID_ORDER);
         }
         this.status = OrderStatus.FAILED;
+    }
+
+    //---- 상태 전이 검증 ------------------------------
+
+    public boolean canTransitionTo(OrderStatus target) {
+        return switch (this.status) {
+            case CREATED         -> target == OrderStatus.PAYMENT_PENDING;
+            case PAYMENT_PENDING -> target == OrderStatus.PAID
+                                 || target == OrderStatus.FAILED
+                                 || target == OrderStatus.CANCELLED;
+            case PAID            -> target == OrderStatus.CANCELLED;
+            default              -> false;
+        };
     }
 
     //-------------------

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/repository/OrderRepository.java
@@ -22,4 +22,6 @@ public interface OrderRepository {
 
     Page<Order> findAllByUserId(UUID userId, OrderStatus status, Pageable pageable);
 
+    List<Order> findExpiredOrders(OrderStatus status, int expirationMinutes);
+
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderJpaRepository.java
@@ -2,6 +2,7 @@ package com.devticket.commerce.order.infrastructure.persistence;
 
 import com.devticket.commerce.common.enums.OrderStatus;
 import com.devticket.commerce.order.domain.model.Order;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -22,5 +23,12 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
     Page<Order> findAllByUserId(UUID userId, Pageable pageable);
 
     Page<Order> findAllByUserIdAndStatus(UUID userId, OrderStatus status, Pageable pageable);
+
+    @org.springframework.data.jpa.repository.Query(
+            value = "SELECT * FROM commerce.\"order\" WHERE status = :status AND created_at < NOW() - CAST(:minutes || ' minutes' AS INTERVAL)",
+            nativeQuery = true)
+    List<Order> findExpiredOrders(
+            @org.springframework.data.repository.query.Param("status") String status,
+            @org.springframework.data.repository.query.Param("minutes") int minutes);
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderJpaRepository.java
@@ -26,12 +26,15 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
 
     Page<Order> findAllByUserIdAndStatus(UUID userId, OrderStatus status, Pageable pageable);
 
-    @Query(
-            value = "SELECT * FROM commerce.\"order\" WHERE status = :status AND created_at < NOW() - CAST(:minutes || ' minutes' AS INTERVAL)",
-            nativeQuery = true)
+    // 만료 조건: status + updatedAt < threshold
+    // PAYMENT_PENDING 진입 시각 기준 — BaseEntity.updated_at (@LastModifiedDate) 재활용
+    // 이유: created_at 기준은 CREATED 진입 시각이라 stock.deducted 지연 시 결제 시간 단축 문제 발생 (PR #426 Codex P2)
+    // 가정: PAYMENT_PENDING 상태에서 Order 엔티티 mutation 경로 없음 (Order.updateTotalAmount() @Deprecated)
+    // 근거: docs/kafka-impl-plan.md §주문 만료 스케줄러
+    @Query("SELECT o FROM Order o WHERE o.status = :status AND o.updatedAt < :threshold")
     List<Order> findExpiredOrders(
-            @Param("status") String status,
-            @Param("minutes") int minutes);
+            @Param("status") OrderStatus status,
+            @Param("threshold") LocalDateTime threshold);
 
     @Query("""
             SELECT o FROM Order o

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderRepositoryAdapter.java
@@ -50,4 +50,9 @@ public class OrderRepositoryAdapter implements OrderRepository {
         return orderJpaRepository.findAllByUserIdAndStatus(userId, status, pageable);
     }
 
+    @Override
+    public List<Order> findExpiredOrders(OrderStatus status, int expirationMinutes) {
+        return orderJpaRepository.findExpiredOrders(status.name(), expirationMinutes);
+    }
+
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/persistence/OrderRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.devticket.commerce.order.infrastructure.persistence;
 import com.devticket.commerce.common.enums.OrderStatus;
 import com.devticket.commerce.order.domain.model.Order;
 import com.devticket.commerce.order.domain.repository.OrderRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -52,7 +53,8 @@ public class OrderRepositoryAdapter implements OrderRepository {
 
     @Override
     public List<Order> findExpiredOrders(OrderStatus status, int expirationMinutes) {
-        return orderJpaRepository.findExpiredOrders(status.name(), expirationMinutes);
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(expirationMinutes);
+        return orderJpaRepository.findExpiredOrders(status, threshold);
     }
 
     @Override

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/scheduler/OrderExpirationScheduler.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/scheduler/OrderExpirationScheduler.java
@@ -1,0 +1,40 @@
+package com.devticket.commerce.order.infrastructure.scheduler;
+
+import com.devticket.commerce.common.enums.OrderStatus;
+import com.devticket.commerce.order.application.service.OrderExpirationCancelService;
+import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.repository.OrderRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderExpirationScheduler {
+
+    private static final int EXPIRATION_MINUTES = 30;
+
+    private final OrderRepository orderRepository;
+    private final OrderExpirationCancelService cancelService;
+
+    @Scheduled(fixedDelay = 60_000)
+    @SchedulerLock(name = "order-expiration-scheduler", lockAtMostFor = "50s", lockAtLeastFor = "10s")
+    public void cancelExpiredOrders() {
+        List<Order> expiredOrders = orderRepository.findExpiredOrders(OrderStatus.PAYMENT_PENDING, EXPIRATION_MINUTES);
+
+        if (expiredOrders.isEmpty()) {
+            return;
+        }
+
+        log.info("[OrderExpiration] 만료 대상 주문: {}건", expiredOrders.size());
+
+        for (Order order : expiredOrders) {
+            // 별도 빈 호출 → Spring AOP 프록시 경유 → per-Order @Transactional 적용
+            cancelService.cancelOrder(order);
+        }
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/scheduler/OrderExpirationScheduler.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/scheduler/OrderExpirationScheduler.java
@@ -11,6 +11,25 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+/**
+ * 주문 만료 스케줄러 — PAYMENT_PENDING 상태가 30분 초과 시 CANCELLED 전이 + 재고 복구 Outbox 발행.
+ *
+ * <p>SchedulerLock 타이밍 설계:
+ * <ul>
+ *   <li>fixedDelay=60s, lockAtMostFor=2m, lockAtLeastFor=10s
+ *   <li>lockAtMostFor=2m은 fixedDelay의 2배 여유 — 만료 건수가 많아 처리가 길어져도 락 자동 해제로
+ *       인한 타 인스턴스 중복 진입 경로 축소
+ *   <li>lockAtMostFor 〈 fixedDelay 이면 A 인스턴스 처리 중 락 만료 후 B 인스턴스가 다음 스케줄에
+ *       재획득하여 중복 실행 가능 (PR #426 멘토 피드백). 2분 여유로 이 경로 차단
+ * </ul>
+ *
+ * <p>이중 실행 시 안전성 — 타이밍상 중복 실행이 발생해도 데이터 정합성 보장:
+ * <ul>
+ *   <li>Order.@Version 낙관적 락 — 한쪽만 커밋 성공, 다른 쪽은 ObjectOptimisticLockingFailureException
+ *   <li>canTransitionTo(CANCELLED) 선가드 — 이미 CANCELLED면 Outbox 발행 없이 스킵
+ *   <li>결과: payment.failed Outbox는 최대 1회만 발행 (재고 복구 이중 실행 없음)
+ * </ul>
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -22,7 +41,7 @@ public class OrderExpirationScheduler {
     private final OrderExpirationCancelService cancelService;
 
     @Scheduled(fixedDelay = 60_000)
-    @SchedulerLock(name = "order-expiration-scheduler", lockAtMostFor = "50s", lockAtLeastFor = "10s")
+    @SchedulerLock(name = "order-expiration-scheduler", lockAtMostFor = "2m", lockAtLeastFor = "10s")
     public void cancelExpiredOrders() {
         List<Order> expiredOrders = orderRepository.findExpiredOrders(OrderStatus.PAYMENT_PENDING, EXPIRATION_MINUTES);
 

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/consumer/PaymentCompletedConsumer.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/consumer/PaymentCompletedConsumer.java
@@ -1,0 +1,85 @@
+package com.devticket.commerce.order.presentation.consumer;
+
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.order.application.usecase.OrderUsecase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentCompletedConsumer {
+
+    private final OrderUsecase orderUsecase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopics.PAYMENT_COMPLETED,
+            groupId = "commerce-payment.completed"
+    )
+    public void consume(ConsumerRecord<String, String> record, Acknowledgment ack) {
+        try {
+            // X-Message-Id 헤더 우선, 없으면 본문의 messageId 필드에서 추출
+            UUID messageId = extractMessageId(record);
+            String payload = extractPayload(record.value());
+
+            try {
+                orderUsecase.processPaymentCompleted(messageId, record.topic(), payload);
+            } catch (DataIntegrityViolationException e) {
+                log.warn("[PaymentCompletedConsumer] UNIQUE 충돌 — 이미 처리된 메시지. messageId={}", messageId);
+            }
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("[PaymentCompletedConsumer] 메시지 처리 실패 — topic={}, error={}",
+                    record.topic(), e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    private UUID extractMessageId(ConsumerRecord<String, String> record) {
+        // 1. Kafka 헤더에서 추출 시도
+        Header header = record.headers().lastHeader("X-Message-Id");
+        if (header != null) {
+            try {
+                return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8));
+            } catch (IllegalArgumentException e) {
+                log.warn("[PaymentCompletedConsumer] 헤더 UUID 파싱 실패, 본문 fallback. header={}",
+                        new String(header.value(), StandardCharsets.UTF_8));
+            }
+        }
+        // 2. 본문 wrapper의 messageId 필드에서 추출 (Payment Outbox 구조 대응)
+        try {
+            JsonNode root = objectMapper.readTree(record.value());
+            JsonNode messageIdNode = root.get("messageId");
+            if (messageIdNode != null && !messageIdNode.isNull()) {
+                return UUID.fromString(messageIdNode.asText());
+            }
+        } catch (Exception e) {
+            log.warn("[PaymentCompletedConsumer] 본문에서 messageId 추출 실패", e);
+        }
+        throw new IllegalArgumentException("messageId를 추출할 수 없습니다. topic=" + record.topic());
+    }
+
+    private String extractPayload(String value) {
+        // Outbox wrapper 구조인 경우 payload 필드 추출, 아니면 원본 그대로 반환
+        try {
+            JsonNode root = objectMapper.readTree(value);
+            JsonNode payloadNode = root.get("payload");
+            if (payloadNode != null && !payloadNode.isNull()) {
+                return payloadNode.asText();
+            }
+        } catch (Exception ignored) {
+        }
+        return value;
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/consumer/PaymentCompletedConsumer.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/consumer/PaymentCompletedConsumer.java
@@ -15,6 +15,18 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
+/**
+ * payment.completed Consumer — Order PAYMENT_PENDING → PAID 전이 + 티켓 발급 + 장바구니 삭제.
+ *
+ * <p>예외 정책 (at-least-once + DLT, 무한 재시도 아님):
+ * <ul>
+ *   <li>processed_message UNIQUE 충돌(constraint=uk_processed_message_message_id_topic) → 이미 처리
+ *       완료 간주 → ACK + 스킵
+ *   <li>그 외 DataIntegrityViolationException → rethrow → KafkaConsumerConfig의 ExponentialBackOff
+ *       (2→4→8초, 3회) 재시도 → 소진 시 {topic}.DLT 이동
+ *   <li>DLT 이동 후 수동 조치 (Admin API 또는 재처리 워커)
+ * </ul>
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -28,22 +40,34 @@ public class PaymentCompletedConsumer {
             groupId = "commerce-payment.completed"
     )
     public void consume(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        try {
-            // X-Message-Id 헤더 우선, 없으면 본문의 messageId 필드에서 추출
-            UUID messageId = extractMessageId(record);
-            String payload = extractPayload(record.value());
+        // X-Message-Id 헤더 우선, 없으면 본문의 messageId 필드에서 추출
+        UUID messageId = extractMessageId(record);
+        String payload = extractPayload(record.value());
 
-            try {
-                orderUsecase.processPaymentCompleted(messageId, record.topic(), payload);
-            } catch (DataIntegrityViolationException e) {
-                log.warn("[PaymentCompletedConsumer] UNIQUE 충돌 — 이미 처리된 메시지. messageId={}", messageId);
-            }
+        try {
+            orderUsecase.processPaymentCompleted(messageId, record.topic(), payload);
             ack.acknowledge();
-        } catch (Exception e) {
-            log.error("[PaymentCompletedConsumer] 메시지 처리 실패 — topic={}, error={}",
-                    record.topic(), e.getMessage(), e);
+        } catch (DataIntegrityViolationException e) {
+            if (isProcessedMessageUniqueConflict(e)) {
+                log.warn("[PaymentCompletedConsumer] processed_message UNIQUE 충돌 — 이미 처리 완료, 스킵. messageId={}",
+                        messageId);
+                ack.acknowledge();
+                return;
+            }
             throw e;
         }
+    }
+
+    private boolean isProcessedMessageUniqueConflict(DataIntegrityViolationException e) {
+        Throwable cause = e.getCause();
+        while (cause != null) {
+            if (cause instanceof org.hibernate.exception.ConstraintViolationException constraintViolation) {
+                String constraintName = constraintViolation.getConstraintName();
+                return "uk_processed_message_message_id_topic".equals(constraintName);
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
 
     private UUID extractMessageId(ConsumerRecord<String, String> record) {

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/consumer/PaymentFailedConsumer.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/consumer/PaymentFailedConsumer.java
@@ -1,0 +1,81 @@
+package com.devticket.commerce.order.presentation.consumer;
+
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.order.application.usecase.OrderUsecase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentFailedConsumer {
+
+    private final OrderUsecase orderUsecase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopics.PAYMENT_FAILED,
+            groupId = "commerce-payment.failed"
+    )
+    public void consume(ConsumerRecord<String, String> record, Acknowledgment ack) {
+        try {
+            UUID messageId = extractMessageId(record);
+            String payload = extractPayload(record.value());
+
+            try {
+                orderUsecase.processPaymentFailed(messageId, record.topic(), payload);
+            } catch (DataIntegrityViolationException e) {
+                log.warn("[PaymentFailedConsumer] UNIQUE 충돌 — 이미 처리된 메시지. messageId={}", messageId);
+            }
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("[PaymentFailedConsumer] 메시지 처리 실패 — topic={}, error={}",
+                    record.topic(), e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    private UUID extractMessageId(ConsumerRecord<String, String> record) {
+        Header header = record.headers().lastHeader("X-Message-Id");
+        if (header != null) {
+            try {
+                return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8));
+            } catch (IllegalArgumentException e) {
+                log.warn("[PaymentFailedConsumer] 헤더 UUID 파싱 실패, 본문 fallback. header={}",
+                        new String(header.value(), StandardCharsets.UTF_8));
+            }
+        }
+        try {
+            JsonNode root = objectMapper.readTree(record.value());
+            JsonNode messageIdNode = root.get("messageId");
+            if (messageIdNode != null && !messageIdNode.isNull()) {
+                return UUID.fromString(messageIdNode.asText());
+            }
+        } catch (Exception e) {
+            log.warn("[PaymentFailedConsumer] 본문에서 messageId 추출 실패", e);
+        }
+        throw new IllegalArgumentException("messageId를 추출할 수 없습니다. topic=" + record.topic());
+    }
+
+    private String extractPayload(String value) {
+        try {
+            JsonNode root = objectMapper.readTree(value);
+            JsonNode payloadNode = root.get("payload");
+            if (payloadNode != null && !payloadNode.isNull()) {
+                return payloadNode.asText();
+            }
+        } catch (Exception ignored) {
+        }
+        return value;
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/consumer/PaymentFailedConsumer.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/consumer/PaymentFailedConsumer.java
@@ -15,6 +15,18 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
+/**
+ * payment.failed Consumer — Order PAYMENT_PENDING → FAILED 전이.
+ *
+ * <p>예외 정책 (at-least-once + DLT, 무한 재시도 아님):
+ * <ul>
+ *   <li>processed_message UNIQUE 충돌(constraint=uk_processed_message_message_id_topic) → 이미 처리
+ *       완료 간주 → ACK + 스킵
+ *   <li>그 외 DataIntegrityViolationException → rethrow → KafkaConsumerConfig의 ExponentialBackOff
+ *       (2→4→8초, 3회) 재시도 → 소진 시 {topic}.DLT 이동
+ *   <li>DLT 이동 후 수동 조치 (Admin API 또는 재처리 워커)
+ * </ul>
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -28,21 +40,33 @@ public class PaymentFailedConsumer {
             groupId = "commerce-payment.failed"
     )
     public void consume(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        try {
-            UUID messageId = extractMessageId(record);
-            String payload = extractPayload(record.value());
+        UUID messageId = extractMessageId(record);
+        String payload = extractPayload(record.value());
 
-            try {
-                orderUsecase.processPaymentFailed(messageId, record.topic(), payload);
-            } catch (DataIntegrityViolationException e) {
-                log.warn("[PaymentFailedConsumer] UNIQUE 충돌 — 이미 처리된 메시지. messageId={}", messageId);
-            }
+        try {
+            orderUsecase.processPaymentFailed(messageId, record.topic(), payload);
             ack.acknowledge();
-        } catch (Exception e) {
-            log.error("[PaymentFailedConsumer] 메시지 처리 실패 — topic={}, error={}",
-                    record.topic(), e.getMessage(), e);
+        } catch (DataIntegrityViolationException e) {
+            if (isProcessedMessageUniqueConflict(e)) {
+                log.warn("[PaymentFailedConsumer] processed_message UNIQUE 충돌 — 이미 처리 완료, 스킵. messageId={}",
+                        messageId);
+                ack.acknowledge();
+                return;
+            }
             throw e;
         }
+    }
+
+    private boolean isProcessedMessageUniqueConflict(DataIntegrityViolationException e) {
+        Throwable cause = e.getCause();
+        while (cause != null) {
+            if (cause instanceof org.hibernate.exception.ConstraintViolationException constraintViolation) {
+                String constraintName = constraintViolation.getConstraintName();
+                return "uk_processed_message_message_id_topic".equals(constraintName);
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
 
     private UUID extractMessageId(ConsumerRecord<String, String> record) {

--- a/commerce/src/test/java/com/devticket/commerce/integration/ConsumerDltIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/ConsumerDltIntegrationTest.java
@@ -1,0 +1,168 @@
+package com.devticket.commerce.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.devticket.commerce.common.enums.PaymentMethod;
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.common.messaging.event.PaymentCompletedEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import net.javacrumbs.shedlock.core.LockProvider;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.util.backoff.FixedBackOff;
+
+/**
+ * IT-3 Consumer DLT 이동 통합테스트 — 멘토 피드백 "무한 재시도 아님" 증명.
+ *
+ * <p>운영 설정과 차이 (테스트 속도 최적화 목적):
+ * <ul>
+ *   <li>운영: {@code KafkaConsumerConfig.kafkaListenerContainerFactory()} —
+ *       {@code ExponentialBackOff(2→4→8초, maxElapsedTime=14s)} + {@code DeadLetterPublishingRecoverer}
+ *       로 {@code {topic}.DLT} 로 이동. 실행에 최소 14초 필요
+ *   <li>테스트: {@link TestDltConfig} 에서 {@link DefaultErrorHandler} 를 {@code @Primary} 로 덮어써
+ *       {@code FixedBackOff(100ms, 2회)} 로 동작 → 수백 ms 내 DLT 도달 확인
+ *   <li>검증 대상은 동일한 "예외 → 제한 횟수 재시도 → DLT 이동" 경로 — 운영 빈도 동일한 구조 사용
+ * </ul>
+ *
+ * <p>시나리오: 존재하지 않는 orderId로 payment.completed 발행 → OrderService.processPaymentCompleted
+ * 에서 {@code BusinessException(ORDER_NOT_FOUND)} → 재시도 2회 소진 → {@code payment.completed.DLT}
+ * 수신 + 원본 X-Message-Id 헤더 보존 확인.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(
+        partitions = 1,
+        topics = {KafkaTopics.PAYMENT_COMPLETED, KafkaTopics.PAYMENT_COMPLETED + ".DLT"},
+        bootstrapServersProperty = "spring.kafka.bootstrap-servers"
+)
+@DirtiesContext
+@Import(ConsumerDltIntegrationTest.TestDltConfig.class)
+class ConsumerDltIntegrationTest {
+
+    @TestConfiguration
+    static class TestDltConfig {
+        /**
+         * 테스트 전용 ErrorHandler — 운영 {@code KafkaConsumerConfig} 의 빈을 {@code @Primary} 로 덮어씀.
+         * FixedBackOff(100ms, 2): 100ms 간격 2회 재시도 후 DLT 이동. 테스트 속도 최적화 목적.
+         */
+        @Bean
+        @Primary
+        public DefaultErrorHandler errorHandler(KafkaTemplate<String, String> template) {
+            DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
+            return new DefaultErrorHandler(recoverer, new FixedBackOff(100L, 2L));
+        }
+    }
+
+    @MockitoBean private LockProvider lockProvider;
+
+    @Autowired private KafkaTemplate<String, String> kafkaTemplate;
+    @Autowired private EmbeddedKafkaBroker embeddedKafkaBroker;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private TransactionTemplate txTemplate;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        given(lockProvider.lock(any())).willReturn(Optional.of(() -> {}));
+    }
+
+    @AfterEach
+    void cleanup() {
+        txTemplate.executeWithoutResult(s -> {
+            entityManager.createQuery("DELETE FROM Outbox").executeUpdate();
+            entityManager.createQuery("DELETE FROM ProcessedMessage").executeUpdate();
+        });
+    }
+
+    @Test
+    @DisplayName("IT-3: payment.completed 예외 → 재시도 소진 → payment.completed.DLT 수신 (무한 재시도 아님 증명)")
+    void movesToDltAfterRetriesExhausted() throws Exception {
+        // given — 존재하지 않는 orderId로 PaymentCompletedEvent 발행
+        //   OrderService.processPaymentCompleted → orderRepository.findByOrderId → empty → BusinessException(ORDER_NOT_FOUND)
+        UUID nonExistentOrderId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        PaymentCompletedEvent event = new PaymentCompletedEvent(
+                nonExistentOrderId,
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                PaymentMethod.PG,
+                10_000,
+                Instant.now()
+        );
+
+        try (Consumer<String, String> dltConsumer =
+                     createTestConsumer(KafkaTopics.PAYMENT_COMPLETED + ".DLT")) {
+
+            // when
+            ProducerRecord<String, String> record = new ProducerRecord<>(
+                    KafkaTopics.PAYMENT_COMPLETED,
+                    nonExistentOrderId.toString(),
+                    objectMapper.writeValueAsString(event)
+            );
+            record.headers().add("X-Message-Id",
+                    messageId.toString().getBytes(StandardCharsets.UTF_8));
+            kafkaTemplate.send(record).get(5, TimeUnit.SECONDS);
+
+            // then — DLT 토픽에 메시지 도달 (재시도 소진 후 이동)
+            ConsumerRecord<String, String> dltRecord = KafkaTestUtils.getSingleRecord(
+                    dltConsumer, KafkaTopics.PAYMENT_COMPLETED + ".DLT", Duration.ofSeconds(30));
+
+            assertThat(dltRecord.value()).contains(nonExistentOrderId.toString());
+
+            // X-Message-Id 헤더가 DLT 메시지에도 보존되는지 (재처리 워커의 dedup 전제)
+            assertThat(dltRecord.headers().lastHeader("X-Message-Id")).isNotNull();
+            String preservedMessageId = new String(
+                    dltRecord.headers().lastHeader("X-Message-Id").value(), StandardCharsets.UTF_8);
+            assertThat(preservedMessageId).isEqualTo(messageId.toString());
+        }
+    }
+
+    private Consumer<String, String> createTestConsumer(String topic) {
+        Map<String, Object> props = KafkaTestUtils.consumerProps(
+                "dlt-test-consumer-" + UUID.randomUUID(), "true", embeddedKafkaBroker);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        Consumer<String, String> consumer = new DefaultKafkaConsumerFactory<>(
+                props, new StringDeserializer(), new StringDeserializer())
+                .createConsumer();
+        consumer.subscribe(List.of(topic));
+        return consumer;
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/integration/OrderCreationFlowIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/OrderCreationFlowIntegrationTest.java
@@ -1,0 +1,207 @@
+package com.devticket.commerce.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.devticket.commerce.common.enums.OrderStatus;
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.common.messaging.event.OrderCreatedEvent;
+import com.devticket.commerce.common.messaging.event.StockDeductedEvent;
+import com.devticket.commerce.common.messaging.event.StockFailedEvent;
+import com.devticket.commerce.common.outbox.Outbox;
+import com.devticket.commerce.common.outbox.OutboxRepository;
+import com.devticket.commerce.common.outbox.OutboxService;
+import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.model.OrderItem;
+import com.devticket.commerce.order.domain.repository.OrderItemRepository;
+import com.devticket.commerce.order.domain.repository.OrderRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import net.javacrumbs.shedlock.core.LockProvider;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * IT-1 주문생성 플로우 통합테스트 — EmbeddedKafka + H2 단일 JVM.
+ *
+ * <p>검증 대상:
+ * <ul>
+ *   <li>order.created Outbox → Kafka 발행 경로 (팀 스코프 — 취합된 주문생성 Producer)
+ *   <li>stock.deducted 수신 → Order CREATED → PAYMENT_PENDING 전이 (팀 스코프 — StockEventConsumer)
+ *   <li>stock.failed 수신 → Order CREATED → FAILED 전이
+ * </ul>
+ *
+ * <p>테스트 데이터는 UUID로 격리되어 메서드 간 간섭 없음. ShedLock은 no-op으로 mocking.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(
+        partitions = 1,
+        topics = {KafkaTopics.ORDER_CREATED, KafkaTopics.STOCK_DEDUCTED, KafkaTopics.STOCK_FAILED},
+        bootstrapServersProperty = "spring.kafka.bootstrap-servers"
+)
+@DirtiesContext
+class OrderCreationFlowIntegrationTest {
+
+    @MockitoBean private LockProvider lockProvider;
+
+    @Autowired private OrderRepository orderRepository;
+    @Autowired private OrderItemRepository orderItemRepository;
+    @Autowired private OutboxRepository outboxRepository;
+    @Autowired private OutboxService outboxService;
+    @Autowired private KafkaTemplate<String, String> kafkaTemplate;
+    @Autowired private EmbeddedKafkaBroker embeddedKafkaBroker;
+    @Autowired private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        given(lockProvider.lock(any())).willReturn(Optional.of(() -> {}));
+    }
+
+    @Test
+    @DisplayName("IT-1-A: Outbox 저장 → processOne → order.created Kafka 발행 (X-Message-Id 헤더 포함)")
+    void publishesOrderCreatedEventViaOutbox() throws Exception {
+        // given
+        UUID orderId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        OrderCreatedEvent event = new OrderCreatedEvent(
+                orderId,
+                userId,
+                List.of(new OrderCreatedEvent.OrderItem(UUID.randomUUID(), 2)),
+                10_000,
+                Instant.now()
+        );
+        Outbox outbox = Outbox.create(
+                orderId.toString(),
+                orderId.toString(),
+                "OrderCreated",
+                KafkaTopics.ORDER_CREATED,
+                objectMapper.writeValueAsString(event)
+        );
+        Outbox saved = outboxRepository.save(outbox);
+
+        try (Consumer<String, String> testConsumer = createTestConsumer(KafkaTopics.ORDER_CREATED)) {
+            // when — OutboxScheduler 대신 수동 호출 (폴링 대기 단축)
+            outboxService.processOne(saved);
+
+            // then
+            ConsumerRecord<String, String> record = KafkaTestUtils.getSingleRecord(
+                    testConsumer, KafkaTopics.ORDER_CREATED, Duration.ofSeconds(10));
+
+            assertThat(record.value()).contains(orderId.toString());
+
+            String messageIdHeader = new String(
+                    record.headers().lastHeader("X-Message-Id").value(),
+                    StandardCharsets.UTF_8);
+            assertThat(messageIdHeader).isEqualTo(saved.getMessageId());
+        }
+    }
+
+    @Test
+    @DisplayName("IT-1-B: stock.deducted 수신 → Order CREATED → PAYMENT_PENDING 전이")
+    void transitionsToPaymentPendingOnStockDeducted() throws Exception {
+        // given — Order CREATED 저장
+        UUID userId = UUID.randomUUID();
+        Order order = Order.create(userId, 10_000, "hash-it1-b-" + UUID.randomUUID());
+        Order savedOrder = orderRepository.save(order);
+
+        UUID eventId = UUID.randomUUID();
+        OrderItem item = OrderItem.create(savedOrder.getId(), userId, eventId, 5_000, 2, 10);
+        orderItemRepository.save(item);
+
+        UUID messageId = UUID.randomUUID();
+        StockDeductedEvent deducted = new StockDeductedEvent(
+                savedOrder.getOrderId(), eventId, 2, Instant.now());
+
+        // when — stock.deducted Kafka 발행 (X-Message-Id 헤더)
+        sendWithMessageIdHeader(
+                KafkaTopics.STOCK_DEDUCTED,
+                savedOrder.getOrderId().toString(),
+                objectMapper.writeValueAsString(deducted),
+                messageId);
+
+        // then — Consumer가 수신·처리하여 상태 전이 완료
+        await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
+            Order refreshed = orderRepository.findByOrderId(savedOrder.getOrderId())
+                    .orElseThrow();
+            assertThat(refreshed.getStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+        });
+    }
+
+    @Test
+    @DisplayName("IT-1-C: stock.failed 수신 → Order CREATED → FAILED 전이")
+    void transitionsToFailedOnStockFailed() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        Order order = Order.create(userId, 10_000, "hash-it1-c-" + UUID.randomUUID());
+        Order savedOrder = orderRepository.save(order);
+
+        UUID eventId = UUID.randomUUID();
+        OrderItem item = OrderItem.create(savedOrder.getId(), userId, eventId, 5_000, 2, 10);
+        orderItemRepository.save(item);
+
+        UUID messageId = UUID.randomUUID();
+        StockFailedEvent failed = new StockFailedEvent(
+                savedOrder.getOrderId(), eventId, "SOLD_OUT", Instant.now());
+
+        // when
+        sendWithMessageIdHeader(
+                KafkaTopics.STOCK_FAILED,
+                savedOrder.getOrderId().toString(),
+                objectMapper.writeValueAsString(failed),
+                messageId);
+
+        // then
+        await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
+            Order refreshed = orderRepository.findByOrderId(savedOrder.getOrderId())
+                    .orElseThrow();
+            assertThat(refreshed.getStatus()).isEqualTo(OrderStatus.FAILED);
+        });
+    }
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────
+
+    private void sendWithMessageIdHeader(String topic, String key, String payload, UUID messageId)
+            throws Exception {
+        ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, payload);
+        record.headers().add("X-Message-Id",
+                messageId.toString().getBytes(StandardCharsets.UTF_8));
+        kafkaTemplate.send(record).get(5, TimeUnit.SECONDS);
+    }
+
+    private Consumer<String, String> createTestConsumer(String topic) {
+        Map<String, Object> props = KafkaTestUtils.consumerProps(
+                "test-consumer-" + UUID.randomUUID(), "true", embeddedKafkaBroker);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        Consumer<String, String> consumer = new DefaultKafkaConsumerFactory<>(
+                props, new StringDeserializer(), new StringDeserializer())
+                .createConsumer();
+        consumer.subscribe(List.of(topic));
+        return consumer;
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/integration/OrderExpirationFlowIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/OrderExpirationFlowIntegrationTest.java
@@ -1,0 +1,252 @@
+package com.devticket.commerce.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.devticket.commerce.common.enums.OrderStatus;
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.common.messaging.event.PaymentFailedEvent;
+import com.devticket.commerce.common.outbox.Outbox;
+import com.devticket.commerce.common.outbox.OutboxRepository;
+import com.devticket.commerce.common.outbox.OutboxService;
+import com.devticket.commerce.common.outbox.OutboxStatus;
+import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.model.OrderItem;
+import com.devticket.commerce.order.domain.repository.OrderItemRepository;
+import com.devticket.commerce.order.domain.repository.OrderRepository;
+import com.devticket.commerce.order.infrastructure.scheduler.OrderExpirationScheduler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import net.javacrumbs.shedlock.core.LockProvider;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * IT-2 만료 플로우 통합테스트 — OrderExpirationScheduler 동작 검증 (PR #426 피드백 대응).
+ *
+ * <p>검증 대상:
+ * <ul>
+ *   <li>PAYMENT_PENDING + updated_at 30분 경과 → CANCELLED 전이 (Codex P2)
+ *   <li>payment.failed Outbox 발행 (reason=ORDER_TIMEOUT, orderItems 매핑) (Codex P1)
+ *   <li>Outbox → Kafka 실제 발행 payload 검증
+ *   <li>PAID 상태는 만료 대상에서 제외
+ * </ul>
+ *
+ * <p>updated_at 조작: JPA Auditing이 자동 갱신하므로 save 후 JPQL UPDATE로 과거 시각 강제 주입.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(
+        partitions = 1,
+        topics = {KafkaTopics.PAYMENT_FAILED},
+        bootstrapServersProperty = "spring.kafka.bootstrap-servers"
+)
+@DirtiesContext
+class OrderExpirationFlowIntegrationTest {
+
+    @MockitoBean private LockProvider lockProvider;
+
+    @Autowired private OrderRepository orderRepository;
+    @Autowired private OrderItemRepository orderItemRepository;
+    @Autowired private OutboxRepository outboxRepository;
+    @Autowired private OutboxService outboxService;
+    @Autowired private OrderExpirationScheduler scheduler;
+    @Autowired private EmbeddedKafkaBroker embeddedKafkaBroker;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private TransactionTemplate txTemplate;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        given(lockProvider.lock(any())).willReturn(Optional.of(() -> {}));
+    }
+
+    @AfterEach
+    void cleanup() {
+        // 테스트 간 DB 격리 — 스케줄러가 이전 테스트의 Order를 감지하는 간섭 방지
+        txTemplate.executeWithoutResult(s -> {
+            entityManager.createQuery("DELETE FROM Outbox").executeUpdate();
+            entityManager.createQuery("DELETE FROM ProcessedMessage").executeUpdate();
+            entityManager.createQuery("DELETE FROM OrderItem").executeUpdate();
+            entityManager.createQuery("DELETE FROM Order").executeUpdate();
+        });
+    }
+
+    @Test
+    @DisplayName("IT-2-A: PAYMENT_PENDING + updated_at 30분 경과 → CANCELLED 전이 + payment.failed Outbox INSERT")
+    void cancelsExpiredOrderAndInsertsOutbox() {
+        // given — PAYMENT_PENDING 상태로 Order 저장 후 updated_at 과거로 강제
+        UUID userId = UUID.randomUUID();
+        Order savedOrder = createPaymentPendingOrderWithItems(userId,
+                List.of(new TestItemSpec(UUID.randomUUID(), 2),
+                        new TestItemSpec(UUID.randomUUID(), 1)));
+        forceUpdatedAtToPast(savedOrder.getId(), 31);
+
+        long outboxCountBefore = outboxRepository.count();
+
+        // when — 스케줄러 수동 호출 (fixedDelay 대신)
+        scheduler.cancelExpiredOrders();
+
+        // then — Order CANCELLED 전이
+        Order refreshed = orderRepository.findByOrderId(savedOrder.getOrderId()).orElseThrow();
+        assertThat(refreshed.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+
+        // then — payment.failed Outbox INSERT 확인
+        assertThat(outboxRepository.count()).isEqualTo(outboxCountBefore + 1);
+        Outbox outbox = outboxRepository.findAll().stream()
+                .filter(o -> KafkaTopics.PAYMENT_FAILED.equals(o.getTopic()))
+                .filter(o -> savedOrder.getOrderId().toString().equals(o.getAggregateId()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(outbox.getEventType()).isEqualTo("PaymentFailed");
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("IT-2-B: Outbox → Kafka 발행 → payload 검증 (reason=ORDER_TIMEOUT, orderItems 매핑)")
+    void publishesPaymentFailedWithCorrectPayload() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID eventId1 = UUID.randomUUID();
+        UUID eventId2 = UUID.randomUUID();
+        Order savedOrder = createPaymentPendingOrderWithItems(userId,
+                List.of(new TestItemSpec(eventId1, 3),
+                        new TestItemSpec(eventId2, 1)));
+        forceUpdatedAtToPast(savedOrder.getId(), 31);
+
+        // when — 스케줄러 호출 (Outbox INSERT) + Outbox 발행 (Kafka 전송)
+        scheduler.cancelExpiredOrders();
+        Outbox outbox = outboxRepository.findAll().stream()
+                .filter(o -> KafkaTopics.PAYMENT_FAILED.equals(o.getTopic()))
+                .filter(o -> savedOrder.getOrderId().toString().equals(o.getAggregateId()))
+                .findFirst()
+                .orElseThrow();
+
+        try (Consumer<String, String> testConsumer = createTestConsumer(KafkaTopics.PAYMENT_FAILED)) {
+            outboxService.processOne(outbox);
+
+            // then — Kafka payload 검증
+            ConsumerRecord<String, String> record = KafkaTestUtils.getSingleRecord(
+                    testConsumer, KafkaTopics.PAYMENT_FAILED, Duration.ofSeconds(10));
+
+            assertThat(record.headers().lastHeader("X-Message-Id")).isNotNull();
+            String messageIdHeader = new String(
+                    record.headers().lastHeader("X-Message-Id").value(), StandardCharsets.UTF_8);
+            assertThat(messageIdHeader).isEqualTo(outbox.getMessageId());
+
+            PaymentFailedEvent published = objectMapper.readValue(
+                    record.value(), PaymentFailedEvent.class);
+            assertThat(published.orderId()).isEqualTo(savedOrder.getOrderId());
+            assertThat(published.userId()).isEqualTo(userId);
+            assertThat(published.reason()).isEqualTo("ORDER_TIMEOUT");
+            assertThat(published.orderItems()).hasSize(2);
+            assertThat(published.orderItems())
+                    .extracting(PaymentFailedEvent.OrderItem::eventId)
+                    .containsExactlyInAnyOrder(eventId1, eventId2);
+            assertThat(published.orderItems())
+                    .extracting(PaymentFailedEvent.OrderItem::quantity)
+                    .containsExactlyInAnyOrder(3, 1);
+        }
+    }
+
+    @Test
+    @DisplayName("IT-2-C: PAID 상태 Order는 updated_at이 과거여도 만료 대상에서 제외")
+    void excludesPaidOrderFromExpiration() {
+        // given — PAID 상태 Order, updated_at 30분 이전
+        UUID userId = UUID.randomUUID();
+        Order savedOrder = createPaymentPendingOrderWithItems(userId,
+                List.of(new TestItemSpec(UUID.randomUUID(), 1)));
+        // PAYMENT_PENDING → PAID 전이
+        txTemplate.executeWithoutResult(s -> {
+            entityManager.createQuery(
+                    "UPDATE Order o SET o.status = :paid WHERE o.id = :id")
+                    .setParameter("paid", OrderStatus.PAID)
+                    .setParameter("id", savedOrder.getId())
+                    .executeUpdate();
+        });
+        forceUpdatedAtToPast(savedOrder.getId(), 31);
+
+        long outboxCountBefore = outboxRepository.count();
+
+        // when
+        scheduler.cancelExpiredOrders();
+
+        // then — 상태 변경 없음, Outbox INSERT 없음
+        Order refreshed = orderRepository.findByOrderId(savedOrder.getOrderId()).orElseThrow();
+        assertThat(refreshed.getStatus()).isEqualTo(OrderStatus.PAID);
+        assertThat(outboxRepository.count()).isEqualTo(outboxCountBefore);
+    }
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────
+
+    private record TestItemSpec(UUID eventId, int quantity) {}
+
+    /** PAYMENT_PENDING 상태의 Order + OrderItem 생성 (JPQL UPDATE로 status 강제 세팅). */
+    private Order createPaymentPendingOrderWithItems(UUID userId, List<TestItemSpec> items) {
+        Order order = Order.create(userId, 10_000, "hash-it2-" + UUID.randomUUID());
+        Order saved = orderRepository.save(order);
+        for (TestItemSpec spec : items) {
+            orderItemRepository.save(
+                    OrderItem.create(saved.getId(), userId, spec.eventId(), 5_000, spec.quantity(), 10));
+        }
+        txTemplate.executeWithoutResult(s -> {
+            entityManager.createQuery(
+                    "UPDATE Order o SET o.status = :pending WHERE o.id = :id")
+                    .setParameter("pending", OrderStatus.PAYMENT_PENDING)
+                    .setParameter("id", saved.getId())
+                    .executeUpdate();
+        });
+        entityManager.clear(); // 1차 캐시 무효화 → 다음 조회 시 DB 재조회
+        return orderRepository.findByOrderId(saved.getOrderId()).orElseThrow();
+    }
+
+    /** @LastModifiedDate 자동 갱신을 우회하여 updated_at을 과거로 덮어쓴다. */
+    private void forceUpdatedAtToPast(Long orderId, int minutesAgo) {
+        txTemplate.executeWithoutResult(s -> {
+            entityManager.createQuery(
+                    "UPDATE Order o SET o.updatedAt = :past WHERE o.id = :id")
+                    .setParameter("past", LocalDateTime.now().minusMinutes(minutesAgo))
+                    .setParameter("id", orderId)
+                    .executeUpdate();
+        });
+        entityManager.clear();
+    }
+
+    private Consumer<String, String> createTestConsumer(String topic) {
+        Map<String, Object> props = KafkaTestUtils.consumerProps(
+                "test-consumer-" + UUID.randomUUID(), "true", embeddedKafkaBroker);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        Consumer<String, String> consumer = new DefaultKafkaConsumerFactory<>(
+                props, new StringDeserializer(), new StringDeserializer())
+                .createConsumer();
+        consumer.subscribe(List.of(topic));
+        return consumer;
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/order/application/service/OrderExpirationCancelServiceTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/order/application/service/OrderExpirationCancelServiceTest.java
@@ -1,0 +1,171 @@
+package com.devticket.commerce.order.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import com.devticket.commerce.common.enums.OrderStatus;
+import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.repository.OrderRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OrderExpirationCancelServiceTest {
+
+    @Mock private OrderRepository orderRepository;
+
+    @InjectMocks private OrderExpirationCancelService cancelService;
+
+    private Order buildOrder(OrderStatus status) {
+        Order order = Order.builder()
+                .orderId(UUID.randomUUID())
+                .userId(UUID.randomUUID())
+                .orderNumber("20260417-TEST0001")
+                .totalAmount(10_000)
+                .status(status)
+                .orderedAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(order, "id", 1L);
+        return order;
+    }
+
+    @Nested
+    @DisplayName("정상 전이 — PAYMENT_PENDING → CANCELLED")
+    class HappyPath {
+
+        @Test
+        @DisplayName("canTransitionTo 통과 → cancel() + save() 호출")
+        void cancelsPaymentPendingOrder() {
+            // given
+            Order order = buildOrder(OrderStatus.PAYMENT_PENDING);
+
+            // when
+            cancelService.cancelOrder(order);
+
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+            then(orderRepository).should().save(order);
+        }
+    }
+
+    @Nested
+    @DisplayName("canTransitionTo 실패 — 스킵")
+    class SkipOnInvalidTransition {
+
+        @Test
+        @DisplayName("이미 CANCELLED 상태면 save 호출 없이 스킵")
+        void skipsWhenAlreadyCancelled() {
+            // given
+            Order order = buildOrder(OrderStatus.CANCELLED);
+
+            // when
+            cancelService.cancelOrder(order);
+
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+            then(orderRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("PAID 상태도 canTransitionTo(CANCELLED)는 가능하지만 호출 경로상 만료 대상 아님 — 직접 호출 시 cancel 수행")
+        void paidOrderCanStillTransitionToCancelled() {
+            // given — 스케줄러는 PAYMENT_PENDING만 조회하므로 실제 호출 안 되지만 도메인 전이는 가능
+            Order order = buildOrder(OrderStatus.PAID);
+
+            // when
+            cancelService.cancelOrder(order);
+
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+            then(orderRepository).should().save(order);
+        }
+
+        @Test
+        @DisplayName("FAILED 상태 (종단) → canTransitionTo false → 스킵")
+        void skipsWhenFailed() {
+            // given
+            Order order = buildOrder(OrderStatus.FAILED);
+
+            // when
+            cancelService.cancelOrder(order);
+
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.FAILED);
+            then(orderRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("낙관적 락 충돌 — Consumer와 동시 상태 전이")
+    class OptimisticLockConflict {
+
+        @Test
+        @DisplayName("save 시 OptimisticLockException → 재조회 결과 PAID면 스킵 로그")
+        void skipsAfterConflictWhenRefreshedToPaid() {
+            // given
+            Order order = buildOrder(OrderStatus.PAYMENT_PENDING);
+            willThrow(new ObjectOptimisticLockingFailureException(Order.class, order.getOrderId()))
+                    .given(orderRepository).save(order);
+
+            Order refreshed = buildOrder(OrderStatus.PAID);
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.of(refreshed));
+
+            // when / then (예외 전파되지 않음 — 내부 catch)
+            cancelService.cancelOrder(order);
+
+            then(orderRepository).should().save(order);
+            then(orderRepository).should().findByOrderId(order.getOrderId());
+        }
+
+        @Test
+        @DisplayName("save 시 OptimisticLockException → 재조회 실패(null) → 경고 로그 후 종료")
+        void warnsWhenRefreshReturnsEmpty() {
+            // given
+            Order order = buildOrder(OrderStatus.PAYMENT_PENDING);
+            willThrow(new ObjectOptimisticLockingFailureException(Order.class, order.getOrderId()))
+                    .given(orderRepository).save(order);
+
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.empty());
+
+            // when
+            cancelService.cancelOrder(order);
+
+            // then
+            then(orderRepository).should().save(order);
+            then(orderRepository).should().findByOrderId(order.getOrderId());
+        }
+
+        @Test
+        @DisplayName("save 시 OptimisticLockException → 재조회 결과 PAYMENT_PENDING(비종단) → 재시도 필요 로그")
+        void retryNeededWhenStillPending() {
+            // given
+            Order order = buildOrder(OrderStatus.PAYMENT_PENDING);
+            willThrow(new ObjectOptimisticLockingFailureException(Order.class, order.getOrderId()))
+                    .given(orderRepository).save(order);
+
+            Order refreshed = buildOrder(OrderStatus.PAYMENT_PENDING);
+            given(orderRepository.findByOrderId(order.getOrderId())).willReturn(Optional.of(refreshed));
+
+            // when
+            cancelService.cancelOrder(order);
+
+            // then — 예외 전파 없음, catch 블록 진입 확인
+            then(orderRepository).should().save(order);
+            then(orderRepository).should().findByOrderId(order.getOrderId());
+        }
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/order/application/service/OrderExpirationCancelServiceTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/order/application/service/OrderExpirationCancelServiceTest.java
@@ -2,21 +2,30 @@ package com.devticket.commerce.order.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
 import com.devticket.commerce.common.enums.OrderStatus;
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.common.messaging.event.PaymentFailedEvent;
+import com.devticket.commerce.common.outbox.OutboxService;
 import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.model.OrderItem;
+import com.devticket.commerce.order.domain.repository.OrderItemRepository;
 import com.devticket.commerce.order.domain.repository.OrderRepository;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,6 +36,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 class OrderExpirationCancelServiceTest {
 
     @Mock private OrderRepository orderRepository;
+    @Mock private OrderItemRepository orderItemRepository;
+    @Mock private OutboxService outboxService;
 
     @InjectMocks private OrderExpirationCancelService cancelService;
 
@@ -43,15 +54,66 @@ class OrderExpirationCancelServiceTest {
         return order;
     }
 
+    private OrderItem buildOrderItem(UUID eventId, int quantity) {
+        return OrderItem.builder()
+                .orderItemId(UUID.randomUUID())
+                .orderId(1L)
+                .userId(UUID.randomUUID())
+                .eventId(eventId)
+                .price(5_000)
+                .quantity(quantity)
+                .subtotalAmount(5_000 * quantity)
+                .build();
+    }
+
     @Nested
-    @DisplayName("정상 전이 — PAYMENT_PENDING → CANCELLED")
+    @DisplayName("정상 전이 — PAYMENT_PENDING → CANCELLED + 재고 복구 Outbox 발행")
     class HappyPath {
 
         @Test
-        @DisplayName("canTransitionTo 통과 → cancel() + save() 호출")
-        void cancelsPaymentPendingOrder() {
+        @DisplayName("canTransitionTo 통과 → cancel() + save() + payment.failed Outbox 발행")
+        void cancelsPaymentPendingOrderAndPublishesOutbox() {
             // given
             Order order = buildOrder(OrderStatus.PAYMENT_PENDING);
+            UUID eventId1 = UUID.randomUUID();
+            UUID eventId2 = UUID.randomUUID();
+            given(orderItemRepository.findAllByOrderId(order.getId()))
+                    .willReturn(List.of(buildOrderItem(eventId1, 2), buildOrderItem(eventId2, 1)));
+
+            // when
+            cancelService.cancelOrder(order);
+
+            // then — 상태 전이 + 저장
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+            then(orderRepository).should().save(order);
+
+            // then — Outbox 발행 검증 (reason=ORDER_EXPIRED, orderItems 매핑 확인)
+            ArgumentCaptor<PaymentFailedEvent> eventCaptor = ArgumentCaptor.forClass(PaymentFailedEvent.class);
+            then(outboxService).should().save(
+                    eq(order.getOrderId().toString()),
+                    eq(order.getOrderId().toString()),
+                    eq("PaymentFailed"),
+                    eq(KafkaTopics.PAYMENT_FAILED),
+                    eventCaptor.capture()
+            );
+            PaymentFailedEvent published = eventCaptor.getValue();
+            assertThat(published.orderId()).isEqualTo(order.getOrderId());
+            assertThat(published.userId()).isEqualTo(order.getUserId());
+            assertThat(published.reason()).isEqualTo("ORDER_TIMEOUT");
+            assertThat(published.orderItems()).hasSize(2);
+            assertThat(published.orderItems()).extracting(PaymentFailedEvent.OrderItem::eventId)
+                    .containsExactlyInAnyOrder(eventId1, eventId2);
+            assertThat(published.orderItems()).extracting(PaymentFailedEvent.OrderItem::quantity)
+                    .containsExactlyInAnyOrder(2, 1);
+        }
+
+        @Test
+        @DisplayName("OrderItem 0건이어도 Outbox는 발행 (빈 리스트)")
+        void publishesOutboxEvenWithEmptyOrderItems() {
+            // given
+            Order order = buildOrder(OrderStatus.PAYMENT_PENDING);
+            given(orderItemRepository.findAllByOrderId(order.getId()))
+                    .willReturn(Collections.emptyList());
 
             // when
             cancelService.cancelOrder(order);
@@ -59,15 +121,19 @@ class OrderExpirationCancelServiceTest {
             // then
             assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
             then(orderRepository).should().save(order);
+
+            ArgumentCaptor<PaymentFailedEvent> eventCaptor = ArgumentCaptor.forClass(PaymentFailedEvent.class);
+            then(outboxService).should().save(any(), any(), any(), any(), eventCaptor.capture());
+            assertThat(eventCaptor.getValue().orderItems()).isEmpty();
         }
     }
 
     @Nested
-    @DisplayName("canTransitionTo 실패 — 스킵")
+    @DisplayName("canTransitionTo 실패 — Outbox 발행 없이 스킵")
     class SkipOnInvalidTransition {
 
         @Test
-        @DisplayName("이미 CANCELLED 상태면 save 호출 없이 스킵")
+        @DisplayName("이미 CANCELLED 상태면 save/Outbox 호출 없이 스킵")
         void skipsWhenAlreadyCancelled() {
             // given
             Order order = buildOrder(OrderStatus.CANCELLED);
@@ -78,20 +144,8 @@ class OrderExpirationCancelServiceTest {
             // then
             assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
             then(orderRepository).should(never()).save(any());
-        }
-
-        @Test
-        @DisplayName("PAID 상태도 canTransitionTo(CANCELLED)는 가능하지만 호출 경로상 만료 대상 아님 — 직접 호출 시 cancel 수행")
-        void paidOrderCanStillTransitionToCancelled() {
-            // given — 스케줄러는 PAYMENT_PENDING만 조회하므로 실제 호출 안 되지만 도메인 전이는 가능
-            Order order = buildOrder(OrderStatus.PAID);
-
-            // when
-            cancelService.cancelOrder(order);
-
-            // then
-            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
-            then(orderRepository).should().save(order);
+            then(outboxService).shouldHaveNoInteractions();
+            then(orderItemRepository).shouldHaveNoInteractions();
         }
 
         @Test
@@ -106,6 +160,8 @@ class OrderExpirationCancelServiceTest {
             // then
             assertThat(order.getStatus()).isEqualTo(OrderStatus.FAILED);
             then(orderRepository).should(never()).save(any());
+            then(outboxService).shouldHaveNoInteractions();
+            then(orderItemRepository).shouldHaveNoInteractions();
         }
     }
 
@@ -114,9 +170,9 @@ class OrderExpirationCancelServiceTest {
     class OptimisticLockConflict {
 
         @Test
-        @DisplayName("save 시 OptimisticLockException → 재조회 결과 PAID면 스킵 로그")
+        @DisplayName("save 시 OptimisticLockException → 재조회 결과 PAID면 스킵 로그 (Outbox 발행 안 함)")
         void skipsAfterConflictWhenRefreshedToPaid() {
-            // given
+            // given — save()에서 예외 발생 → OrderItem 조회/Outbox 발행 경로 미진입
             Order order = buildOrder(OrderStatus.PAYMENT_PENDING);
             willThrow(new ObjectOptimisticLockingFailureException(Order.class, order.getOrderId()))
                     .given(orderRepository).save(order);
@@ -129,10 +185,12 @@ class OrderExpirationCancelServiceTest {
 
             then(orderRepository).should().save(order);
             then(orderRepository).should().findByOrderId(order.getOrderId());
+            then(outboxService).shouldHaveNoInteractions();
+            then(orderItemRepository).shouldHaveNoInteractions();
         }
 
         @Test
-        @DisplayName("save 시 OptimisticLockException → 재조회 실패(null) → 경고 로그 후 종료")
+        @DisplayName("save 시 OptimisticLockException → 재조회 실패(null) → 경고 로그 후 종료 (Outbox 발행 안 함)")
         void warnsWhenRefreshReturnsEmpty() {
             // given
             Order order = buildOrder(OrderStatus.PAYMENT_PENDING);
@@ -147,10 +205,12 @@ class OrderExpirationCancelServiceTest {
             // then
             then(orderRepository).should().save(order);
             then(orderRepository).should().findByOrderId(order.getOrderId());
+            then(outboxService).shouldHaveNoInteractions();
+            then(orderItemRepository).shouldHaveNoInteractions();
         }
 
         @Test
-        @DisplayName("save 시 OptimisticLockException → 재조회 결과 PAYMENT_PENDING(비종단) → 재시도 필요 로그")
+        @DisplayName("save 시 OptimisticLockException → 재조회 결과 PAYMENT_PENDING(비종단) → 재시도 필요 로그 (Outbox 발행 안 함)")
         void retryNeededWhenStillPending() {
             // given
             Order order = buildOrder(OrderStatus.PAYMENT_PENDING);
@@ -166,6 +226,8 @@ class OrderExpirationCancelServiceTest {
             // then — 예외 전파 없음, catch 블록 진입 확인
             then(orderRepository).should().save(order);
             then(orderRepository).should().findByOrderId(order.getOrderId());
+            then(outboxService).shouldHaveNoInteractions();
+            then(orderItemRepository).shouldHaveNoInteractions();
         }
     }
 }

--- a/commerce/src/test/java/com/devticket/commerce/order/presentation/consumer/PaymentCompletedConsumerTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/order/presentation/consumer/PaymentCompletedConsumerTest.java
@@ -1,0 +1,195 @@
+package com.devticket.commerce.order.presentation.consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.order.application.usecase.OrderUsecase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentCompletedConsumerTest {
+
+    @Mock private OrderUsecase orderUsecase;
+    @Mock private Acknowledgment ack;
+
+    private PaymentCompletedConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        consumer = new PaymentCompletedConsumer(orderUsecase, new ObjectMapper());
+    }
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────
+
+    private ConsumerRecord<String, String> recordWithHeader(UUID messageId, String payload) {
+        ConsumerRecord<String, String> record =
+                new ConsumerRecord<>(KafkaTopics.PAYMENT_COMPLETED, 0, 0L, null, payload);
+        record.headers().add(new RecordHeader(
+                "X-Message-Id", messageId.toString().getBytes(StandardCharsets.UTF_8)));
+        return record;
+    }
+
+    private ConsumerRecord<String, String> recordWithoutHeader(String payload) {
+        return new ConsumerRecord<>(KafkaTopics.PAYMENT_COMPLETED, 0, 0L, null, payload);
+    }
+
+    // ── 테스트 ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("정상 흐름")
+    class HappyPath {
+
+        @Test
+        @DisplayName("X-Message-Id 헤더 정상 → OrderUsecase 호출 + ACK")
+        void 헤더_정상_처리시_서비스를_호출하고_ACK한다() {
+            // given
+            UUID messageId = UUID.randomUUID();
+            String payload = "{\"orderId\":\"" + UUID.randomUUID() + "\"}";
+            ConsumerRecord<String, String> record = recordWithHeader(messageId, payload);
+
+            // when
+            consumer.consume(record, ack);
+
+            // then
+            then(orderUsecase).should()
+                    .processPaymentCompleted(messageId, KafkaTopics.PAYMENT_COMPLETED, payload);
+            then(ack).should().acknowledge();
+        }
+
+        @Test
+        @DisplayName("헤더 없음 + 본문 messageId fallback → 처리 + ACK")
+        void 헤더가_없어도_본문_messageId로_fallback하여_처리한다() {
+            // given — Payment Outbox 발행 시 헤더 누락 시나리오
+            UUID messageId = UUID.randomUUID();
+            String payload = "{\"messageId\":\"" + messageId + "\",\"orderId\":\"xyz\"}";
+            ConsumerRecord<String, String> record = recordWithoutHeader(payload);
+
+            // when
+            consumer.consume(record, ack);
+
+            // then
+            then(orderUsecase).should()
+                    .processPaymentCompleted(eq(messageId), eq(KafkaTopics.PAYMENT_COMPLETED), any());
+            then(ack).should().acknowledge();
+        }
+
+        @Test
+        @DisplayName("Outbox wrapper(payload 필드) → payload 문자열만 추출되어 전달")
+        void Outbox_wrapper_payload_필드를_추출하여_전달한다() {
+            // given — {"messageId":"...","payload":"inner-json-string"}
+            UUID messageId = UUID.randomUUID();
+            String innerPayload = "inner-payload-content";
+            String wrapped = "{\"messageId\":\"" + messageId + "\","
+                    + "\"payload\":\"" + innerPayload + "\"}";
+            ConsumerRecord<String, String> record = recordWithoutHeader(wrapped);
+
+            // when
+            consumer.consume(record, ack);
+
+            // then
+            ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+            then(orderUsecase).should()
+                    .processPaymentCompleted(eq(messageId), eq(KafkaTopics.PAYMENT_COMPLETED),
+                            payloadCaptor.capture());
+            assertThat(payloadCaptor.getValue()).isEqualTo(innerPayload);
+            then(ack).should().acknowledge();
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성")
+    class Idempotency {
+
+        @Test
+        @DisplayName("DataIntegrityViolationException(processed_message UNIQUE 충돌) → 상태 변화 없이 ACK")
+        void 중복_메시지_수신시_상태변화_없이_ACK한다() {
+            // given — processed_message UNIQUE 충돌 시나리오 (동일 messageId 재수신)
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record = recordWithHeader(messageId, "{}");
+            org.hibernate.exception.ConstraintViolationException hibernateCause =
+                    new org.hibernate.exception.ConstraintViolationException(
+                            "duplicate key", null, "uk_processed_message_message_id_topic");
+            willThrow(new DataIntegrityViolationException("duplicate key", hibernateCause))
+                    .given(orderUsecase).processPaymentCompleted(any(), any(), any());
+
+            // when
+            consumer.consume(record, ack);
+
+            // then — 예외는 삼켜지고 ACK만 호출 (재시도 없이 종료)
+            then(ack).should().acknowledge();
+        }
+
+        @Test
+        @DisplayName("UNIQUE 외 constraint 위반 DIV → rethrow + ACK 없음 (Kafka 재시도 → DLT)")
+        void UNIQUE_외_무결성_위반은_rethrow된다() {
+            // given — 티켓/Outbox 등 다른 제약 위반 시나리오
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record = recordWithHeader(messageId, "{}");
+            org.hibernate.exception.ConstraintViolationException hibernateCause =
+                    new org.hibernate.exception.ConstraintViolationException(
+                            "fk violation", null, "fk_ticket_order_id");
+            willThrow(new DataIntegrityViolationException("fk violation", hibernateCause))
+                    .given(orderUsecase).processPaymentCompleted(any(), any(), any());
+
+            // when & then — 재시도 경로로 rethrow, ACK 호출 없음
+            assertThatThrownBy(() -> consumer.consume(record, ack))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+            then(ack).should(never()).acknowledge();
+        }
+
+        @Test
+        @DisplayName("Hibernate cause 없는 DIV → rethrow + ACK 없음")
+        void Hibernate_cause_없는_DIV는_rethrow된다() {
+            // given — DIV는 발생했으나 ConstraintViolationException 원인 체인 없음
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record = recordWithHeader(messageId, "{}");
+            willThrow(new DataIntegrityViolationException("unknown"))
+                    .given(orderUsecase).processPaymentCompleted(any(), any(), any());
+
+            // when & then
+            assertThatThrownBy(() -> consumer.consume(record, ack))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+            then(ack).should(never()).acknowledge();
+        }
+    }
+
+    @Nested
+    @DisplayName("messageId 추출 실패")
+    class InvalidMessageId {
+
+        @Test
+        @DisplayName("헤더·본문 모두 messageId 없음 → IllegalArgumentException + ACK 없음")
+        void messageId_추출_실패시_예외를_던지고_ACK하지_않는다() {
+            // given
+            ConsumerRecord<String, String> record = recordWithoutHeader("{\"orderId\":\"xyz\"}");
+
+            // when & then
+            assertThatThrownBy(() -> consumer.consume(record, ack))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("messageId");
+
+            then(ack).should(never()).acknowledge();
+            then(orderUsecase).shouldHaveNoInteractions();
+        }
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/order/presentation/consumer/PaymentFailedConsumerTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/order/presentation/consumer/PaymentFailedConsumerTest.java
@@ -1,0 +1,195 @@
+package com.devticket.commerce.order.presentation.consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.order.application.usecase.OrderUsecase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentFailedConsumerTest {
+
+    @Mock private OrderUsecase orderUsecase;
+    @Mock private Acknowledgment ack;
+
+    private PaymentFailedConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        consumer = new PaymentFailedConsumer(orderUsecase, new ObjectMapper());
+    }
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────
+
+    private ConsumerRecord<String, String> recordWithHeader(UUID messageId, String payload) {
+        ConsumerRecord<String, String> record =
+                new ConsumerRecord<>(KafkaTopics.PAYMENT_FAILED, 0, 0L, null, payload);
+        record.headers().add(new RecordHeader(
+                "X-Message-Id", messageId.toString().getBytes(StandardCharsets.UTF_8)));
+        return record;
+    }
+
+    private ConsumerRecord<String, String> recordWithoutHeader(String payload) {
+        return new ConsumerRecord<>(KafkaTopics.PAYMENT_FAILED, 0, 0L, null, payload);
+    }
+
+    // ── 테스트 ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("정상 흐름")
+    class HappyPath {
+
+        @Test
+        @DisplayName("X-Message-Id 헤더 정상 → OrderUsecase 호출 + ACK")
+        void 헤더_정상_처리시_서비스를_호출하고_ACK한다() {
+            // given
+            UUID messageId = UUID.randomUUID();
+            String payload = "{\"orderId\":\"" + UUID.randomUUID() + "\"}";
+            ConsumerRecord<String, String> record = recordWithHeader(messageId, payload);
+
+            // when
+            consumer.consume(record, ack);
+
+            // then
+            then(orderUsecase).should()
+                    .processPaymentFailed(messageId, KafkaTopics.PAYMENT_FAILED, payload);
+            then(ack).should().acknowledge();
+        }
+
+        @Test
+        @DisplayName("헤더 없음 + 본문 messageId fallback → 처리 + ACK")
+        void 헤더가_없어도_본문_messageId로_fallback하여_처리한다() {
+            // given
+            UUID messageId = UUID.randomUUID();
+            String payload = "{\"messageId\":\"" + messageId + "\",\"orderId\":\"xyz\"}";
+            ConsumerRecord<String, String> record = recordWithoutHeader(payload);
+
+            // when
+            consumer.consume(record, ack);
+
+            // then
+            then(orderUsecase).should()
+                    .processPaymentFailed(eq(messageId), eq(KafkaTopics.PAYMENT_FAILED), any());
+            then(ack).should().acknowledge();
+        }
+
+        @Test
+        @DisplayName("Outbox wrapper(payload 필드) → payload 문자열만 추출되어 전달")
+        void Outbox_wrapper_payload_필드를_추출하여_전달한다() {
+            // given
+            UUID messageId = UUID.randomUUID();
+            String innerPayload = "inner-payload-content";
+            String wrapped = "{\"messageId\":\"" + messageId + "\","
+                    + "\"payload\":\"" + innerPayload + "\"}";
+            ConsumerRecord<String, String> record = recordWithoutHeader(wrapped);
+
+            // when
+            consumer.consume(record, ack);
+
+            // then
+            ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+            then(orderUsecase).should()
+                    .processPaymentFailed(eq(messageId), eq(KafkaTopics.PAYMENT_FAILED),
+                            payloadCaptor.capture());
+            assertThat(payloadCaptor.getValue()).isEqualTo(innerPayload);
+            then(ack).should().acknowledge();
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성")
+    class Idempotency {
+
+        @Test
+        @DisplayName("DataIntegrityViolationException(processed_message UNIQUE 충돌) → 상태 변화 없이 ACK")
+        void 중복_메시지_수신시_상태변화_없이_ACK한다() {
+            // given — processed_message UNIQUE 충돌 (동일 messageId 재수신)
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record = recordWithHeader(messageId, "{}");
+            org.hibernate.exception.ConstraintViolationException hibernateCause =
+                    new org.hibernate.exception.ConstraintViolationException(
+                            "duplicate key", null, "uk_processed_message_message_id_topic");
+            willThrow(new DataIntegrityViolationException("duplicate key", hibernateCause))
+                    .given(orderUsecase).processPaymentFailed(any(), any(), any());
+
+            // when
+            consumer.consume(record, ack);
+
+            // then — 예외 삼켜지고 ACK만 호출
+            then(ack).should().acknowledge();
+        }
+
+        @Test
+        @DisplayName("UNIQUE 외 constraint 위반 DIV → rethrow + ACK 없음 (Kafka 재시도 → DLT)")
+        void UNIQUE_외_무결성_위반은_rethrow된다() {
+            // given — Outbox/Order 등 다른 제약 위반 시나리오
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record = recordWithHeader(messageId, "{}");
+            org.hibernate.exception.ConstraintViolationException hibernateCause =
+                    new org.hibernate.exception.ConstraintViolationException(
+                            "fk violation", null, "fk_outbox_order_id");
+            willThrow(new DataIntegrityViolationException("fk violation", hibernateCause))
+                    .given(orderUsecase).processPaymentFailed(any(), any(), any());
+
+            // when & then — 재시도 경로로 rethrow, ACK 호출 없음
+            assertThatThrownBy(() -> consumer.consume(record, ack))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+            then(ack).should(never()).acknowledge();
+        }
+
+        @Test
+        @DisplayName("Hibernate cause 없는 DIV → rethrow + ACK 없음")
+        void Hibernate_cause_없는_DIV는_rethrow된다() {
+            // given
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record = recordWithHeader(messageId, "{}");
+            willThrow(new DataIntegrityViolationException("unknown"))
+                    .given(orderUsecase).processPaymentFailed(any(), any(), any());
+
+            // when & then
+            assertThatThrownBy(() -> consumer.consume(record, ack))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+            then(ack).should(never()).acknowledge();
+        }
+    }
+
+    @Nested
+    @DisplayName("messageId 추출 실패")
+    class InvalidMessageId {
+
+        @Test
+        @DisplayName("헤더·본문 모두 messageId 없음 → IllegalArgumentException + ACK 없음")
+        void messageId_추출_실패시_예외를_던지고_ACK하지_않는다() {
+            // given
+            ConsumerRecord<String, String> record = recordWithoutHeader("{\"orderId\":\"xyz\"}");
+
+            // when & then
+            assertThatThrownBy(() -> consumer.consume(record, ack))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("messageId");
+
+            then(ack).should(never()).acknowledge();
+            then(orderUsecase).shouldHaveNoInteractions();
+        }
+    }
+}

--- a/commerce/src/test/resources/application-test.yml
+++ b/commerce/src/test/resources/application-test.yml
@@ -1,0 +1,40 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;NON_KEYWORDS=ORDER;INIT=CREATE SCHEMA IF NOT EXISTS commerce
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        default_schema: commerce
+  kafka:
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      group-id: commerce-integration-test
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      enable-auto-commit: false
+    listener:
+      ack-mode: manual
+
+external:
+  event-base-url: http://localhost:8082
+  payment-base-url: http://localhost:8084
+  member-base-url: http://localhost:8081
+
+logging:
+  level:
+    org.hibernate.SQL: WARN
+    com.devticket: INFO
+    org.apache.kafka: WARN
+    org.springframework.kafka: WARN
+    state.change.logger: WARN
+    kafka.server: WARN


### PR DESCRIPTION
## Summary
  - `payment.completed` / `payment.failed` Consumer 구현 — Order `PAID` / `FAILED` 전이 (Phase 4 / impl-plan #8)
  - `OrderExpirationScheduler` + `OrderExpirationCancelService` — PAYMENT_PENDING 30분 만료 처리
  - 만료 취소 시 `payment.failed` Outbox 발행 (`reason="ORDER_TIMEOUT"`) — Event 모듈이 재고 복구
  - **PR 리뷰 피드백 5건 전건 반영 + 통합테스트 보강**

  ## 변경 범위 (kafka-impl-plan.md Phase 4)
  - [x] `PaymentCompletedConsumer` — payment.completed 수신 → Order PAID 전이 + 티켓 발급 + 장바구니 삭제
  - [x] `PaymentFailedConsumer` — payment.failed 수신 → Order FAILED 전이
  - [x] `OrderExpirationScheduler` + `OrderExpirationCancelService` — PAYMENT_PENDING `updated_at + 30분` 만료
  처리 + `payment.failed` Outbox 발행
  - [x] Consumer DIV 예외 정제 — `processed_message` UNIQUE constraint 명시 확인 후 ACK, 그 외 rethrow → DLT
  - [x] `Order.updateTotalAmount` `@Deprecated` — `updated_at` 재활용 안전장치

  ## 리뷰 피드백 반영 (커밋 `13c87e2`, `cc62b31`, `e459e81`)
  - [x] **Codex P1** 만료 취소 재고 복구 누락 → `OrderExpirationCancelService` 에 `payment.failed` Outbox 발행
  추가
  - [x] **Codex P1** Consumer DIV 무조건 ACK → `isProcessedMessageUniqueConflict()` 로 constraint 이름 확인
  - [x] **Codex P2** 만료 기준 `created_at` → `updated_at` (PAYMENT_PENDING 진입 시각 기준)
  - [x] **멘토** SchedulerLock `lockAtMostFor` 50s → 2m (중복 실행 경로 축소) + 이중 가드 JavaDoc
  - [x] **멘토** ACK 미호출 무한 재시도 우려 → 운영 `KafkaConsumerConfig`(ExponentialBackOff 2→4→8초 + DLT
  Recoverer) 이미 존재 확인 + IT-3 DLT 이동 실증

  ## 설계 문서 매핑
  - `docs/kafka-design.md §3` — PaymentFailedEvent `reason` 허용값 표 (`ORDER_TIMEOUT` 포함)
  - `docs/kafka-impl-plan.md §3-2` — 주문 만료 스케줄러 체크리스트
  - `docs/schema_plan.md` — `updated_at` 재활용 결정 기록
  - `docs/kafka-idempotency-guide.md §10` — 재고 복구 Outbox 원칙

  ## 스코프 외 (후속 PR)
  - `#9` Event 모듈 `payment.failed` Consumer (재고 RESTORED 전이) — 별도 레포
  - 환불 Saga — 본 스코프 제외

  ## Test plan
  - [x] **단위 테스트 24건 통과** — Order/Consumer/Scheduler
  - [x] **통합 테스트 (EmbeddedKafka + H2)**
    - [x] IT-1 주문생성 플로우: `order.created` 발행 + `stock.deducted/failed` 수신 → PAYMENT_PENDING/FAILED 전이
    - [x] IT-2 만료 플로우: `updated_at + 30분` → CANCELLED + `payment.failed` Kafka
  payload(`reason=ORDER_TIMEOUT`) 검증
    - [x] IT-3 DLT 이동: 예외 → 재시도 소진 → `{topic}.DLT` 수신 + X-Message-Id 헤더 보존
  - [x] 멱등성 검증 — `processed_message` UNIQUE 충돌 ACK / UNIQUE 외 DIV rethrow 각각 단위 + 통합 테스트

  ## Notes
  - 후속 커밋:
    - `13c87e2` 피드백 코드 반영 + 단위 테스트 보강
    - `cc62b31` 통합테스트 인프라 + IT-1 (팀 스코프 — 취합된 주문생성 경로)
    - `e459e81` 피드백 통합 검증 IT-2 + IT-3