### PR TITLE
[Settlement] feat:  event,commerce서비스의 정산대상데이터 요청 API연결, 테스트용 엔드포인트 설정

### DIFF
--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementService.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementService.java
@@ -3,6 +3,8 @@ package com.devticket.settlement.application.service;
 import com.devticket.settlement.infrastructure.client.dto.res.InternalSettlementDataResponse;
 import com.devticket.settlement.presentation.dto.SellerSettlementDetailResponse;
 import com.devticket.settlement.presentation.dto.SettlementResponse;
+import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -13,4 +15,6 @@ public interface SettlementService {
     List<SettlementResponse> getSellerSettlements(UUID sellerId);
 
     SellerSettlementDetailResponse getSellerSettlementDetail(UUID sellerId, UUID settlementId);
+
+    SettlementTargetPreviewResponse previewSettlementTarget(LocalDate targetDate);
 }

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
@@ -3,22 +3,36 @@ package com.devticket.settlement.application.service;
 import com.devticket.settlement.common.exception.BusinessException;
 import com.devticket.settlement.common.exception.CommonErrorCode;
 import com.devticket.settlement.domain.exception.SettlementErrorCode;
+import com.devticket.settlement.domain.model.FeePolicy;
 import com.devticket.settlement.domain.model.Settlement;
 import com.devticket.settlement.domain.model.SettlementItem;
+import com.devticket.settlement.domain.model.SettlementItemStatus;
+import com.devticket.settlement.domain.repository.FeePolicyRepository;
 import com.devticket.settlement.domain.repository.SettlementItemRepository;
 import com.devticket.settlement.domain.repository.SettlementRepository;
 import com.devticket.settlement.infrastructure.client.SettlementToCommerceClient;
+import com.devticket.settlement.infrastructure.client.SettlementToEventClient;
 import com.devticket.settlement.infrastructure.client.dto.req.InternalSettlementDataRequest;
+import com.devticket.settlement.infrastructure.client.dto.res.EndedEventResponse;
+import com.devticket.settlement.infrastructure.client.dto.res.EventTicketSettlementResponse;
 import com.devticket.settlement.infrastructure.client.dto.res.InternalSettlementDataResponse;
 import com.devticket.settlement.presentation.dto.EventItemResponse;
 import com.devticket.settlement.presentation.dto.SellerSettlementDetailResponse;
 import com.devticket.settlement.presentation.dto.SettlementResponse;
+import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse;
+import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse.EventSettlementPreview;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -26,7 +40,9 @@ public class SettlementServiceImpl implements SettlementService {
 
     private final SettlementRepository settlementRepository;
     private final SettlementItemRepository settlementItemRepository;
+    private final FeePolicyRepository feePolicyRepository;
     private final SettlementToCommerceClient settlementToCommerceClient;
+    private final SettlementToEventClient settlementToEventClient;
 
     @Override
     public InternalSettlementDataResponse fetchSettlementData(UUID sellerId, String periodStart, String periodEnd) {
@@ -34,7 +50,6 @@ public class SettlementServiceImpl implements SettlementService {
         return settlementToCommerceClient.getSettlementData(request);
     }
 
-    // 정산 내역 목록 조회
     @Override
     public List<SettlementResponse> getSellerSettlements(UUID sellerId) {
         List<Settlement> settlements = settlementRepository.findBySellerId(sellerId);
@@ -43,8 +58,6 @@ public class SettlementServiceImpl implements SettlementService {
             .toList();
     }
 
-
-    // 정산 내역 상세 조회
     @Override
     public SellerSettlementDetailResponse getSellerSettlementDetail(UUID sellerId, UUID settlementId) {
         Settlement settlement = settlementRepository.findBySettlementId(settlementId)
@@ -58,17 +71,108 @@ public class SettlementServiceImpl implements SettlementService {
         return toResponse(settlement, settlementItems);
     }
 
+    /**
+     * Event 서비스 → Commerce 서비스 실제 API 호출 후
+     * Platform Fee 수수료를 적용하여 orderItem 단위로 SettlementItem을 저장한다.
+     * orderItemId 기준으로 중복된 항목은 저장하지 않고 SKIPPED로 표기한다.
+     */
+    @Override
+    @Transactional
+    public SettlementTargetPreviewResponse previewSettlementTarget(LocalDate targetDate) {
+        // 1. Platform Fee 정책 조회
+        FeePolicy feePolicy = feePolicyRepository.findByName("PLATFORM_FEE")
+            .orElseThrow(() -> new BusinessException(SettlementErrorCode.FEE_POLICY_NOT_FOUND));
+        log.info("[previewSettlementTarget] FeePolicy - name: {}, feeValue: {}",
+            feePolicy.getName(), feePolicy.getFeeValue());
 
-    //    사용자 인가 확인 메서드
+        // 2. Event 서비스: 해당 날짜에 종료된 이벤트 목록 조회
+        log.info("[previewSettlementTarget] Event 서비스 호출 - targetDate: {}", targetDate);
+        List<EndedEventResponse> endedEvents = settlementToEventClient.getEndedEvents(targetDate);
+        log.info("[previewSettlementTarget] 종료된 이벤트 {}건 조회됨", endedEvents.size());
+
+        if (endedEvents.isEmpty()) {
+            return new SettlementTargetPreviewResponse(
+                targetDate.toString(), 0, 0, 0,
+                feePolicy.getName(), feePolicy.getFeeValue().toPlainString(),
+                List.of()
+            );
+        }
+
+        Map<UUID, EndedEventResponse> eventMap = endedEvents.stream()
+            .collect(Collectors.toMap(EndedEventResponse::eventId, e -> e));
+
+        // 3. Commerce 서비스: 전체 eventId 리스트를 한 번에 전송
+        List<UUID> eventIds = endedEvents.stream().map(EndedEventResponse::eventId).toList();
+        List<EventTicketSettlementResponse> ticketItems =
+            settlementToCommerceClient.getTicketSettlementData(eventIds);
+        log.info("[previewSettlementTarget] Commerce 응답 - orderItem 건수: {}", ticketItems.size());
+
+        // 4. orderItem 단위로 수수료 계산 후 저장
+        List<EventSettlementPreview> previews = new ArrayList<>();
+        int savedCount = 0;
+        int skippedCount = 0;
+
+        for (EventTicketSettlementResponse ticketItem : ticketItems) {
+            Long feeAmount = feePolicy.calculateFee(ticketItem.salesAmount());
+            Long settlementAmount = ticketItem.salesAmount() - ticketItem.refundAmount() - feeAmount;
+            EndedEventResponse event = eventMap.get(ticketItem.eventId());
+
+            if (settlementItemRepository.existsByOrderItemId(ticketItem.orderItemId())) {
+                log.warn("[previewSettlementTarget] 중복 스킵 - orderItemId: {}", ticketItem.orderItemId());
+                previews.add(new EventSettlementPreview(
+                    ticketItem.orderItemId(), event.id(), ticketItem.eventId(), event.sellerId(),
+                    ticketItem.salesAmount(), ticketItem.refundAmount(), feeAmount, settlementAmount,
+                    "SKIPPED"
+                ));
+                skippedCount++;
+                continue;
+            }
+
+            SettlementItem item = SettlementItem.builder()
+                .orderItemId(ticketItem.orderItemId())
+                .eventId(event.id())
+                .eventUUID(ticketItem.eventId())
+                .sellerId(event.sellerId())
+                .salesAmount(ticketItem.salesAmount())
+                .refundAmount(ticketItem.refundAmount())
+                .feeAmount(feeAmount)
+                .settlementAmount(settlementAmount)
+                .status(SettlementItemStatus.READY)
+                .build();
+
+            settlementItemRepository.save(item);
+            savedCount++;
+
+            log.info("[previewSettlementTarget] 저장 완료 - orderItemId: {}, eventId: {}, sales: {}, fee: {}, settlement: {}",
+                ticketItem.orderItemId(), ticketItem.eventId(),
+                ticketItem.salesAmount(), feeAmount, settlementAmount);
+
+            previews.add(new EventSettlementPreview(
+                ticketItem.orderItemId(), event.id(), ticketItem.eventId(), event.sellerId(),
+                ticketItem.salesAmount(), ticketItem.refundAmount(), feeAmount, settlementAmount,
+                "SAVED"
+            ));
+        }
+
+        log.info("[previewSettlementTarget] 완료 - 저장: {}건, 중복 스킵: {}건", savedCount, skippedCount);
+        return new SettlementTargetPreviewResponse(
+            targetDate.toString(),
+            endedEvents.size(),
+            savedCount,
+            skippedCount,
+            feePolicy.getName(),
+            feePolicy.getFeeValue().toPlainString(),
+            previews
+        );
+    }
+
+
     private void validateSellerAccess(UUID sellerId, Settlement settlement) {
         if (!sellerId.equals(settlement.getSellerId())) {
             throw new BusinessException(CommonErrorCode.ACCESS_DENIED);
         }
     }
 
-
-    //    dto 변환 메서드 : "toResponse"
-    // 1. Settlement -> SettlementResponse 변환 메서드
     private SettlementResponse toResponse(Settlement settlement) {
         return new SettlementResponse(
             settlement.getSettlementId(),
@@ -83,9 +187,7 @@ public class SettlementServiceImpl implements SettlementService {
         );
     }
 
-    // 2. SettlementItem, settlement -> SellerSettlementDetailResponse 변환 메서드
     private SellerSettlementDetailResponse toResponse(Settlement settlement, List<SettlementItem> settlementItems) {
-        // e
         List<EventItemResponse> eventItems = settlementItems.stream()
             .map(this::toResponse)
             .toList();
@@ -104,7 +206,6 @@ public class SettlementServiceImpl implements SettlementService {
         );
     }
 
-    // 3. SettlementItem -> EventItems
     private EventItemResponse toResponse(SettlementItem settlementItem) {
         return new EventItemResponse(
             settlementItem.getEventId().toString(),
@@ -115,5 +216,4 @@ public class SettlementServiceImpl implements SettlementService {
             settlementItem.getSettlementAmount()
         );
     }
-
 }

--- a/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementItem.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementItem.java
@@ -4,6 +4,8 @@ package com.devticket.settlement.domain.model;
 import com.devticket.settlement.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,35 +25,49 @@ public class SettlementItem extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
-    @Column(name = "settlement_id", nullable = false)
+    @Column(name = "settlement_id")
     private UUID settlementId;
 
-    @Column(name = "order_item_id", nullable = false)
-    private Long orderItemId;
+    // Commerce 서비스의 orderItemId(UUID) - 멱등성 관리용 유니크 키
+    @Column(name = "order_item_id", unique = true, nullable = false)
+    private UUID orderItemId;
 
     @Column(name = "event_id", nullable = false)
     private Long eventId;
 
+    @Column(name = "event_uuid", nullable = false)
+    private UUID eventUUID;
+
+    @Column(name = "seller_id", nullable = false)
+    private UUID sellerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private SettlementItemStatus status;
+
     @Column(name = "sales_amount", nullable = false)
-    private Integer salesAmount;
+    private Long salesAmount;
 
     @Column(name = "refund_amount", nullable = false)
-    private Integer refundAmount;
+    private Long refundAmount;
 
     @Column(name = "fee_amount", nullable = false)
-    private Integer feeAmount;
+    private Long feeAmount;
 
     @Column(name = "settlement_amount", nullable = false)
-    private Integer settlementAmount;
+    private Long settlementAmount;
 
 
-    // 빌더 패턴
     @Builder
-    public SettlementItem(UUID settlementId, Long orderItemId, Long eventId, Integer salesAmount, Integer refundAmount,
-        Integer feeAmount, Integer settlementAmount) {
+    public SettlementItem(UUID settlementId, UUID orderItemId, Long eventId, UUID eventUUID,
+        UUID sellerId, SettlementItemStatus status,
+        Long salesAmount, Long refundAmount, Long feeAmount, Long settlementAmount) {
         this.settlementId = settlementId;
         this.orderItemId = orderItemId;
         this.eventId = eventId;
+        this.eventUUID = eventUUID;
+        this.sellerId = sellerId;
+        this.status = (status != null) ? status : SettlementItemStatus.READY;
         this.salesAmount = salesAmount;
         this.refundAmount = refundAmount;
         this.feeAmount = feeAmount;

--- a/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementItemStatus.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementItemStatus.java
@@ -1,7 +1,6 @@
 package com.devticket.settlement.domain.model;
 
 public enum SettlementItemStatus {
-    PENDING,
-    COMPLETED,
-    FAILED
+    READY,      // 집계예정
+    FINALIZED   // 집계확정
 }

--- a/settlement/src/main/java/com/devticket/settlement/domain/repository/FeePolicyRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/repository/FeePolicyRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeePolicyRepository extends JpaRepository<FeePolicy, Long> {
     Optional<FeePolicy> findTopByOrderByCreatedAtDesc();
+    Optional<FeePolicy> findByName(String name);
 }

--- a/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementItemRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementItemRepository.java
@@ -10,4 +10,8 @@ public interface SettlementItemRepository {
 
     List<SettlementItem> findBySettlementId(UUID settlementId);
 
+    boolean existsByOrderItemId(UUID orderItemId);
+
+    SettlementItem save(SettlementItem settlementItem);
+
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToCommerceClient.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToCommerceClient.java
@@ -3,7 +3,11 @@ package com.devticket.settlement.infrastructure.client;
 import com.devticket.settlement.common.exception.BusinessException;
 import com.devticket.settlement.common.exception.CommonErrorCode;
 import com.devticket.settlement.infrastructure.client.dto.req.InternalSettlementDataRequest;
+import com.devticket.settlement.infrastructure.client.dto.res.CommerceTicketSettlementResponse;
+import com.devticket.settlement.infrastructure.client.dto.res.EventTicketSettlementResponse;
 import com.devticket.settlement.infrastructure.client.dto.res.InternalSettlementDataResponse;
+import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatusCode;
@@ -40,6 +44,44 @@ public class SettlementToCommerceClient {
                     throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
                 })
                 .body(InternalSettlementDataResponse.class);
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[SettlementToCommerceClient] Critical Error: ", e);
+            throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 여러 이벤트의 티켓 정산 데이터를 한 번에 조회.
+     * POST /internal/tickets/settlement-data
+     * Request body : [uuid1, uuid2, ...]
+     * Response     : { "items": [ { eventId, orderItemId, salesAmount, refundAmount }, ... ] }
+     */
+    public List<EventTicketSettlementResponse> getTicketSettlementData(List<UUID> eventIds) {
+        try {
+            log.info("[SettlementToCommerceClient] getTicketSettlementData - eventIds 수: {}", eventIds.size());
+
+            CommerceTicketSettlementResponse response = restClient.post()
+                .uri("/internal/tickets/settlement-data")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(eventIds)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    log.error("[SettlementToCommerceClient] Ticket API Error: Status {}", res.getStatusCode());
+                    throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
+                })
+                .body(CommerceTicketSettlementResponse.class);
+
+            if (response == null || response.items() == null) {
+                log.warn("[SettlementToCommerceClient] 응답 데이터 없음");
+                return List.of();
+            }
+
+            log.info("[SettlementToCommerceClient] 조회된 orderItem 건수: {}", response.items().size());
+            return response.items();
 
         } catch (BusinessException e) {
             throw e;

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToEventClient.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToEventClient.java
@@ -1,0 +1,64 @@
+package com.devticket.settlement.infrastructure.client;
+
+import com.devticket.settlement.common.exception.BusinessException;
+import com.devticket.settlement.common.exception.CommonErrorCode;
+import com.devticket.settlement.infrastructure.client.dto.res.EndedEventResponse;
+import com.devticket.settlement.infrastructure.client.dto.res.EventServiceResponse;
+import com.devticket.settlement.infrastructure.client.dto.res.InternalEndedEventsData;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class SettlementToEventClient {
+
+    private final RestClient restClient;
+
+    public SettlementToEventClient(@Qualifier("settlementToEventRestClient") RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    /**
+     * 특정 날짜에 종료된 이벤트 목록 조회.
+     * GET /internal/events/ended?date={date}
+     * 응답: SuccessResponse<InternalEndedEventsResponse>
+     *   → { status, message, data: { events: [ {id, eventId, sellerId}, ... ] } }
+     */
+    public List<EndedEventResponse> getEndedEvents(LocalDate date) {
+        try {
+            log.info("[SettlementToEventClient] getEndedEvents - date: {}", date);
+
+            EventServiceResponse<InternalEndedEventsData> response = restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                    .path("/internal/events/ended")
+                    .queryParam("date", date.toString())
+                    .build())
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    log.error("[SettlementToEventClient] External API Error: Status {}", res.getStatusCode());
+                    throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
+                })
+                .body(new ParameterizedTypeReference<EventServiceResponse<InternalEndedEventsData>>() {});
+
+            if (response == null || response.data() == null || response.data().events() == null) {
+                log.warn("[SettlementToEventClient] 응답 데이터 없음 - date: {}", date);
+                return List.of();
+            }
+
+            log.info("[SettlementToEventClient] 종료된 이벤트 {}건 조회됨", response.data().events().size());
+            return response.data().events();
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[SettlementToEventClient] Critical Error: ", e);
+            throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/req/EventTicketSettlementRequest.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/req/EventTicketSettlementRequest.java
@@ -1,0 +1,10 @@
+package com.devticket.settlement.infrastructure.client.dto.req;
+
+import java.util.List;
+import java.util.UUID;
+
+public record EventTicketSettlementRequest(
+    List<UUID> eventIds
+) {
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/CommerceTicketSettlementResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/CommerceTicketSettlementResponse.java
@@ -1,0 +1,13 @@
+package com.devticket.settlement.infrastructure.client.dto.res;
+
+import java.util.List;
+
+/**
+ * Commerce 서비스의 InternalTicketSettlementDataResponse에 대응하는 역직렬화 DTO.
+ * { "items": [ { "eventId", "orderItemId", "salesAmount", "refundAmount" }, ... ] }
+ */
+public record CommerceTicketSettlementResponse(
+    List<EventTicketSettlementResponse> items
+) {
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EndedEventResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EndedEventResponse.java
@@ -1,0 +1,10 @@
+package com.devticket.settlement.infrastructure.client.dto.res;
+
+import java.util.UUID;
+public record EndedEventResponse(
+    Long id,          // Event 서비스의 숫자형 PK
+    UUID eventId,     // Event 서비스의 UUID 식별자
+    UUID sellerId     // 판매자 UUID
+) {
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EventServiceResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EventServiceResponse.java
@@ -1,0 +1,16 @@
+package com.devticket.settlement.infrastructure.client.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Event 서비스의 공통 응답 래퍼 SuccessResponse<T>에 대응하는 역직렬화 DTO.
+ * { "status": 200, "message": "성공", "data": { ... } }
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record EventServiceResponse<T>(
+    int status,
+    String message,
+    T data
+) {
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EventTicketSettlementResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EventTicketSettlementResponse.java
@@ -1,0 +1,12 @@
+package com.devticket.settlement.infrastructure.client.dto.res;
+
+import java.util.UUID;
+
+public record EventTicketSettlementResponse(
+    UUID eventId,
+    UUID orderItemId,
+    Long salesAmount,
+    Long refundAmount
+) {
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/InternalEndedEventsData.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/InternalEndedEventsData.java
@@ -1,0 +1,13 @@
+package com.devticket.settlement.infrastructure.client.dto.res;
+
+import java.util.List;
+
+/**
+ * Event 서비스의 InternalEndedEventsResponse에 대응하는 역직렬화 DTO.
+ * { "events": [ { "id": 1001, "eventId": "uuid", "sellerId": "uuid" }, ... ] }
+ */
+public record InternalEndedEventsData(
+    List<EndedEventResponse> events
+) {
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/config/SettlementRestClientConfig.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/config/SettlementRestClientConfig.java
@@ -27,4 +27,13 @@ public class SettlementRestClientConfig {
             .build();
     }
 
+    @Bean
+    public RestClient settlementToEventRestClient(
+        @Value("${external.event-base-url}") String baseUrl) {
+        return RestClient.builder()
+            .baseUrl(baseUrl)
+            .defaultHeader("Content-Type", "application/json")
+            .build();
+    }
+
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementItemJpaRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementItemJpaRepository.java
@@ -9,4 +9,6 @@ public interface SettlementItemJpaRepository extends JpaRepository<SettlementIte
 
     List<SettlementItem> findBySettlementId(UUID settlementId);
 
+    boolean existsByOrderItemId(UUID orderItemId);
+
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementItemRepositoryImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementItemRepositoryImpl.java
@@ -17,4 +17,14 @@ public class SettlementItemRepositoryImpl implements SettlementItemRepository {
     public List<SettlementItem> findBySettlementId(UUID settlementId) {
         return settlementItemJpaRepository.findBySettlementId(settlementId);
     }
+
+    @Override
+    public boolean existsByOrderItemId(UUID orderItemId) {
+        return settlementItemJpaRepository.existsByOrderItemId(orderItemId);
+    }
+
+    @Override
+    public SettlementItem save(SettlementItem settlementItem) {
+        return settlementItemJpaRepository.save(settlementItem);
+    }
 }

--- a/settlement/src/main/java/com/devticket/settlement/presentation/controller/SettlementController.java
+++ b/settlement/src/main/java/com/devticket/settlement/presentation/controller/SettlementController.java
@@ -1,13 +1,14 @@
 package com.devticket.settlement.presentation.controller;
 
 import com.devticket.settlement.application.service.SettlementServiceImpl;
-import com.devticket.settlement.infrastructure.client.dto.res.InternalSettlementDataResponse;
 import com.devticket.settlement.presentation.dto.SellerSettlementDetailResponse;
 import com.devticket.settlement.presentation.dto.SettlementResponse;
-import com.devticket.settlement.presentation.scheduler.SettlementScheduler;
+import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -27,28 +28,19 @@ public class SettlementController {
 
     private final SettlementServiceImpl settlementServiceImpl;
 
-    // 자동 정산 스케쥴러 목 데이터
-    private final SettlementScheduler settlementScheduler;
-
-    // 목 데이터
-    @GetMapping("/seller/settlements/fetch")
-    public ResponseEntity<InternalSettlementDataResponse> fetchSettlementData(
-        @RequestHeader("X-User-Id") UUID sellerId,
-        @RequestParam String periodStart,
-        @RequestParam String periodEnd
+    @Operation(
+        summary = "[테스트] 정산대상 데이터 수집 미리보기",
+        description = "DB 저장 없이 Event 서비스 → Commerce 서비스 순서대로 실제 API를 호출하여 " +
+            "수집될 정산대상 데이터를 미리 확인합니다. date 미입력 시 어제 날짜로 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "미리보기 조회 성공")
+    @GetMapping("/test/settlement-target/preview")
+    public ResponseEntity<SettlementTargetPreviewResponse> previewSettlementTarget(
+        @Parameter(description = "종료된 이벤트 조회 기준 날짜 (yyyy-MM-dd), 미입력 시 어제")
+        @RequestParam(required = false) LocalDate date
     ) {
-        return ResponseEntity.ok(settlementServiceImpl.fetchSettlementData(sellerId, periodStart, periodEnd));
-    }
-
-    // 자동 정산 목 데이터
-    @GetMapping("/test/batch")
-    public ResponseEntity<String> runBatch() {
-        try {
-            settlementScheduler.runSettlementJob();
-            return ResponseEntity.ok("배치 실행 완료");
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().body("배치 실행 실패: " + e.getMessage());
-        }
+        LocalDate targetDate = (date != null) ? date : LocalDate.now().minusDays(1);
+        return ResponseEntity.ok(settlementServiceImpl.previewSettlementTarget(targetDate));
     }
 
     @Operation(
@@ -73,5 +65,4 @@ public class SettlementController {
         @PathVariable UUID settlementId) {
         return ResponseEntity.ok(settlementServiceImpl.getSellerSettlementDetail(sellerId, settlementId));
     }
-
 }

--- a/settlement/src/main/java/com/devticket/settlement/presentation/dto/EventItemResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/presentation/dto/EventItemResponse.java
@@ -15,19 +15,19 @@ public record EventItemResponse(
 
     @NotNull
     @Schema(description = "판매 금액", example = "810000", minimum = "0")
-    Integer salesAmount,
+    Long salesAmount,
 
     @NotNull
     @Schema(description = "환불 금액", example = "30000", minimum = "0")
-    Integer refundAmount,
+    Long refundAmount,
 
     @NotNull
     @Schema(description = "수수료 금액", example = "78000", minimum = "0")
-    Integer feeAmount,
+    Long feeAmount,
 
     @NotNull
     @Schema(description = "최종 정산 금액", example = "702000", minimum = "0")
-    Integer settlementAmount
+    Long settlementAmount
 ) {
 
 }

--- a/settlement/src/main/java/com/devticket/settlement/presentation/dto/SettlementTargetPreviewResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/presentation/dto/SettlementTargetPreviewResponse.java
@@ -1,0 +1,29 @@
+package com.devticket.settlement.presentation.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record SettlementTargetPreviewResponse(
+    String targetDate,
+    int totalEventCount,
+    int savedCount,
+    int skippedCount,
+    String feePolicyName,
+    String feeValue,
+    List<EventSettlementPreview> items
+) {
+
+    public record EventSettlementPreview(
+        UUID orderItemId,
+        Long eventNumericId,
+        UUID eventId,
+        UUID sellerId,
+        Long salesAmount,
+        Long refundAmount,
+        Long feeAmount,
+        Long settlementAmount,
+        String status   // SAVED | SKIPPED(중복)
+    ) {
+
+    }
+}

--- a/settlement/src/main/resources/application-local.yml
+++ b/settlement/src/main/resources/application-local.yml
@@ -26,3 +26,4 @@ logging:
 external:
   commerce-base-url: http://localhost:8083
   member-base-url: http://localhost:8081
+  event-base-url: http://localhost:8082


### PR DESCRIPTION
## 관련 이슈
- close #432

## 작업 내용
- Event서비스에 종료된 이벤트 목록을 요청 API 
- Commerce서비스에 종료된 이벤트ids를 기반으로 판매자별 판매현황데이터 요청 API
- 수동으로 정산대상데이터를 요청 후 SettlementItem에 적재하는 테스트용 엔드포인트 추가 

## 변경 사항
- 엔티티 수정 
  - [ ] SettlementItem 엔티티 : orderItemId필드 데이터타입 Long -> UUID
  - [ ]  SettlementItem 엔티티 : salesAmount 등 금액관련 필드 Integer -> Long
  - [ ] settlementItemStatus : READY, FINALIZED

- Event 서비스에 종료된 이벤트들의 id목록 요청 API
  - [ ] SettlementToEventClient
  - [ ] DTO - EndedEventResponse
  - [ ] DTO - InternalEndedEventsData
  - [ ] DTO - EventServiceResponse
  
- Commerce서비스에 종료된 이벤트ids 들의 판매데이터 요청 API
  - [ ] SettlementToCommerceClient
  - [ ] DTO - EventTicketSettlementRequest
  - [ ] DTO - EventTicketSettlementResponse
  - [ ] DTO - CommerceTicketSettlementResponse

- 데이터타입 Integer -> Long으로 수정 
  - [ ]  EventItemResponse

- 수동으로 정산대상데이터요청하는 API추가 
  - [ ] SettlementController - previewSettlementTarget  : 수동으로 정산대상데이터요청하는 API (테스트용)
  - [ ] DTO - SettlementTargetPreviewResponse 
  - [ ] Service - previewSettlementTarget추가 

## API 엔드포인트
- GET /test/settlement-target/preview
- GET /internal/events/ended
- GET /internal/orders/settlement-data

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항

