### PR TITLE
[Commerce] fix: Cart 멱등 응답 + UNIQUE 가드 + 결제완료 카트 정리 (#416, #427)

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
@@ -65,15 +65,16 @@ public class CartService implements CartUseCase, CartItemUseCase {
         return CartItemResponse.of(cart, cartItem, event.title(), event.price());
     }
 
-    // 장바구니 전체 조회
+    // 장바구니 전체 조회 — Cart row가 없으면 빈 응답 반환 (#416: 신규 사용자 400 → 200)
     @Override
     public CartResponse getCart(UUID userId) {
-        // 장바구니 비어 있음 예외
-        Cart cart = getCartByUserId(userId);
-        // 장바구니 내 아이템 조회
+        Cart cart = cartRepository.findByUserId(userId).orElse(null);
+        if (cart == null) {
+            return CartResponse.empty();
+        }
+
         List<CartItem> cartItems = cartItemRepository.findAllByCartId(cart.getId());
 
-        // 아이템 -> 아이템 상세
         List<CartItemDetail> itemDetails = cartItems.stream()
             .map(cartItem -> {
                 InternalPurchaseValidationResponse event =
@@ -84,20 +85,25 @@ public class CartService implements CartUseCase, CartItemUseCase {
         return CartResponse.of(cart, itemDetails);
     }
 
-    // 장바구니 비우기
+    // 장바구니 비우기 — Cart row가 없으면 멱등 성공 반환 (#416: 이미 비어있음도 성공으로 취급)
     @Override
     public CartClearResponse clearCart(UUID userId) {
-        Cart cart = getCartByUserId(userId);
+        Cart cart = cartRepository.findByUserId(userId).orElse(null);
+        if (cart == null) {
+            return CartClearResponse.of();
+        }
         List<CartItem> cartItems = cartItemRepository.findAllByCartId(cart.getId());
-        cartItemRepository.deleteAllInBatch(cartItems);
+        if (!cartItems.isEmpty()) {
+            cartItemRepository.deleteAllInBatch(cartItems);
+        }
         return CartClearResponse.of();
     }
 
     // 장바구니 아이템 갯수 증감
     @Override
     public CartItemQuantityResponse updateTicket(UUID userId, Long cartItemId, CartItemQuantityRequest request) {
-        // 장바구니 가져오기
-        Cart cart = getCartByUserId(userId);
+        // 장바구니 가져오기 — Cart 없으면 ITEM_NOT_FOUND (#416)
+        Cart cart = getCartOrThrowItemNotFound(userId);
         // 장바구니 아이템 가져오기
         CartItem cartItem = getCartItemById(cartItemId);
 
@@ -125,8 +131,8 @@ public class CartService implements CartUseCase, CartItemUseCase {
     // 장바구니 아이템 삭제
     @Override
     public CartItemDeleteResponse deleteTicket(UUID userId, Long cartItemId) {
-        // 장바구니 가져오기
-        Cart cart = getCartByUserId(userId);
+        // 장바구니 가져오기 — Cart 없으면 ITEM_NOT_FOUND (#416)
+        Cart cart = getCartOrThrowItemNotFound(userId);
         // 장바구니 아이템 가져오기
         CartItem cartItem = getCartItemById(cartItemId);
 
@@ -159,17 +165,28 @@ public class CartService implements CartUseCase, CartItemUseCase {
     }
 
     private CartItem addOrUpdateCartItem(Long cartId, CartItemRequest request) {
-        return cartItemRepository.findByCartIdAndEventId(cartId, request.eventId())
-            .map(existingItem -> {
-                log.info("[CartService] 기존 아이템 수량 추가: cartId={}, eventId={}", cartId, request.eventId());
-                existingItem.addQuantity(request.quantity());
-                return cartItemRepository.save(existingItem);
-            })
-            .orElseGet(() -> {
-                log.info("[CartService] 신규 아이템 생성: cartId={}, eventId={}", cartId, request.eventId());
-                CartItem newItem = CartItem.create(cartId, request.eventId(), request.quantity());
-                return cartItemRepository.save(newItem);
-            });
+        try {
+            return cartItemRepository.findByCartIdAndEventId(cartId, request.eventId())
+                .map(existingItem -> {
+                    log.info("[CartService] 기존 아이템 수량 추가: cartId={}, eventId={}", cartId, request.eventId());
+                    existingItem.addQuantity(request.quantity());
+                    return cartItemRepository.save(existingItem);
+                })
+                .orElseGet(() -> {
+                    log.info("[CartService] 신규 아이템 생성: cartId={}, eventId={}", cartId, request.eventId());
+                    CartItem newItem = CartItem.create(cartId, request.eventId(), request.quantity());
+                    return cartItemRepository.save(newItem);
+                });
+        } catch (DataIntegrityViolationException e) {
+            // 광클 race: 동시 INSERT 중 다른 트랜잭션이 먼저 커밋 → (cart_id, event_id) UNIQUE 위반
+            // findOrCreateCart 와 동일한 복구 패턴 — 재조회 후 수량 합산
+            log.warn("[CartService] addOrUpdateCartItem UNIQUE 충돌 감지 — race 복구 재조회. cartId={}, eventId={}",
+                cartId, request.eventId());
+            CartItem existing = cartItemRepository.findByCartIdAndEventId(cartId, request.eventId())
+                .orElseThrow(() -> new RuntimeException("장바구니 아이템 확보 실패", e));
+            existing.addQuantity(request.quantity());
+            return cartItemRepository.save(existing);
+        }
     }
 
     // Event에서 반환된 reason값 기준 에러 처리
@@ -198,10 +215,10 @@ public class CartService implements CartUseCase, CartItemUseCase {
     }
 
 
-    // 장바구니 존재 유무 확인
-    private Cart getCartByUserId(UUID userId) {
+    // Cart row 없음도 단건 ITEM_NOT_FOUND 로 통일 (#416: CART_EMPTY 400 대신 404 매핑)
+    private Cart getCartOrThrowItemNotFound(UUID userId) {
         return cartRepository.findByUserId(userId)
-            .orElseThrow(() -> new BusinessException(CartErrorCode.CART_EMPTY));
+            .orElseThrow(() -> new BusinessException(CartErrorCode.ITEM_NOT_FOUND));
     }
 
     // 장바구니 아이템 존재 유무 확인

--- a/commerce/src/main/java/com/devticket/commerce/cart/domain/model/CartItem.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/domain/model/CartItem.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -22,7 +23,14 @@ import lombok.experimental.SuperBuilder;
 @Entity
 @Getter
 @SuperBuilder
-@Table(name = "cart_item", schema = "commerce")
+@Table(
+    name = "cart_item",
+    schema = "commerce",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_cart_item_cart_event",
+        columnNames = {"cart_id", "event_id"}
+    )
+)
 // JPA 엔티티를 위한 기본생성자 필수
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 // 전체 생성자는 내부에서만 사용

--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartResponse.java
@@ -33,4 +33,13 @@ public record CartResponse(
             .build();
     }
 
+    // 신규 사용자 또는 Cart row가 없는 경우: 400 대신 200 빈 응답 반환 (#416)
+    public static CartResponse empty() {
+        return CartResponse.builder()
+            .cartId(null)
+            .items(List.of())
+            .totalAmount(0)
+            .build();
+    }
+
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -46,6 +46,7 @@ import com.devticket.commerce.ticket.presentation.dto.req.TicketRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.stream.IntStream;
 import java.util.List;
@@ -482,12 +483,34 @@ public class OrderService implements OrderUsecase {
             return;
         }
 
-        // 장바구니 비우기 (카트가 없으면 무시)
-        Optional<Cart> cart = cartRepository.findByUserId(event.userId());
-        cart.ifPresent(c -> {
-            List<CartItem> cartItems = cartItemRepository.findAllByCartId(c.getId());
-            if (!cartItems.isEmpty()) {
-                cartItemRepository.deleteAllInBatch(cartItems);
+        // 장바구니 분기 삭제 (A안, #427) — 결제된 OrderItem eventId별 총 qty를 카트에서 차감
+        //   - (cart_id, event_id) UNIQUE 전제: eventId당 CartItem은 0 또는 1개
+        //   - remaining == 0 이면 row 삭제, 그 외 quantity 갱신
+        //   - 결제 대상이 아닌 CartItem 은 카트에 보존 (부분 결제 UX 대응)
+        Map<UUID, Integer> orderedByEvent = orderItems.stream()
+                .collect(Collectors.toMap(
+                        OrderItem::getEventId,
+                        OrderItem::getQuantity,
+                        Integer::sum
+                ));
+        cartRepository.findByUserId(event.userId()).ifPresent(cart -> {
+            List<CartItem> cartItems = cartItemRepository.findAllByCartId(cart.getId());
+            List<CartItem> toDelete = new ArrayList<>();
+            for (CartItem cartItem : cartItems) {
+                Integer orderedQty = orderedByEvent.get(cartItem.getEventId());
+                if (orderedQty == null) {
+                    continue;
+                }
+                int deduct = Math.min(orderedQty, cartItem.getQuantity());
+                int remaining = cartItem.getQuantity() - deduct;
+                if (remaining == 0) {
+                    toDelete.add(cartItem);
+                } else {
+                    cartItem.updateQuantity(remaining);
+                }
+            }
+            if (!toDelete.isEmpty()) {
+                cartItemRepository.deleteAllInBatch(toDelete);
             }
         });
 

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -484,7 +484,8 @@ public class OrderService implements OrderUsecase {
         }
 
         // 장바구니 분기 삭제 (A안, #427) — 결제된 OrderItem eventId별 총 qty를 카트에서 차감
-        //   - (cart_id, event_id) UNIQUE 전제: eventId당 CartItem은 0 또는 1개
+        //   - 차감 후 orderedByEvent 잔여 수량을 갱신/제거 → 동일 eventId 행이 복수일 때 과차감 방지
+        //     (UNIQUE 제약은 신규 데이터에 대해서만 보장 — 레거시 중복 행 가능성 방어)
         //   - remaining == 0 이면 row 삭제, 그 외 quantity 갱신
         //   - 결제 대상이 아닌 CartItem 은 카트에 보존 (부분 결제 UX 대응)
         Map<UUID, Integer> orderedByEvent = orderItems.stream()
@@ -498,7 +499,7 @@ public class OrderService implements OrderUsecase {
             List<CartItem> toDelete = new ArrayList<>();
             for (CartItem cartItem : cartItems) {
                 Integer orderedQty = orderedByEvent.get(cartItem.getEventId());
-                if (orderedQty == null) {
+                if (orderedQty == null || orderedQty == 0) {
                     continue;
                 }
                 int deduct = Math.min(orderedQty, cartItem.getQuantity());
@@ -507,6 +508,12 @@ public class OrderService implements OrderUsecase {
                     toDelete.add(cartItem);
                 } else {
                     cartItem.updateQuantity(remaining);
+                }
+                int remainingOrder = orderedQty - deduct;
+                if (remainingOrder == 0) {
+                    orderedByEvent.remove(cartItem.getEventId());
+                } else {
+                    orderedByEvent.put(cartItem.getEventId(), remainingOrder);
                 }
             }
             if (!toDelete.isEmpty()) {

--- a/commerce/src/test/java/com/devticket/commerce/integration/CartFlowIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/CartFlowIntegrationTest.java
@@ -1,0 +1,105 @@
+package com.devticket.commerce.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.devticket.commerce.cart.application.usecase.CartItemUseCase;
+import com.devticket.commerce.cart.application.usecase.CartUseCase;
+import com.devticket.commerce.cart.domain.exception.CartErrorCode;
+import com.devticket.commerce.cart.infrastructure.external.client.EventClient;
+import com.devticket.commerce.cart.presentation.dto.req.CartItemQuantityRequest;
+import com.devticket.commerce.cart.presentation.dto.res.CartClearResponse;
+import com.devticket.commerce.cart.presentation.dto.res.CartResponse;
+import com.devticket.commerce.common.exception.BusinessException;
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import java.util.Optional;
+import java.util.UUID;
+import net.javacrumbs.shedlock.core.LockProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * IT-#416 장바구니 빈 카트 UX 일관성 통합테스트.
+ *
+ * <p>검증 대상:
+ * <ul>
+ *   <li>신규 사용자(Cart row 없음) getCart → 200 빈 응답
+ *   <li>Cart 없는 사용자 clearCart → 200 멱등 성공
+ *   <li>Cart 없는 사용자 updateTicket/deleteTicket → 404 ITEM_NOT_FOUND
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(
+        partitions = 1,
+        topics = {KafkaTopics.ORDER_CREATED},
+        bootstrapServersProperty = "spring.kafka.bootstrap-servers"
+)
+@DirtiesContext
+class CartFlowIntegrationTest {
+
+    @MockitoBean private LockProvider lockProvider;
+    @MockitoBean private EventClient eventClient;
+
+    @Autowired private CartUseCase cartUseCase;
+    @Autowired private CartItemUseCase cartItemUseCase;
+
+    @BeforeEach
+    void setUp() {
+        given(lockProvider.lock(any())).willReturn(Optional.of(() -> {}));
+    }
+
+    @Test
+    @DisplayName("IT-#416-A: 신규 사용자 getCart → 200 빈 응답")
+    void getCartReturnsEmptyForNewUser() {
+        UUID userId = UUID.randomUUID();
+
+        CartResponse response = cartUseCase.getCart(userId);
+
+        assertThat(response.cartId()).isNull();
+        assertThat(response.items()).isEmpty();
+        assertThat(response.totalAmount()).isZero();
+    }
+
+    @Test
+    @DisplayName("IT-#416-B: Cart 없는 사용자 clearCart → 200 멱등 성공")
+    void clearCartIsIdempotentForNewUser() {
+        UUID userId = UUID.randomUUID();
+
+        CartClearResponse response = cartUseCase.clearCart(userId);
+
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    @DisplayName("IT-#416-C: Cart 없는 사용자 updateTicket → ITEM_NOT_FOUND 404")
+    void updateTicketThrowsItemNotFoundForNewUser() {
+        UUID userId = UUID.randomUUID();
+        CartItemQuantityRequest request = new CartItemQuantityRequest(1);
+
+        assertThatThrownBy(() -> cartItemUseCase.updateTicket(userId, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(CartErrorCode.ITEM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("IT-#416-D: Cart 없는 사용자 deleteTicket → ITEM_NOT_FOUND 404")
+    void deleteTicketThrowsItemNotFoundForNewUser() {
+        UUID userId = UUID.randomUUID();
+
+        assertThatThrownBy(() -> cartItemUseCase.deleteTicket(userId, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(CartErrorCode.ITEM_NOT_FOUND);
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/integration/PaymentCompletedCartIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/PaymentCompletedCartIntegrationTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -52,6 +53,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
  *   <li>B. 부분 결제 → 결제된 eventId 만 삭제, 미주문 아이템 보존
  *   <li>C. 수량 일부만 결제 → row 보존 + quantity 차감
  *   <li>D. 광클 race → (cart_id, event_id) UNIQUE 차단 + catch 복구 → 최종 row 1개 유지
+ *   <li>E. 동일 eventId 중복 행(레거시) → 차감량 소진으로 과차감 방지
  * </ul>
  */
 @SpringBootTest
@@ -74,6 +76,7 @@ class PaymentCompletedCartIntegrationTest {
     @Autowired private CartRepository cartRepository;
     @Autowired private CartItemRepository cartItemRepository;
     @Autowired private ObjectMapper objectMapper;
+    @Autowired private JdbcTemplate jdbcTemplate;
 
     @BeforeEach
     void setUp() {
@@ -193,6 +196,44 @@ class PaymentCompletedCartIntegrationTest {
         assertThat(rows).hasSize(1);
         assertThat(rows.get(0).getEventId()).isEqualTo(eventId);
         assertThat(rows.get(0).getQuantity()).isBetween(1, threadCount);
+    }
+
+    @Test
+    @DisplayName("IT-#427-E: 동일 eventId 중복 행(레거시) → 차감량 소진으로 과차감 방지")
+    void duplicateRows_preventOverDeduction() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID eventA = UUID.randomUUID();
+
+        Cart cart = cartRepository.save(Cart.create(userId));
+        cartItemRepository.save(CartItem.create(cart.getId(), eventA, 1));
+
+        // UNIQUE 제약 일시 DROP — 레거시 중복 행 시뮬레이션
+        jdbcTemplate.execute(
+                "ALTER TABLE commerce.cart_item DROP CONSTRAINT IF EXISTS uk_cart_item_cart_event");
+        try {
+            // 동일 (cart_id, event_id) 두 번째 행 — 제약 없음 상태로 INSERT 가능
+            cartItemRepository.save(CartItem.create(cart.getId(), eventA, 1));
+
+            // 주문: eventA 1개만 결제
+            Order order = savePendingOrder(userId, 10_000, "hash-E");
+            orderItemRepository.save(OrderItem.create(order.getId(), userId, eventA, 10_000, 1, 10));
+
+            String payload = paymentCompletedPayload(order.getOrderId(), userId, 10_000);
+
+            orderService.processPaymentCompleted(
+                    UUID.randomUUID(), KafkaTopics.PAYMENT_COMPLETED, payload);
+
+            // 차감량 소진 적용 시: 1개 행만 삭제, 1개 행 보존 (과차감 방지)
+            List<CartItem> remaining = cartItemRepository.findAllByCartId(cart.getId());
+            assertThat(remaining).hasSize(1);
+            assertThat(remaining.get(0).getEventId()).isEqualTo(eventA);
+            assertThat(remaining.get(0).getQuantity()).isEqualTo(1);
+        } finally {
+            // UNIQUE 제약 복구 — 다른 테스트 격리
+            jdbcTemplate.execute(
+                    "ALTER TABLE commerce.cart_item ADD CONSTRAINT uk_cart_item_cart_event "
+                            + "UNIQUE (cart_id, event_id)");
+        }
     }
 
     private Order savePendingOrder(UUID userId, int totalAmount, String hashPrefix) {

--- a/commerce/src/test/java/com/devticket/commerce/integration/PaymentCompletedCartIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/PaymentCompletedCartIntegrationTest.java
@@ -1,0 +1,210 @@
+package com.devticket.commerce.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+
+import com.devticket.commerce.cart.application.usecase.CartUseCase;
+import com.devticket.commerce.cart.domain.model.Cart;
+import com.devticket.commerce.cart.domain.model.CartItem;
+import com.devticket.commerce.cart.domain.repository.CartItemRepository;
+import com.devticket.commerce.cart.domain.repository.CartRepository;
+import com.devticket.commerce.cart.infrastructure.external.client.EventClient;
+import com.devticket.commerce.cart.infrastructure.external.client.dto.InternalPurchaseValidationResponse;
+import com.devticket.commerce.cart.presentation.dto.req.CartItemRequest;
+import com.devticket.commerce.common.enums.PaymentMethod;
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.common.messaging.event.PaymentCompletedEvent;
+import com.devticket.commerce.order.application.service.OrderService;
+import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.model.OrderItem;
+import com.devticket.commerce.order.domain.repository.OrderItemRepository;
+import com.devticket.commerce.order.domain.repository.OrderRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import net.javacrumbs.shedlock.core.LockProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * IT-#427 cart_hash 분기 삭제(A안) 통합테스트 — payment.completed 수신 후 카트 차감 로직.
+ *
+ * <p>검증 대상:
+ * <ul>
+ *   <li>A. 카트 전체 결제 → 모든 CartItem 삭제
+ *   <li>B. 부분 결제 → 결제된 eventId 만 삭제, 미주문 아이템 보존
+ *   <li>C. 수량 일부만 결제 → row 보존 + quantity 차감
+ *   <li>D. 광클 race → (cart_id, event_id) UNIQUE 차단 + catch 복구 → 최종 row 1개 유지
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(
+        partitions = 1,
+        topics = {KafkaTopics.PAYMENT_COMPLETED, KafkaTopics.TICKET_ISSUE_FAILED},
+        bootstrapServersProperty = "spring.kafka.bootstrap-servers"
+)
+@DirtiesContext
+class PaymentCompletedCartIntegrationTest {
+
+    @MockitoBean private LockProvider lockProvider;
+    @MockitoBean private EventClient eventClient;
+
+    @Autowired private OrderService orderService;
+    @Autowired private CartUseCase cartUseCase;
+    @Autowired private OrderRepository orderRepository;
+    @Autowired private OrderItemRepository orderItemRepository;
+    @Autowired private CartRepository cartRepository;
+    @Autowired private CartItemRepository cartItemRepository;
+    @Autowired private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        given(lockProvider.lock(any())).willReturn(Optional.of(() -> {}));
+    }
+
+    @Test
+    @DisplayName("IT-#427-A: 카트 전체 결제 → 모든 CartItem 삭제")
+    void fullPayment_deletesAllCartItems() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID eventA = UUID.randomUUID();
+        UUID eventB = UUID.randomUUID();
+
+        Cart cart = cartRepository.save(Cart.create(userId));
+        cartItemRepository.save(CartItem.create(cart.getId(), eventA, 2));
+        cartItemRepository.save(CartItem.create(cart.getId(), eventB, 3));
+
+        Order order = savePendingOrder(userId, 50_000, "hash-A");
+        orderItemRepository.save(OrderItem.create(order.getId(), userId, eventA, 10_000, 2, 10));
+        orderItemRepository.save(OrderItem.create(order.getId(), userId, eventB, 10_000, 3, 10));
+
+        String payload = paymentCompletedPayload(order.getOrderId(), userId, 50_000);
+
+        orderService.processPaymentCompleted(UUID.randomUUID(), KafkaTopics.PAYMENT_COMPLETED, payload);
+
+        List<CartItem> remaining = cartItemRepository.findAllByCartId(cart.getId());
+        assertThat(remaining).isEmpty();
+    }
+
+    @Test
+    @DisplayName("IT-#427-B: 부분 결제 → 결제분만 삭제, 미주문 아이템은 보존")
+    void partialPayment_keepsUnorderedItems() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID eventA = UUID.randomUUID();
+        UUID eventB = UUID.randomUUID();
+        UUID eventC = UUID.randomUUID();
+
+        Cart cart = cartRepository.save(Cart.create(userId));
+        cartItemRepository.save(CartItem.create(cart.getId(), eventA, 1));
+        cartItemRepository.save(CartItem.create(cart.getId(), eventB, 2));
+        cartItemRepository.save(CartItem.create(cart.getId(), eventC, 3));
+
+        Order order = savePendingOrder(userId, 30_000, "hash-B");
+        orderItemRepository.save(OrderItem.create(order.getId(), userId, eventA, 10_000, 1, 10));
+        orderItemRepository.save(OrderItem.create(order.getId(), userId, eventB, 10_000, 2, 10));
+
+        String payload = paymentCompletedPayload(order.getOrderId(), userId, 30_000);
+
+        orderService.processPaymentCompleted(UUID.randomUUID(), KafkaTopics.PAYMENT_COMPLETED, payload);
+
+        List<CartItem> remaining = cartItemRepository.findAllByCartId(cart.getId());
+        assertThat(remaining).hasSize(1);
+        assertThat(remaining.get(0).getEventId()).isEqualTo(eventC);
+        assertThat(remaining.get(0).getQuantity()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("IT-#427-C: 수량 일부만 결제 → row 보존 + quantity 차감")
+    void partialQuantityPayment_keepsRowWithRemaining() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID eventA = UUID.randomUUID();
+
+        Cart cart = cartRepository.save(Cart.create(userId));
+        cartItemRepository.save(CartItem.create(cart.getId(), eventA, 5));
+
+        Order order = savePendingOrder(userId, 20_000, "hash-C");
+        orderItemRepository.save(OrderItem.create(order.getId(), userId, eventA, 10_000, 2, 10));
+
+        String payload = paymentCompletedPayload(order.getOrderId(), userId, 20_000);
+
+        orderService.processPaymentCompleted(UUID.randomUUID(), KafkaTopics.PAYMENT_COMPLETED, payload);
+
+        List<CartItem> remaining = cartItemRepository.findAllByCartId(cart.getId());
+        assertThat(remaining).hasSize(1);
+        assertThat(remaining.get(0).getEventId()).isEqualTo(eventA);
+        assertThat(remaining.get(0).getQuantity()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("IT-#427-D: 광클 race — 동시 addToCart 4회, (cart_id, event_id) UNIQUE + catch 복구")
+    void raceSimulation_uniqueAndCatch() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+
+        cartRepository.save(Cart.create(userId));
+
+        given(eventClient.getValidateEventStatus(any(), any(), anyInt()))
+                .willReturn(new InternalPurchaseValidationResponse(
+                        eventId, Boolean.TRUE, null, 10, "이벤트-race", 10_000));
+
+        int threadCount = 4;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    cartUseCase.save(userId, new CartItemRequest(eventId, 1));
+                } catch (Throwable t) {
+                    errors.add(t);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertThat(doneLatch.await(10, TimeUnit.SECONDS)).isTrue();
+        executor.shutdown();
+
+        Cart cart = cartRepository.findByUserId(userId).orElseThrow();
+        List<CartItem> rows = cartItemRepository.findAllByCartId(cart.getId());
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getEventId()).isEqualTo(eventId);
+        assertThat(rows.get(0).getQuantity()).isBetween(1, threadCount);
+    }
+
+    private Order savePendingOrder(UUID userId, int totalAmount, String hashPrefix) {
+        Order order = Order.create(userId, totalAmount, hashPrefix + "-" + UUID.randomUUID());
+        Order saved = orderRepository.save(order);
+        saved.pendingPayment();
+        return orderRepository.save(saved);
+    }
+
+    private String paymentCompletedPayload(UUID orderId, UUID userId, int totalAmount) throws Exception {
+        PaymentCompletedEvent event = new PaymentCompletedEvent(
+                orderId, userId, UUID.randomUUID(), PaymentMethod.PG, totalAmount, Instant.now());
+        return objectMapper.writeValueAsString(event);
+    }
+}


### PR DESCRIPTION
## Summary
- **#416** Cart 응답 멱등성 + 누락 아이템 404 매핑 + (cart_id, event_id) UNIQUE 동시성 가드
- **#427** 결제완료 시 주문 수량만큼 CartItem 차감 (qty=0 row 자동 삭제)
- 통합 테스트 8건 신규 (CartFlow*, PaymentCompletedCart*)

## 변경 상세

### #416 — Cart 응답 멱등성 + UNIQUE 동시성 가드 (커밋 `08671d0`)
- [x] `CartResponse.empty()` 정적 팩토리 추가
- [x] `CartService.getCart` — 빈 카트도 200 빈 응답
- [x] `CartService.clearCart` — Cart 없어도 200 멱등 응답
- [x] `updateTicket` / `deleteTicket` — 누락 아이템 → `ITEM_NOT_FOUND`(404) 매핑 (헬퍼 `getCartOrThrowItemNotFound`)
- [x] `CartItem` `(cart_id, event_id)` UNIQUE 제약 추가 (`uk_cart_item_cart_event`)
- [x] `addOrUpdateCartItem` — `DataIntegrityViolationException` catch → 재조회 후 수량 합산

### #427 — 결제완료 시 카트 자동 정리 (커밋 `bf67784`)
- [x] `OrderService.processPaymentCompleted` — A안(전체 삭제) 분기 제거
- [x] `eventId` 그룹핑 → `min(orderQty, cartQty)`만큼 `CartItem.quantity` 차감
- [x] 차감 후 `quantity=0` row 자동 삭제

## Test plan
- [x] **통합 테스트 8건 신규 (전부 통과)**
  - IT-#416-A 신규 사용자 getCart → 200 빈 응답
  - IT-#416-B Cart 없는 사용자 clearCart → 200 멱등
  - IT-#416-C updateTicket → 404 ITEM_NOT_FOUND
  - IT-#416-D deleteTicket → 404 ITEM_NOT_FOUND
  - IT-#427-A 카트 전체 결제 → 모든 CartItem 삭제
  - IT-#427-B 부분 결제 → 결제분만 삭제, 미주문 보존
  - IT-#427-C 수량 일부 결제 → row 보존 + quantity 차감
  - IT-#427-D 광클 race → UNIQUE 차단 + catch 복구
- [x] **전체 81개 테스트 통과 — 회귀 없음**

## ⚠️ Known Limitation — 광클 race

- IT-#427-D 통과하나 catch 시 Hibernate 세션 오염 경고 관찰
- **최종 정합성은 유지** (UNIQUE 제약) — 다만 수량 합산이 항상 성공하지 않음
- 방어선은 본 PR에서 제공, UPSERT 전환은 별도 이슈로 추적: #435

## Closes
Closes #416
Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)