### PR TITLE
[Settlement] feat(2/4) :Commerce서비스에 정산대상 데이터요청 API

### DIFF
--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToCommerceClient.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToCommerceClient.java
@@ -3,7 +3,11 @@ package com.devticket.settlement.infrastructure.client;
 import com.devticket.settlement.common.exception.BusinessException;
 import com.devticket.settlement.common.exception.CommonErrorCode;
 import com.devticket.settlement.infrastructure.client.dto.req.InternalSettlementDataRequest;
+import com.devticket.settlement.infrastructure.client.dto.res.CommerceTicketSettlementResponse;
+import com.devticket.settlement.infrastructure.client.dto.res.EventTicketSettlementResponse;
 import com.devticket.settlement.infrastructure.client.dto.res.InternalSettlementDataResponse;
+import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatusCode;
@@ -40,6 +44,44 @@ public class SettlementToCommerceClient {
                     throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
                 })
                 .body(InternalSettlementDataResponse.class);
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[SettlementToCommerceClient] Critical Error: ", e);
+            throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 여러 이벤트의 티켓 정산 데이터를 한 번에 조회.
+     * POST /internal/tickets/settlement-data
+     * Request body : [uuid1, uuid2, ...]
+     * Response     : { "items": [ { eventId, orderItemId, salesAmount, refundAmount }, ... ] }
+     */
+    public List<EventTicketSettlementResponse> getTicketSettlementData(List<UUID> eventIds) {
+        try {
+            log.info("[SettlementToCommerceClient] getTicketSettlementData - eventIds 수: {}", eventIds.size());
+
+            CommerceTicketSettlementResponse response = restClient.post()
+                .uri("/internal/tickets/settlement-data")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(eventIds)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    log.error("[SettlementToCommerceClient] Ticket API Error: Status {}", res.getStatusCode());
+                    throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
+                })
+                .body(CommerceTicketSettlementResponse.class);
+
+            if (response == null || response.items() == null) {
+                log.warn("[SettlementToCommerceClient] 응답 데이터 없음");
+                return List.of();
+            }
+
+            log.info("[SettlementToCommerceClient] 조회된 orderItem 건수: {}", response.items().size());
+            return response.items();
 
         } catch (BusinessException e) {
             throw e;

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToCommerceClient.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToCommerceClient.java
@@ -60,6 +60,10 @@ public class SettlementToCommerceClient {
      * Response     : { "items": [ { eventId, orderItemId, salesAmount, refundAmount }, ... ] }
      */
     public List<EventTicketSettlementResponse> getTicketSettlementData(List<UUID> eventIds) {
+        if (eventIds == null || eventIds.isEmpty()) {
+            log.warn("[SettlementToCommerceClient] eventIds가 null 또는 빈 리스트 - 외부 호출 생략");
+            return List.of();
+        }
         try {
             log.info("[SettlementToCommerceClient] getTicketSettlementData - eventIds 수: {}", eventIds.size());
 

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/req/EventTicketSettlementRequest.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/req/EventTicketSettlementRequest.java
@@ -1,0 +1,10 @@
+package com.devticket.settlement.infrastructure.client.dto.req;
+
+import java.util.List;
+import java.util.UUID;
+
+public record EventTicketSettlementRequest(
+    List<UUID> eventIds
+) {
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/CommerceTicketSettlementResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/CommerceTicketSettlementResponse.java
@@ -1,0 +1,13 @@
+package com.devticket.settlement.infrastructure.client.dto.res;
+
+import java.util.List;
+
+/**
+ * Commerce 서비스의 InternalTicketSettlementDataResponse에 대응하는 역직렬화 DTO.
+ * { "items": [ { "eventId", "orderItemId", "salesAmount", "refundAmount" }, ... ] }
+ */
+public record CommerceTicketSettlementResponse(
+    List<EventTicketSettlementResponse> items
+) {
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EventTicketSettlementResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EventTicketSettlementResponse.java
@@ -1,0 +1,12 @@
+package com.devticket.settlement.infrastructure.client.dto.res;
+
+import java.util.UUID;
+
+public record EventTicketSettlementResponse(
+    UUID eventId,
+    UUID orderItemId,
+    Long salesAmount,
+    Long refundAmount
+) {
+
+}


### PR DESCRIPTION
## 관련 이슈
- close #432

## 작업 내용
- Commerce서비스에 종료된 이벤트ids를 기반으로 판매자별 판매현황데이터 요청 API

## 변경 사항
- Commerce서비스에 종료된 이벤트ids 들의 판매데이터 요청 API
  - [ ] SettlementToCommerceClient
  - [ ] DTO - EventTicketSettlementRequest
  - [ ] DTO - EventTicketSettlementResponse
  - [ ] DTO - CommerceTicketSettlementResponse

## API 엔드포인트
- GET /internal/orders/settlement-data

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항

