### PR TITLE
[Payment] refactor: 트랜잭션 경계를 가지는 로직을 별도 Bean으로 분리

### DIFF
--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -1,8 +1,6 @@
 package com.devticket.payment.wallet.application.service;
 
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -10,17 +8,12 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import com.devticket.payment.common.messaging.KafkaTopics;
 import com.devticket.payment.common.outbox.OutboxService;
@@ -34,7 +27,7 @@ import com.devticket.payment.payment.infrastructure.client.CommerceInternalClien
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentStatusResponse;
 import com.devticket.payment.wallet.application.event.PaymentCompletedEvent;
-import com.devticket.payment.wallet.domain.WalletPolicyConstants;
+import com.devticket.payment.wallet.application.service.support.WalletChargeTransactionService;
 import com.devticket.payment.wallet.domain.exception.WalletErrorCode;
 import com.devticket.payment.wallet.domain.exception.WalletException;
 import com.devticket.payment.wallet.domain.model.Wallet;
@@ -67,13 +60,7 @@ public class WalletServiceImpl implements WalletService {
     private final PgPaymentClient pgPaymentClient;
     private final OutboxService outboxService;
     private final CommerceInternalClient commerceInternalClient;
-    private final PlatformTransactionManager txManager;
-
-    //this.claimChargeForProcessing() 같은 Self-call이 프록시를 우회하는 문제를 해결하려면 자기 참조 주입(self-injection) 이 필요
-    // Self-invocation 문제 해결을 위한 자기 참조 주입
-    @Lazy
-    @Autowired
-    private WalletServiceImpl self;
+    private final WalletChargeTransactionService walletChargeTransactionService;
 
     // =====================================================================
     // 충전 시작(결제인증에 필요한 WalletCharge생성-chargeId)
@@ -92,46 +79,10 @@ public class WalletServiceImpl implements WalletService {
         }
 
         // TX1: 비관적 락으로 지갑 조회/생성 → 커밋 후 락 해제
-        Wallet wallet = self.getWallet(userId);
+        walletChargeTransactionService.getWallet(userId);
 
         // TX2: 2차 멱등성 체크 + 한도 체크 + WalletCharge 생성
-        return self.createChargeWithLimitCheck(userId, request, idempotencyKey);
-    }
-
-    // TX1: Wallet 조회/생성
-    // TODO : Wallet이 존재하지 않은 신규사용자의 여러기기 접속+예치금 충전 동시요청의 케이스 추가고려 필요.
-    //  테스트메서드 "신규유저_지갑미생성_다기기_동시충전_각기다른멱등성키()" 실패
-    @Transactional
-    public Wallet getWallet(UUID userId) {
-        return walletRepository.findByUserId(userId)
-            .orElseGet(() -> walletRepository.save(Wallet.create(userId)));
-    }
-
-    // TX2: 비관적 락 재획득 → 멱등성 재확인 → 한도 체크 → WalletCharge 생성
-    @Transactional
-    public WalletChargeResponse createChargeWithLimitCheck(UUID userId,
-        WalletChargeRequest request, String idempotencyKey) {
-
-        // 한도 체크 직렬화를 위해 비관적 락 재획득 (TX1 커밋 후 락이 해제됐으므로 재진입)
-        Wallet wallet = walletRepository.findByUserIdForUpdate(userId)
-            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
-
-        // 2차 멱등성 체크 (TX1과 사이에 끼어든 동시 요청 방어)
-        Optional<WalletCharge> existing =
-            walletChargeRepository.findByUserIdAndIdempotencyKey(userId, idempotencyKey);
-        if (existing.isPresent()) {
-            return WalletChargeResponse.from(existing.get());
-        }
-
-        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
-        int todayTotal = walletChargeRepository.sumTodayChargeAmount(userId, startOfDay);
-        if (todayTotal + request.amount() > WalletPolicyConstants.DAILY_CHARGE_LIMIT) {
-            throw new WalletException(WalletErrorCode.DAILY_CHARGE_LIMIT_EXCEEDED);
-        }
-
-        WalletCharge walletCharge = WalletCharge.create(wallet.getId(), userId, request.amount(), idempotencyKey);
-        walletChargeRepository.save(walletCharge);
-        return WalletChargeResponse.from(walletCharge);
+        return walletChargeTransactionService.createChargeWithLimitCheck(userId, request, idempotencyKey);
     }
 
 
@@ -148,9 +99,8 @@ public class WalletServiceImpl implements WalletService {
         WalletChargeConfirmRequest request) {
 
         // ── 1단계: 비관적 락으로 상태 선점 (PENDING → PROCESSING) ──
-        // self를 통해 호출 → 프록시 경유 → @Transactional 실제 적용
         UUID chargeId = parseUUID(request.chargeId());
-        self.claimChargeForProcessing(userId, chargeId, request.amount());
+        walletChargeTransactionService.claimChargeForProcessing(userId, chargeId, request.amount());
 
         // ── 2단계: 락 해제 후 PG 호출 (DB 커넥션 점유 없음) ──
         PgPaymentConfirmResult pgResult;
@@ -160,7 +110,7 @@ public class WalletServiceImpl implements WalletService {
             ));
         } catch (Exception e) {
             log.error("[WalletCharge] PG 승인 실패 — chargeId={}, error={}", chargeId, e.getMessage());
-            self.failProcessingCharge(chargeId);
+            walletChargeTransactionService.failProcessingCharge(chargeId);
             return WalletChargeConfirmResponse.from(
                 chargeId.toString(), request.amount(),
                 null, "FAILED", null
@@ -168,75 +118,7 @@ public class WalletServiceImpl implements WalletService {
         }
 
         // ── 3단계: 새 트랜잭션에서 결과 반영 ──
-        return self.completeChargeAfterPg(userId, chargeId, pgResult);
-    }
-
-    /**
-     * 비관적 락으로 PENDING → PROCESSING 선점. 락은 트랜잭션 종료 시 즉시 해제.
-     */
-    @Transactional
-    public void claimChargeForProcessing(UUID userId, UUID chargeId, Integer expectedAmount) {
-        WalletCharge walletCharge = walletChargeRepository.findByChargeIdForUpdate(chargeId)
-            .orElseThrow(() -> new WalletException(WalletErrorCode.CHARGE_NOT_FOUND));
-
-        if (!walletCharge.getUserId().equals(userId)) {
-            throw new WalletException(WalletErrorCode.CHARGE_NOT_FOUND);
-        }
-        if (!walletCharge.isPending()) {
-            throw new WalletException(WalletErrorCode.CHARGE_NOT_PENDING);
-        }
-        if (!walletCharge.getAmount().equals(expectedAmount)) {
-            throw new WalletException(WalletErrorCode.CHARGE_AMOUNT_MISMATCH);
-        }
-
-        walletCharge.markProcessing();
-    }
-
-    /**
-     * PG 실패 시 PROCESSING → FAILED 원복.
-     */
-    @Transactional
-    public void failProcessingCharge(UUID chargeId) {
-        WalletCharge walletCharge = walletChargeRepository.findByChargeId(chargeId)
-            .orElseThrow(() -> new WalletException(WalletErrorCode.CHARGE_NOT_FOUND));
-        walletCharge.fail();
-    }
-
-    /**
-     * PG 승인 성공 후 잔액 반영 + WalletTransaction 생성.
-     */
-    @Transactional
-    public WalletChargeConfirmResponse completeChargeAfterPg(UUID userId, UUID chargeId,
-        PgPaymentConfirmResult pgResult) {
-        WalletCharge walletCharge = walletChargeRepository.findByChargeId(chargeId)
-            .orElseThrow(() -> new WalletException(WalletErrorCode.CHARGE_NOT_FOUND));
-
-        walletCharge.complete(pgResult.paymentKey());
-        walletRepository.chargeBalanceAtomic(userId, walletCharge.getAmount());
-
-        Wallet wallet = walletRepository.findByUserId(userId)
-            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
-
-        String transactionKey = "CHARGE:" + pgResult.paymentKey();
-        if (walletTransactionRepository.existsByTransactionKey(transactionKey)) {
-            log.warn("[WalletCharge] WalletTransaction 이미 존재 — transactionKey={}", transactionKey);
-            return WalletChargeConfirmResponse.from(
-                walletCharge.getChargeId().toString(), walletCharge.getAmount(),
-                wallet.getBalance(), walletCharge.getStatus().name(), null
-            );
-        }
-        WalletTransaction walletTransaction = WalletTransaction.createCharge(
-            wallet.getId(), userId, transactionKey, walletCharge.getAmount(), wallet.getBalance()
-        );
-        walletTransactionRepository.save(walletTransaction);
-
-        log.info("[WalletCharge] 충전 승인 완료 — chargeId={}, amount={}, balance={}",
-            chargeId, walletCharge.getAmount(), wallet.getBalance());
-
-        return WalletChargeConfirmResponse.from(
-            walletCharge.getChargeId().toString(), walletCharge.getAmount(),
-            wallet.getBalance(), walletCharge.getStatus().name(), walletTransaction.getCreatedAt()
-        );
+        return walletChargeTransactionService.completeChargeAfterPg(userId, chargeId, pgResult);
     }
 
     // =====================================================================

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/support/WalletChargeTransactionService.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/support/WalletChargeTransactionService.java
@@ -1,0 +1,136 @@
+package com.devticket.payment.wallet.application.service.support;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
+import com.devticket.payment.wallet.domain.WalletPolicyConstants;
+import com.devticket.payment.wallet.domain.exception.WalletErrorCode;
+import com.devticket.payment.wallet.domain.exception.WalletException;
+import com.devticket.payment.wallet.domain.model.Wallet;
+import com.devticket.payment.wallet.domain.model.WalletCharge;
+import com.devticket.payment.wallet.domain.model.WalletTransaction;
+import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
+import com.devticket.payment.wallet.domain.repository.WalletRepository;
+import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
+import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmResponse;
+import com.devticket.payment.wallet.presentation.dto.WalletChargeRequest;
+import com.devticket.payment.wallet.presentation.dto.WalletChargeResponse;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WalletChargeTransactionService {
+
+    private final WalletRepository walletRepository;
+    private final WalletChargeRepository walletChargeRepository;
+    private final WalletTransactionRepository walletTransactionRepository;
+
+    // TX1: Wallet 조회/생성
+    // ON CONFLICT DO NOTHING으로 동시 요청이 들어와도 정확히 한 건만 INSERT되고 나머지는 무시됨.
+    @Transactional
+    public Wallet getWallet(UUID userId) {
+        //DB수준의 UPSERT사용한 단일쿼리로 무결성 에러 자체를 방지함.
+        walletRepository.insertWalletIfAbsent(userId);
+        return walletRepository.findByUserId(userId)
+            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
+    }
+
+    // TX2: 비관적 락 재획득 → 멱등성 재확인 → 한도 체크 → WalletCharge 생성
+    @Transactional
+    public WalletChargeResponse createChargeWithLimitCheck(UUID userId,
+        WalletChargeRequest request, String idempotencyKey) {
+
+        // 한도 체크 직렬화를 위해 비관적 락 재획득 (TX1 커밋 후 락이 해제됐으므로 재진입)
+        Wallet wallet = walletRepository.findByUserIdForUpdate(userId)
+            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
+
+        // 2차 멱등성 체크 (TX1과 사이에 끼어든 동시 요청 방어)
+        Optional<WalletCharge> existing =
+            walletChargeRepository.findByUserIdAndIdempotencyKey(userId, idempotencyKey);
+        if (existing.isPresent()) {
+            return WalletChargeResponse.from(existing.get());
+        }
+
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        int todayTotal = walletChargeRepository.sumTodayChargeAmount(userId, startOfDay);
+        if (todayTotal + request.amount() > WalletPolicyConstants.DAILY_CHARGE_LIMIT) {
+            throw new WalletException(WalletErrorCode.DAILY_CHARGE_LIMIT_EXCEEDED);
+        }
+
+        WalletCharge walletCharge = WalletCharge.create(wallet.getId(), userId, request.amount(), idempotencyKey);
+        walletChargeRepository.save(walletCharge);
+        return WalletChargeResponse.from(walletCharge);
+    }
+
+    // 비관적 락으로 PENDING → PROCESSING 선점. 락은 트랜잭션 종료 시 즉시 해제.
+    @Transactional
+    public void claimChargeForProcessing(UUID userId, UUID chargeId, Integer expectedAmount) {
+        WalletCharge walletCharge = walletChargeRepository.findByChargeIdForUpdate(chargeId)
+            .orElseThrow(() -> new WalletException(WalletErrorCode.CHARGE_NOT_FOUND));
+
+        if (!walletCharge.getUserId().equals(userId)) {
+            throw new WalletException(WalletErrorCode.CHARGE_NOT_FOUND);
+        }
+        if (!walletCharge.isPending()) {
+            throw new WalletException(WalletErrorCode.CHARGE_NOT_PENDING);
+        }
+        if (!walletCharge.getAmount().equals(expectedAmount)) {
+            throw new WalletException(WalletErrorCode.CHARGE_AMOUNT_MISMATCH);
+        }
+
+        walletCharge.markProcessing();
+    }
+
+    // PG 실패 시 PROCESSING → FAILED 원복.
+    @Transactional
+    public void failProcessingCharge(UUID chargeId) {
+        WalletCharge walletCharge = walletChargeRepository.findByChargeId(chargeId)
+            .orElseThrow(() -> new WalletException(WalletErrorCode.CHARGE_NOT_FOUND));
+        walletCharge.fail();
+    }
+
+    // PG 승인 성공 후 잔액 반영 + WalletTransaction 생성.
+    @Transactional
+    public WalletChargeConfirmResponse completeChargeAfterPg(UUID userId, UUID chargeId,
+        PgPaymentConfirmResult pgResult) {
+        WalletCharge walletCharge = walletChargeRepository.findByChargeId(chargeId)
+            .orElseThrow(() -> new WalletException(WalletErrorCode.CHARGE_NOT_FOUND));
+
+        walletCharge.complete(pgResult.paymentKey());
+        walletRepository.chargeBalanceAtomic(userId, walletCharge.getAmount());
+
+        Wallet wallet = walletRepository.findByUserId(userId)
+            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
+
+        String transactionKey = "CHARGE:" + pgResult.paymentKey();
+        if (walletTransactionRepository.existsByTransactionKey(transactionKey)) {
+            log.warn("[WalletCharge] WalletTransaction 이미 존재 — transactionKey={}", transactionKey);
+            return WalletChargeConfirmResponse.from(
+                walletCharge.getChargeId().toString(), walletCharge.getAmount(),
+                wallet.getBalance(), walletCharge.getStatus().name(), null
+            );
+        }
+
+        WalletTransaction walletTransaction = WalletTransaction.createCharge(
+            wallet.getId(), userId, transactionKey, walletCharge.getAmount(), wallet.getBalance()
+        );
+        walletTransactionRepository.save(walletTransaction);
+
+        log.info("[WalletCharge] 충전 승인 완료 — chargeId={}, amount={}, balance={}",
+            chargeId, walletCharge.getAmount(), wallet.getBalance());
+
+        return WalletChargeConfirmResponse.from(
+            walletCharge.getChargeId().toString(), walletCharge.getAmount(),
+            wallet.getBalance(), walletCharge.getStatus().name(), walletTransaction.getCreatedAt()
+        );
+    }
+}

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/repository/WalletRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/repository/WalletRepository.java
@@ -8,6 +8,8 @@ public interface WalletRepository {
 
     Optional<Wallet> findByUserId(UUID userId);
 
+    void insertWalletIfAbsent(UUID userId);
+
     Optional<Wallet> findByUserIdForUpdate(UUID userId);
 
     Wallet save(Wallet wallet);

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletJpaRepository.java
@@ -16,10 +16,10 @@ public interface WalletJpaRepository extends JpaRepository<Wallet, Long> {
 
     @Modifying
     @Query(value = "INSERT INTO payment.wallet (wallet_id, user_id, balance, version, created_at, updated_at) " +
-                   "VALUES (gen_random_uuid(), :userId, 0, 0, NOW(), NOW()) " +
-                   "ON CONFLICT (user_id) DO NOTHING",
+                   "VALUES (:walletId, :userId, 0, 0, NOW(), NOW()) " +
+                   "ON CONFLICT DO NOTHING",
            nativeQuery = true)
-    void insertIfAbsent(@Param("userId") UUID userId);
+    void insertIfAbsent(@Param("walletId") UUID walletId, @Param("userId") UUID userId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT w FROM Wallet w WHERE w.userId = :userId")

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletJpaRepository.java
@@ -14,8 +14,10 @@ public interface WalletJpaRepository extends JpaRepository<Wallet, Long> {
 
     Optional<Wallet> findByUserId(UUID userId);
 
-    @Modifying
-    @Query(value = "INSERT INTO payment.wallet (wallet_id, user_id, balance, version, created_at, updated_at) " +
+    //TODO : 향후 제약 추가에 대비하여 "ON CONFLICT (user_id)" 수정 고려
+    // 현시점 ci환경 H2에서 ON CONFLICT 미지원되어 추후 제약조건 추가시 수정필요.
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(value = "INSERT INTO wallet (wallet_id, user_id, balance, version, created_at, updated_at) " +
                    "VALUES (:walletId, :userId, 0, 0, NOW(), NOW()) " +
                    "ON CONFLICT DO NOTHING",
            nativeQuery = true)

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletJpaRepository.java
@@ -14,6 +14,13 @@ public interface WalletJpaRepository extends JpaRepository<Wallet, Long> {
 
     Optional<Wallet> findByUserId(UUID userId);
 
+    @Modifying
+    @Query(value = "INSERT INTO payment.wallet (wallet_id, user_id, balance, version, created_at, updated_at) " +
+                   "VALUES (gen_random_uuid(), :userId, 0, 0, NOW(), NOW()) " +
+                   "ON CONFLICT (user_id) DO NOTHING",
+           nativeQuery = true)
+    void insertIfAbsent(@Param("userId") UUID userId);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT w FROM Wallet w WHERE w.userId = :userId")
     Optional<Wallet> findByUserIdForUpdate(@Param("userId") UUID userId);

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletRepositoryImpl.java
@@ -21,6 +21,11 @@ public class WalletRepositoryImpl implements WalletRepository {
     }
 
     @Override
+    public void insertWalletIfAbsent(UUID userId) {
+        walletJpaRepository.insertIfAbsent(userId);
+    }
+
+    @Override
     public Optional<Wallet> findByUserIdForUpdate(UUID userId) {
         return walletJpaRepository.findByUserIdForUpdate(userId);
     }

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletRepositoryImpl.java
@@ -22,7 +22,7 @@ public class WalletRepositoryImpl implements WalletRepository {
 
     @Override
     public void insertWalletIfAbsent(UUID userId) {
-        walletJpaRepository.insertIfAbsent(userId);
+        walletJpaRepository.insertIfAbsent(UUID.randomUUID(), userId);
     }
 
     @Override

--- a/payment/src/main/resources/application-test.yml
+++ b/payment/src/main/resources/application-test.yml
@@ -6,6 +6,7 @@ spring:
     password:
     hikari:
       maximum-pool-size: 30
+      schema: payment
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:

--- a/payment/src/main/resources/application-test.yml
+++ b/payment/src/main/resources/application-test.yml
@@ -6,7 +6,7 @@ spring:
     password:
     hikari:
       maximum-pool-size: 30
-      schema: payment
+      connection-init-sql: "SET SCHEMA payment"
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:

--- a/payment/src/test/java/com/devticket/payment/application/service/PaymentServiceImplTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/PaymentServiceImplTest.java
@@ -104,7 +104,7 @@ public class PaymentServiceImplTest {
         @DisplayName("PG 결제 준비 성공 — READY 상태 반환")
         void PG_결제_준비_성공() {
             // given
-            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG);
+            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG, null);
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.save(any(Payment.class)))
@@ -126,7 +126,7 @@ public class PaymentServiceImplTest {
         @DisplayName("다른 사용자의 주문 — 예외")
         void 다른_사용자의_주문() {
             // given
-            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG);
+            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG, null);
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
 
@@ -141,7 +141,7 @@ public class PaymentServiceImplTest {
         @DisplayName("주문 상태가 PAYMENT_PENDING이 아닌 경우 — 예외")
         void 주문_상태가_결제_대기가_아닌_경우() {
             // given
-            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG);
+            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG, null);
             InternalOrderInfoResponse paidOrder = new InternalOrderInfoResponse(
                 ORDER_ID, USER_ID, "ORD-001", 130000, "PAID",
                 LocalDateTime.of(2025, 8, 15, 14, 30).toString(),
@@ -161,7 +161,7 @@ public class PaymentServiceImplTest {
         @DisplayName("예치금 결제 준비 성공 — WalletService로 위임")
         void 예치금_결제_준비_성공() {
             // given
-            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.WALLET);
+            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.WALLET, null);
             Payment savedPayment = createReadyPayment();
             savedPayment.approve("WALLET-" + savedPayment.getPaymentId());
 

--- a/payment/src/test/java/com/devticket/payment/application/service/PaymentServiceImplTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/PaymentServiceImplTest.java
@@ -168,7 +168,9 @@ public class PaymentServiceImplTest {
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.save(any(Payment.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
-            given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(savedPayment));
+            given(paymentRepository.findByOrderId(orderInfo.id()))
+                .willReturn(Optional.empty())
+                .willReturn(Optional.of(savedPayment));
 
             // when
             PaymentReadyResponse response = paymentService.readyPayment(USER_ID, request);

--- a/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
@@ -21,6 +21,7 @@ import com.devticket.payment.payment.domain.repository.PaymentRepository;
 import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.wallet.application.service.WalletServiceImpl;
+import com.devticket.payment.wallet.application.service.support.WalletChargeTransactionService;
 import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentStatusResponse;
 import com.devticket.payment.wallet.domain.enums.WalletChargeStatus;
 import com.devticket.payment.wallet.domain.exception.WalletErrorCode;
@@ -41,7 +42,6 @@ import com.devticket.payment.wallet.presentation.dto.WalletChargeResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletTransactionListResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletWithdrawRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletWithdrawResponse;
-import java.time.LocalDateTime;
 import org.springframework.dao.DataIntegrityViolationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -74,6 +74,7 @@ class WalletServiceTest {
     @Mock private PgPaymentClient pgPaymentClient;
     @Mock private OutboxService outboxService;
     @Mock private CommerceInternalClient commerceInternalClient;
+    @Mock private WalletChargeTransactionService walletChargeTransactionService;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper()
@@ -87,7 +88,7 @@ class WalletServiceTest {
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(walletService, "self", walletService);
+        ReflectionTestUtils.setField(walletService, "walletChargeTransactionService", walletChargeTransactionService);
     }
 
     // =====================================================================
@@ -104,11 +105,15 @@ class WalletServiceTest {
         void 정상_충전_요청_생성() {
             // given
             Wallet wallet = walletWithBalance(0);
+            WalletCharge chargeFixture = pendingCharge(UUID.randomUUID(), USER_ID, 10_000);
+            WalletChargeResponse expectedResponse = WalletChargeResponse.from(chargeFixture);
+
             given(walletChargeRepository.findByUserIdAndIdempotencyKey(USER_ID, IDEMPOTENCY_KEY))
                 .willReturn(Optional.empty());
-            given(walletRepository.findByUserIdForUpdate(USER_ID)).willReturn(Optional.of(wallet));
-            given(walletChargeRepository.sumTodayChargeAmount(eq(USER_ID), any(LocalDateTime.class)))
-                .willReturn(0);
+            given(walletChargeTransactionService.getWallet(USER_ID)).willReturn(wallet);
+            given(walletChargeTransactionService.createChargeWithLimitCheck(
+                eq(USER_ID), any(WalletChargeRequest.class), eq(IDEMPOTENCY_KEY)))
+                .willReturn(expectedResponse);
 
             // when
             WalletChargeResponse response = walletService.charge(
@@ -118,20 +123,23 @@ class WalletServiceTest {
             assertThat(response).isNotNull();
             assertThat(response.amount()).isEqualTo(10_000);
             assertThat(response.status()).isEqualTo(WalletChargeStatus.PENDING.name());
-            then(walletChargeRepository).should(times(1)).save(any(WalletCharge.class));
+            then(walletChargeTransactionService).should(times(1)).getWallet(USER_ID);
+            then(walletChargeTransactionService).should(times(1))
+                .createChargeWithLimitCheck(eq(USER_ID), any(WalletChargeRequest.class), eq(IDEMPOTENCY_KEY));
         }
 
         @Test
         void 지갑이_없으면_신규_생성_후_충전_요청() {
-            // given: 지갑이 없을 때 신규 생성 후 WalletCharge 생성
+            // given: getWallet이 신규 지갑을 생성·반환하고, createChargeWithLimitCheck가 WalletCharge를 생성
             Wallet newWallet = walletWithBalance(0);
+            WalletCharge chargeFixture = pendingCharge(UUID.randomUUID(), USER_ID, 10_000);
+            WalletChargeResponse expectedResponse = WalletChargeResponse.from(chargeFixture);
+
             given(walletChargeRepository.findByUserIdAndIdempotencyKey(USER_ID, IDEMPOTENCY_KEY))
                 .willReturn(Optional.empty());
-            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.empty()); // getWallet: 없음 → 생성
-            given(walletRepository.save(any(Wallet.class))).willReturn(newWallet);
-            given(walletRepository.findByUserIdForUpdate(USER_ID)).willReturn(Optional.of(newWallet)); // createChargeWithLimitCheck: 생성된 지갑 조회
-            given(walletChargeRepository.sumTodayChargeAmount(eq(USER_ID), any(LocalDateTime.class)))
-                .willReturn(0);
+            given(walletChargeTransactionService.getWallet(USER_ID)).willReturn(newWallet);
+            given(walletChargeTransactionService.createChargeWithLimitCheck(any(), any(), any()))
+                .willReturn(expectedResponse);
 
             // when
             WalletChargeResponse response = walletService.charge(
@@ -139,13 +147,13 @@ class WalletServiceTest {
 
             // then
             assertThat(response).isNotNull();
-            then(walletRepository).should(times(1)).save(any(Wallet.class));
-            then(walletChargeRepository).should(times(1)).save(any(WalletCharge.class));
+            then(walletChargeTransactionService).should(times(1)).getWallet(USER_ID);
+            then(walletChargeTransactionService).should(times(1)).createChargeWithLimitCheck(any(), any(), any());
         }
 
         @Test
         void 동일_idempotency_key_재요청시_기존_충전건_반환() {
-            // given: 이미 같은 idempotency key로 생성된 충전건이 존재
+            // given: 이미 같은 idempotency key로 생성된 충전건이 존재 → 1차 멱등 체크에서 즉시 반환
             UUID chargeId = UUID.randomUUID();
             WalletCharge existingCharge = pendingCharge(chargeId, USER_ID, 10_000);
             given(walletChargeRepository.findByUserIdAndIdempotencyKey(USER_ID, IDEMPOTENCY_KEY))
@@ -155,21 +163,20 @@ class WalletServiceTest {
             WalletChargeResponse response = walletService.charge(
                 USER_ID, new WalletChargeRequest(10_000), IDEMPOTENCY_KEY);
 
-            // then: 지갑 조회 / 한도 체크 / WalletCharge 저장 없이 기존 건 반환
+            // then: 트랜잭션 서비스 호출 없이 기존 건 반환
             assertThat(response.chargeId()).isEqualTo(chargeId.toString());
-            then(walletRepository).should(never()).findByUserIdForUpdate(any());
-            then(walletChargeRepository).should(never()).save(any());
+            then(walletChargeTransactionService).should(never()).getWallet(any());
+            then(walletChargeTransactionService).should(never()).createChargeWithLimitCheck(any(), any(), any());
         }
 
         @Test
         void 일일_한도_초과시_실패() {
-            // given: 오늘 990,001원 충전 완료 + 10,000원 추가 = 1,000,001원 > 1,000,000원
-            Wallet wallet = walletWithBalance(0);
+            // given: createChargeWithLimitCheck 내부에서 한도 초과 예외 발생
             given(walletChargeRepository.findByUserIdAndIdempotencyKey(USER_ID, IDEMPOTENCY_KEY))
                 .willReturn(Optional.empty());
-            given(walletRepository.findByUserIdForUpdate(USER_ID)).willReturn(Optional.of(wallet));
-            given(walletChargeRepository.sumTodayChargeAmount(eq(USER_ID), any(LocalDateTime.class)))
-                .willReturn(990_001);
+            given(walletChargeTransactionService.getWallet(USER_ID)).willReturn(walletWithBalance(0));
+            given(walletChargeTransactionService.createChargeWithLimitCheck(any(), any(), any()))
+                .willThrow(new WalletException(WalletErrorCode.DAILY_CHARGE_LIMIT_EXCEEDED));
 
             // when & then
             assertThatThrownBy(() ->
@@ -177,19 +184,19 @@ class WalletServiceTest {
                 .isInstanceOf(WalletException.class)
                 .extracting(e -> ((WalletException) e).getErrorCode())
                 .isEqualTo(WalletErrorCode.DAILY_CHARGE_LIMIT_EXCEEDED);
-
-            then(walletChargeRepository).should(never()).save(any());
         }
 
         @Test
         void 일일_한도_경계값_정확히_도달시_성공() {
-            // given: 오늘 990,000원 충전 + 10,000원 = 정확히 1,000,000원 (한도 이내)
-            Wallet wallet = walletWithBalance(0);
+            // given: 정확히 한도에 도달 → createChargeWithLimitCheck 정상 반환
+            WalletCharge chargeFixture = pendingCharge(UUID.randomUUID(), USER_ID, 10_000);
+            WalletChargeResponse expectedResponse = WalletChargeResponse.from(chargeFixture);
+
             given(walletChargeRepository.findByUserIdAndIdempotencyKey(USER_ID, IDEMPOTENCY_KEY))
                 .willReturn(Optional.empty());
-            given(walletRepository.findByUserIdForUpdate(USER_ID)).willReturn(Optional.of(wallet));
-            given(walletChargeRepository.sumTodayChargeAmount(eq(USER_ID), any(LocalDateTime.class)))
-                .willReturn(990_000);
+            given(walletChargeTransactionService.getWallet(USER_ID)).willReturn(walletWithBalance(0));
+            given(walletChargeTransactionService.createChargeWithLimitCheck(any(), any(), any()))
+                .willReturn(expectedResponse);
 
             // when
             WalletChargeResponse response = walletService.charge(
@@ -197,26 +204,27 @@ class WalletServiceTest {
 
             // then: 990,000 + 10,000 = 1,000,000 (> 조건 불충족) → 정상 생성
             assertThat(response).isNotNull();
-            then(walletChargeRepository).should(times(1)).save(any(WalletCharge.class));
+            then(walletChargeTransactionService).should(times(1)).createChargeWithLimitCheck(any(), any(), any());
         }
 
         @Test
         void WalletCharge_저장시_중복_예외_발생시_멱등_처리() {
-            // given: 동시 요청 경쟁 조건 — save 직전에 다른 트랜잭션이 먼저 커밋
+            // given: createChargeWithLimitCheck 내 2차 멱등 체크에서 기존 충전건 반환
             UUID chargeId = UUID.randomUUID();
             WalletCharge existingCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            Wallet wallet = walletWithBalance(0);
+            WalletChargeResponse expectedResponse = WalletChargeResponse.from(existingCharge);
 
             given(walletChargeRepository.findByUserIdAndIdempotencyKey(USER_ID, IDEMPOTENCY_KEY))
-                .willReturn(Optional.empty())           // 1차 멱등 체크: 없음
-                .willReturn(Optional.of(existingCharge)); // DataIntegrityViolation 후 재조회: 있음
-            given(walletRepository.findByUserIdForUpdate(USER_ID)).willReturn(Optional.of(wallet));
+                .willReturn(Optional.empty());
+            given(walletChargeTransactionService.getWallet(USER_ID)).willReturn(walletWithBalance(0));
+            given(walletChargeTransactionService.createChargeWithLimitCheck(any(), any(), any()))
+                .willReturn(expectedResponse);
 
             // when
             WalletChargeResponse response = walletService.charge(
                 USER_ID, new WalletChargeRequest(10_000), IDEMPOTENCY_KEY);
 
-            // then: createChargeWithLimitCheck 내 2차 멱등 체크에서 기존 충전건 반환
+            // then
             assertThat(response.chargeId()).isEqualTo(chargeId.toString());
         }
     }
@@ -234,39 +242,35 @@ class WalletServiceTest {
             // given
             UUID chargeId = UUID.randomUUID();
             String paymentKey = "pk-confirm-123";
-            String transactionKey = "CHARGE:" + paymentKey;
-            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            Wallet wallet = walletWithBalance(60_000);
+            PgPaymentConfirmResult pgResult = new PgPaymentConfirmResult(
+                paymentKey, chargeId.toString(), "카드", "DONE", 10_000, "2024-01-01T12:00:00");
+            WalletChargeConfirmResponse expectedResponse = WalletChargeConfirmResponse.from(
+                chargeId.toString(), 10_000, 60_000, WalletChargeStatus.COMPLETED.name(), null);
 
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId))
-                .willReturn(Optional.of(walletCharge));
-            given(walletChargeRepository.findByChargeId(chargeId))
-                .willReturn(Optional.of(walletCharge)); // completeChargeAfterPg 내 재조회
-            given(pgPaymentClient.confirm(any()))
-                .willReturn(new PgPaymentConfirmResult(
-                    paymentKey, chargeId.toString(), "카드", "DONE", 10_000, "2024-01-01T12:00:00"));
-            given(walletTransactionRepository.existsByTransactionKey(transactionKey)).willReturn(false);
-            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(wallet));
-            given(walletTransactionRepository.save(any())).willReturn(
-                WalletTransaction.createCharge(1L, USER_ID, transactionKey, 10_000, 60_000));
+            given(pgPaymentClient.confirm(any())).willReturn(pgResult);
+            given(walletChargeTransactionService.completeChargeAfterPg(USER_ID, chargeId, pgResult))
+                .willReturn(expectedResponse);
 
             // when
             WalletChargeConfirmResponse response = walletService.confirmCharge(
                 USER_ID, new WalletChargeConfirmRequest(paymentKey, chargeId.toString(), 10_000));
 
             // then
-            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.COMPLETED);
             assertThat(response.balance()).isEqualTo(60_000);
             assertThat(response.status()).isEqualTo(WalletChargeStatus.COMPLETED.name());
-            then(walletRepository).should(times(1)).chargeBalanceAtomic(USER_ID, 10_000);
-            then(walletTransactionRepository).should(times(1)).save(any(WalletTransaction.class));
+            then(walletChargeTransactionService).should(times(1))
+                .claimChargeForProcessing(USER_ID, chargeId, 10_000);
+            then(walletChargeTransactionService).should(times(1))
+                .completeChargeAfterPg(eq(USER_ID), eq(chargeId), any());
         }
 
         @Test
         void 존재하지_않는_chargeId이면_실패() {
-            // given
+            // given: claimChargeForProcessing에서 CHARGE_NOT_FOUND 예외 발생
             UUID chargeId = UUID.randomUUID();
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.empty());
+            org.mockito.BDDMockito.willThrow(new WalletException(WalletErrorCode.CHARGE_NOT_FOUND))
+                .given(walletChargeTransactionService)
+                .claimChargeForProcessing(USER_ID, chargeId, 10_000);
 
             // when & then
             assertThatThrownBy(() -> walletService.confirmCharge(
@@ -278,12 +282,11 @@ class WalletServiceTest {
 
         @Test
         void 다른_사용자의_충전건_확정_시도시_실패() {
-            // given
+            // given: claimChargeForProcessing에서 CHARGE_NOT_FOUND 예외 발생
             UUID chargeId = UUID.randomUUID();
-            UUID otherUserId = UUID.randomUUID();
-            WalletCharge walletCharge = pendingCharge(chargeId, otherUserId, 10_000);
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId))
-                .willReturn(Optional.of(walletCharge));
+            org.mockito.BDDMockito.willThrow(new WalletException(WalletErrorCode.CHARGE_NOT_FOUND))
+                .given(walletChargeTransactionService)
+                .claimChargeForProcessing(USER_ID, chargeId, 10_000);
 
             // when & then
             assertThatThrownBy(() -> walletService.confirmCharge(
@@ -295,12 +298,11 @@ class WalletServiceTest {
 
         @Test
         void PENDING이_아닌_충전건_확정_시도시_실패() {
-            // given: 이미 COMPLETED 상태
+            // given: claimChargeForProcessing에서 CHARGE_NOT_PENDING 예외 발생
             UUID chargeId = UUID.randomUUID();
-            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            walletCharge.complete("already-done-key");
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId))
-                .willReturn(Optional.of(walletCharge));
+            org.mockito.BDDMockito.willThrow(new WalletException(WalletErrorCode.CHARGE_NOT_PENDING))
+                .given(walletChargeTransactionService)
+                .claimChargeForProcessing(USER_ID, chargeId, 10_000);
 
             // when & then
             assertThatThrownBy(() -> walletService.confirmCharge(
@@ -312,11 +314,11 @@ class WalletServiceTest {
 
         @Test
         void 금액_불일치시_실패() {
-            // given: WalletCharge 금액 10,000 / 요청 금액 20,000
+            // given: claimChargeForProcessing에서 CHARGE_AMOUNT_MISMATCH 예외 발생
             UUID chargeId = UUID.randomUUID();
-            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId))
-                .willReturn(Optional.of(walletCharge));
+            org.mockito.BDDMockito.willThrow(new WalletException(WalletErrorCode.CHARGE_AMOUNT_MISMATCH))
+                .given(walletChargeTransactionService)
+                .claimChargeForProcessing(USER_ID, chargeId, 20_000);
 
             // when & then
             assertThatThrownBy(() -> walletService.confirmCharge(
@@ -330,52 +332,40 @@ class WalletServiceTest {
         void PG_승인_실패시_FAILED_상태_응답_반환() {
             // given: PG 네트워크 오류
             UUID chargeId = UUID.randomUUID();
-            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId))
-                .willReturn(Optional.of(walletCharge));
-            given(walletChargeRepository.findByChargeId(chargeId))
-                .willReturn(Optional.of(walletCharge)); // failProcessingCharge 내 재조회
             given(pgPaymentClient.confirm(any())).willThrow(new RuntimeException("PG timeout"));
 
             // when
             WalletChargeConfirmResponse response = walletService.confirmCharge(
                 USER_ID, new WalletChargeConfirmRequest("pk-key", chargeId.toString(), 10_000));
 
-            // then: 충전건 FAILED, 잔액 미반영, 거래기록 미생성
-            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.FAILED);
+            // then: failProcessingCharge 호출, 잔액 미반영
             assertThat(response.status()).isEqualTo("FAILED");
-            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
-            then(walletTransactionRepository).should(never()).save(any());
+            then(walletChargeTransactionService).should(times(1)).failProcessingCharge(chargeId);
+            then(walletChargeTransactionService).should(never()).completeChargeAfterPg(any(), any(), any());
         }
 
         @Test
         void transactionKey_중복시_잔액_반영_후_거래기록_생성_생략() {
-            // given: PG DONE이지만 WalletTransaction은 이미 존재 (부분 실패 후 재요청)
+            // given: completeChargeAfterPg에서 중복 transactionKey 감지 후 WalletTransaction 생성 생략
             UUID chargeId = UUID.randomUUID();
             String paymentKey = "pk-dup-tx";
-            String transactionKey = "CHARGE:" + paymentKey;
-            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            Wallet wallet = walletWithBalance(60_000);
+            PgPaymentConfirmResult pgResult = new PgPaymentConfirmResult(
+                paymentKey, chargeId.toString(), "카드", "DONE", 10_000, "2024-01-01T12:00:00");
+            WalletChargeConfirmResponse expectedResponse = WalletChargeConfirmResponse.from(
+                chargeId.toString(), 10_000, 60_000, WalletChargeStatus.COMPLETED.name(), null);
 
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId))
-                .willReturn(Optional.of(walletCharge));
-            given(walletChargeRepository.findByChargeId(chargeId))
-                .willReturn(Optional.of(walletCharge)); // completeChargeAfterPg 내 재조회
-            given(pgPaymentClient.confirm(any()))
-                .willReturn(new PgPaymentConfirmResult(
-                    paymentKey, chargeId.toString(), "카드", "DONE", 10_000, "2024-01-01T12:00:00"));
-            given(walletTransactionRepository.existsByTransactionKey(transactionKey)).willReturn(true);
-            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(wallet));
+            given(pgPaymentClient.confirm(any())).willReturn(pgResult);
+            given(walletChargeTransactionService.completeChargeAfterPg(USER_ID, chargeId, pgResult))
+                .willReturn(expectedResponse);
 
             // when
             WalletChargeConfirmResponse response = walletService.confirmCharge(
                 USER_ID, new WalletChargeConfirmRequest(paymentKey, chargeId.toString(), 10_000));
 
-            // then: 잔액은 반영, WalletTransaction은 생성 생략
-            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.COMPLETED);
+            // then
             assertThat(response.status()).isEqualTo(WalletChargeStatus.COMPLETED.name());
-            then(walletRepository).should(times(1)).chargeBalanceAtomic(USER_ID, 10_000);
-            then(walletTransactionRepository).should(never()).save(any());
+            then(walletChargeTransactionService).should(times(1))
+                .completeChargeAfterPg(eq(USER_ID), eq(chargeId), any());
         }
 
         @Test

--- a/payment/src/test/java/com/devticket/payment/integration/WalletChargeConcurrencyIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/integration/WalletChargeConcurrencyIntegrationTest.java
@@ -213,7 +213,6 @@ class WalletChargeConcurrencyIntegrationTest {
     // 검증: Wallet 1개만 생성 + 에러 없이 N건 모두 성공 + WalletCharge N건 생성
     // =========================================================================
     @Test
-    @Disabled("TODO: 신규 사용자 동시 다기기 요청 시 Wallet 중복 생성 방어 미구현 — getWallet() 개선 후 활성화")
     @DisplayName("신규 유저: 지갑 없는 상태에서 다기기 동시 충전(다른 멱등성 키) — Wallet 1개, WalletCharge N건 생성")
     void 신규유저_지갑미생성_다기기_동시충전_각기다른멱등성키() throws InterruptedException {
         // given — 지갑이 없는 신규 유저 (setUp의 walletRepository.save 적용 안 됨)


### PR DESCRIPTION
## 관련 이슈
- close #429

## 작업 내용
현재 : 내부 메서드 호출 시 프록시를 타지 않는 문제를 해결하기 위해,
self 주입을 통해 Spring AOP (@transactional)가 정상 적용되도록 처리.

변경 : 
self주입하여 사용되고 있는 메서드를  별도 Bean으로 분리

## 변경 사항
- service패키지 하위 support서브 패키지 생성

- WalletChargeTransactionService에 기존 메서드들을 별도 Bean으로 분리
  - getWallet
  - createChargeWithLimitCheck
  - claimChargeForProcessing
  - failProcessingCharge
  - completeChargeAfterPg
  
-  WalletChargeTransactionService - getWallet : DB수준의 UPSERT사용한 단일쿼리로 무결성 에러 자체를 방지.
   - WalletRepository,WalletJpaRepository,WalletRepositoryImpl  :  insertWalletIfAbsent추가

- WalletChargeConcurrencyIntegrationTest : 신규유저 다기기 동시요청 테스트 추가 


## 테스트
- [ ] 단위 테스트 통과
- [x] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항