### PR TITLE
[Settlement] feat(4/4) : 정산대상데이터 적재 스케줄링작업_ 타서비스에 데이터요청,응답데이터 SettlementItem에 적재, 테스트 코드작성

### DIFF
--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementService.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementService.java
@@ -17,4 +17,6 @@ public interface SettlementService {
     SellerSettlementDetailResponse getSellerSettlementDetail(UUID sellerId, UUID settlementId);
 
     SettlementTargetPreviewResponse previewSettlementTarget(LocalDate targetDate);
+
+    SettlementTargetPreviewResponse collectSettlementTargets(LocalDate targetDate);
 }

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
@@ -118,9 +118,16 @@ public class SettlementServiceImpl implements SettlementService {
         int skippedCount = 0;
 
         for (EventTicketSettlementResponse ticketItem : ticketItems) {
+            EndedEventResponse event = eventMap.get(ticketItem.eventId());
+            if (event == null) {
+                log.warn("[collectSettlementTargets] Event 서비스 응답에 없는 eventId 스킵 - orderItemId: {}, eventId: {}",
+                    ticketItem.orderItemId(), ticketItem.eventId());
+                skippedCount++;
+                continue;
+            }
+
             Long feeAmount = feePolicy.calculateFee(ticketItem.salesAmount());
             Long settlementAmount = ticketItem.salesAmount() - ticketItem.refundAmount() - feeAmount;
-            EndedEventResponse event = eventMap.get(ticketItem.eventId());
 
             if (settlementItemRepository.existsByOrderItemId(ticketItem.orderItemId())) {
                 log.warn("[collectSettlementTargets] 중복 스킵 - orderItemId: {}", ticketItem.orderItemId());

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
@@ -75,6 +75,7 @@ public class SettlementServiceImpl implements SettlementService {
      * 정산대상데이터 요청기능의 수동테스트 진행건.
      */
     @Override
+    @Transactional
     public SettlementTargetPreviewResponse previewSettlementTarget(LocalDate targetDate) {
         return collectSettlementTargets(targetDate);
     }

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
@@ -72,23 +72,29 @@ public class SettlementServiceImpl implements SettlementService {
     }
 
     /**
+     * 정산대상데이터 요청기능의 수동테스트 진행건.
+     */
+    @Override
+    public SettlementTargetPreviewResponse previewSettlementTarget(LocalDate targetDate) {
+        return collectSettlementTargets(targetDate);
+    }
+
+    /**
      * Event 서비스 → Commerce 서비스 실제 API 호출 후
      * Platform Fee 수수료를 적용하여 orderItem 단위로 SettlementItem을 저장한다.
      * orderItemId 기준으로 중복된 항목은 저장하지 않고 SKIPPED로 표기한다.
      */
     @Override
     @Transactional
-    public SettlementTargetPreviewResponse previewSettlementTarget(LocalDate targetDate) {
-        // 1. Platform Fee 정책 조회
+    public SettlementTargetPreviewResponse collectSettlementTargets(LocalDate targetDate) {
         FeePolicy feePolicy = feePolicyRepository.findByName("PLATFORM_FEE")
             .orElseThrow(() -> new BusinessException(SettlementErrorCode.FEE_POLICY_NOT_FOUND));
-        log.info("[previewSettlementTarget] FeePolicy - name: {}, feeValue: {}",
+        log.info("[collectSettlementTargets] FeePolicy - name: {}, feeValue: {}",
             feePolicy.getName(), feePolicy.getFeeValue());
 
-        // 2. Event 서비스: 해당 날짜에 종료된 이벤트 목록 조회
-        log.info("[previewSettlementTarget] Event 서비스 호출 - targetDate: {}", targetDate);
+        log.info("[collectSettlementTargets] Event 서비스 호출 - targetDate: {}", targetDate);
         List<EndedEventResponse> endedEvents = settlementToEventClient.getEndedEvents(targetDate);
-        log.info("[previewSettlementTarget] 종료된 이벤트 {}건 조회됨", endedEvents.size());
+        log.info("[collectSettlementTargets] 종료된 이벤트 {}건 조회됨", endedEvents.size());
 
         if (endedEvents.isEmpty()) {
             return new SettlementTargetPreviewResponse(
@@ -101,13 +107,11 @@ public class SettlementServiceImpl implements SettlementService {
         Map<UUID, EndedEventResponse> eventMap = endedEvents.stream()
             .collect(Collectors.toMap(EndedEventResponse::eventId, e -> e));
 
-        // 3. Commerce 서비스: 전체 eventId 리스트를 한 번에 전송
         List<UUID> eventIds = endedEvents.stream().map(EndedEventResponse::eventId).toList();
         List<EventTicketSettlementResponse> ticketItems =
             settlementToCommerceClient.getTicketSettlementData(eventIds);
-        log.info("[previewSettlementTarget] Commerce 응답 - orderItem 건수: {}", ticketItems.size());
+        log.info("[collectSettlementTargets] Commerce 응답 - orderItem 건수: {}", ticketItems.size());
 
-        // 4. orderItem 단위로 수수료 계산 후 저장
         List<EventSettlementPreview> previews = new ArrayList<>();
         int savedCount = 0;
         int skippedCount = 0;
@@ -118,7 +122,7 @@ public class SettlementServiceImpl implements SettlementService {
             EndedEventResponse event = eventMap.get(ticketItem.eventId());
 
             if (settlementItemRepository.existsByOrderItemId(ticketItem.orderItemId())) {
-                log.warn("[previewSettlementTarget] 중복 스킵 - orderItemId: {}", ticketItem.orderItemId());
+                log.warn("[collectSettlementTargets] 중복 스킵 - orderItemId: {}", ticketItem.orderItemId());
                 previews.add(new EventSettlementPreview(
                     ticketItem.orderItemId(), event.id(), ticketItem.eventId(), event.sellerId(),
                     ticketItem.salesAmount(), ticketItem.refundAmount(), feeAmount, settlementAmount,
@@ -143,7 +147,7 @@ public class SettlementServiceImpl implements SettlementService {
             settlementItemRepository.save(item);
             savedCount++;
 
-            log.info("[previewSettlementTarget] 저장 완료 - orderItemId: {}, eventId: {}, sales: {}, fee: {}, settlement: {}",
+            log.info("[collectSettlementTargets] 저장 완료 - orderItemId: {}, eventId: {}, sales: {}, fee: {}, settlement: {}",
                 ticketItem.orderItemId(), ticketItem.eventId(),
                 ticketItem.salesAmount(), feeAmount, settlementAmount);
 
@@ -154,7 +158,7 @@ public class SettlementServiceImpl implements SettlementService {
             ));
         }
 
-        log.info("[previewSettlementTarget] 완료 - 저장: {}건, 중복 스킵: {}건", savedCount, skippedCount);
+        log.info("[collectSettlementTargets] 완료 - 저장: {}건, 중복 스킵: {}건", savedCount, skippedCount);
         return new SettlementTargetPreviewResponse(
             targetDate.toString(),
             endedEvents.size(),

--- a/settlement/src/main/java/com/devticket/settlement/presentation/scheduler/SettlementScheduler.java
+++ b/settlement/src/main/java/com/devticket/settlement/presentation/scheduler/SettlementScheduler.java
@@ -1,0 +1,37 @@
+package com.devticket.settlement.presentation.scheduler;
+
+import com.devticket.settlement.application.service.SettlementService;
+import com.devticket.settlement.infrastructure.batch.SettlementItemProcessor;
+import com.devticket.settlement.infrastructure.batch.SettlementItemReader;
+import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SettlementScheduler {
+
+    private final SettlementService settlementService;
+
+    @Scheduled(cron = "1 0 0 * * *")
+    public void collectDailySettlementTargets() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        log.info("[SettlementScheduler] 정산대상 데이터 수집 시작 - targetDate: {}", yesterday);
+        try {
+            SettlementTargetPreviewResponse result = settlementService.collectSettlementTargets(yesterday);
+            log.info("[SettlementScheduler] 정산대상 데이터 수집 완료 - 이벤트: {}건, 저장: {}건, 스킵: {}건",
+                result.totalEventCount(), result.savedCount(), result.skippedCount());
+        } catch (Exception e) {
+            //실패 시 에러 로그만 남겨 배치 스케줄러 자체는 계속 동작하도록 처리
+            log.error("[SettlementScheduler] 정산대상 데이터 수집 실패 - targetDate: {}", yesterday, e);
+        }
+    }
+
+}

--- a/settlement/src/test/java/com/devticket/settlement/presentation/controller/SettlementControllerTest.java
+++ b/settlement/src/test/java/com/devticket/settlement/presentation/controller/SettlementControllerTest.java
@@ -1,0 +1,169 @@
+package com.devticket.settlement.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.devticket.settlement.application.service.SettlementServiceImpl;
+import com.devticket.settlement.common.exception.BusinessException;
+import com.devticket.settlement.common.exception.CommonErrorCode;
+import com.devticket.settlement.domain.exception.SettlementErrorCode;
+import com.devticket.settlement.domain.model.SettlementStatus;
+import com.devticket.settlement.presentation.dto.SellerSettlementDetailResponse;
+import com.devticket.settlement.presentation.dto.SettlementResponse;
+import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SettlementController.class)
+class SettlementControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SettlementServiceImpl settlementServiceImpl;
+
+    // 공용 픽스처
+    private final UUID sellerId = UUID.randomUUID();
+    private final UUID settlementId = UUID.randomUUID();
+
+    // ────────────────────────────────────────────────
+    // previewSettlementTarget
+    // ────────────────────────────────────────────────
+
+    @Test
+    void previewSettlementTarget_날짜지정_성공() throws Exception {
+        LocalDate date = LocalDate.of(2024, 1, 1);
+        SettlementTargetPreviewResponse response = makePreviewResponse("2024-01-01", 2, 2, 0);
+        given(settlementServiceImpl.previewSettlementTarget(date)).willReturn(response);
+
+        mockMvc.perform(get("/api/test/settlement-target/preview")
+                .param("date", "2024-01-01"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.targetDate").value("2024-01-01"))
+            .andExpect(jsonPath("$.totalEventCount").value(2))
+            .andExpect(jsonPath("$.savedCount").value(2))
+            .andExpect(jsonPath("$.skippedCount").value(0));
+    }
+
+    @Test
+    void previewSettlementTarget_날짜미지정_어제날짜로_조회() throws Exception {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        SettlementTargetPreviewResponse response = makePreviewResponse(yesterday.toString(), 1, 1, 0);
+        given(settlementServiceImpl.previewSettlementTarget(yesterday)).willReturn(response);
+
+        mockMvc.perform(get("/api/test/settlement-target/preview"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.targetDate").value(yesterday.toString()));
+    }
+
+    @Test
+    void previewSettlementTarget_종료이벤트없음_빈응답() throws Exception {
+        LocalDate date = LocalDate.of(2024, 1, 1);
+        SettlementTargetPreviewResponse response = makePreviewResponse("2024-01-01", 0, 0, 0);
+        given(settlementServiceImpl.previewSettlementTarget(date)).willReturn(response);
+
+        mockMvc.perform(get("/api/test/settlement-target/preview")
+                .param("date", "2024-01-01"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.totalEventCount").value(0))
+            .andExpect(jsonPath("$.items").isEmpty());
+    }
+
+    // ────────────────────────────────────────────────
+    // getSellerSettlements
+    // ────────────────────────────────────────────────
+
+    @Test
+    void getSellerSettlements_성공() throws Exception {
+        List<SettlementResponse> settlements = List.of(
+            new SettlementResponse(settlementId, "2024-01-01", "2024-01-31",
+                100000, 0, 3000, 97000, SettlementStatus.COMPLETED, "2024-02-01T10:00:00"),
+            new SettlementResponse(UUID.randomUUID(), "2024-02-01", "2024-02-28",
+                50000, 5000, 1500, 43500, SettlementStatus.PENDING, null)
+        );
+        given(settlementServiceImpl.getSellerSettlements(sellerId)).willReturn(settlements);
+
+        mockMvc.perform(get("/api/seller/settlements")
+                .header("X-User-Id", sellerId.toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(2))
+            .andExpect(jsonPath("$[0].totalSalesAmount").value(100000))
+            .andExpect(jsonPath("$[0].status").value("COMPLETED"))
+            .andExpect(jsonPath("$[1].status").value("PENDING"));
+    }
+
+    @Test
+    void getSellerSettlements_빈목록_빈배열반환() throws Exception {
+        given(settlementServiceImpl.getSellerSettlements(sellerId)).willReturn(List.of());
+
+        mockMvc.perform(get("/api/seller/settlements")
+                .header("X-User-Id", sellerId.toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    // ────────────────────────────────────────────────
+    // getSellerSettlement (detail)
+    // ────────────────────────────────────────────────
+
+    @Test
+    void getSellerSettlement_상세조회_성공() throws Exception {
+        SellerSettlementDetailResponse detail = new SellerSettlementDetailResponse(
+            settlementId.toString(), "2024-01-01T00:00:00", "2024-01-31T23:59:59",
+            100000, 0, 3000, 97000, "COMPLETED", "2024-02-01T10:00:00", List.of()
+        );
+        given(settlementServiceImpl.getSellerSettlementDetail(sellerId, settlementId)).willReturn(detail);
+
+        mockMvc.perform(get("/api/seller/settlements/{settlementId}", settlementId)
+                .header("X-User-Id", sellerId.toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.settlementId").value(settlementId.toString()))
+            .andExpect(jsonPath("$.totalSalesAmount").value(100000))
+            .andExpect(jsonPath("$.status").value("COMPLETED"));
+    }
+
+    @Test
+    void getSellerSettlement_정산없음_400반환() throws Exception {
+        given(settlementServiceImpl.getSellerSettlementDetail(any(UUID.class), eq(settlementId)))
+            .willThrow(new BusinessException(SettlementErrorCode.SETTLEMENT_BAD_REQUEST));
+
+        mockMvc.perform(get("/api/seller/settlements/{settlementId}", settlementId)
+                .header("X-User-Id", sellerId.toString()))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("SETTLEMENT_002"));
+    }
+
+    @Test
+    void getSellerSettlement_다른판매자접근_403반환() throws Exception {
+        UUID anotherSellerId = UUID.randomUUID();
+        given(settlementServiceImpl.getSellerSettlementDetail(eq(anotherSellerId), eq(settlementId)))
+            .willThrow(new BusinessException(CommonErrorCode.ACCESS_DENIED));
+
+        mockMvc.perform(get("/api/seller/settlements/{settlementId}", settlementId)
+                .header("X-User-Id", anotherSellerId.toString()))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("COMMON_005"));
+    }
+
+    // ────────────────────────────────────────────────
+    // 헬퍼
+    // ────────────────────────────────────────────────
+
+    private SettlementTargetPreviewResponse makePreviewResponse(
+        String date, int totalEvents, int saved, int skipped) {
+        return new SettlementTargetPreviewResponse(
+            date, totalEvents, saved, skipped, "PLATFORM_FEE", "0.03", List.of()
+        );
+    }
+}

--- a/settlement/src/test/java/com/devticket/settlement/presentation/controller/SettlementControllerTest.java
+++ b/settlement/src/test/java/com/devticket/settlement/presentation/controller/SettlementControllerTest.java
@@ -1,11 +1,8 @@
 package com.devticket.settlement.presentation.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.devticket.settlement.application.service.SettlementServiceImpl;
 import com.devticket.settlement.common.exception.BusinessException;
@@ -19,21 +16,22 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
-@WebMvcTest(SettlementController.class)
+@ExtendWith(MockitoExtension.class)
 class SettlementControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
+    @Mock
     private SettlementServiceImpl settlementServiceImpl;
 
-    // 공용 픽스처
+    @InjectMocks
+    private SettlementController settlementController;
+
     private final UUID sellerId = UUID.randomUUID();
     private final UUID settlementId = UUID.randomUUID();
 
@@ -42,42 +40,45 @@ class SettlementControllerTest {
     // ────────────────────────────────────────────────
 
     @Test
-    void previewSettlementTarget_날짜지정_성공() throws Exception {
+    void previewSettlementTarget_날짜지정_성공() {
         LocalDate date = LocalDate.of(2024, 1, 1);
         SettlementTargetPreviewResponse response = makePreviewResponse("2024-01-01", 2, 2, 0);
         given(settlementServiceImpl.previewSettlementTarget(date)).willReturn(response);
 
-        mockMvc.perform(get("/api/test/settlement-target/preview")
-                .param("date", "2024-01-01"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.targetDate").value("2024-01-01"))
-            .andExpect(jsonPath("$.totalEventCount").value(2))
-            .andExpect(jsonPath("$.savedCount").value(2))
-            .andExpect(jsonPath("$.skippedCount").value(0));
+        ResponseEntity<SettlementTargetPreviewResponse> result =
+            settlementController.previewSettlementTarget(date);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().targetDate()).isEqualTo("2024-01-01");
+        assertThat(result.getBody().totalEventCount()).isEqualTo(2);
+        assertThat(result.getBody().savedCount()).isEqualTo(2);
+        assertThat(result.getBody().skippedCount()).isEqualTo(0);
     }
 
     @Test
-    void previewSettlementTarget_날짜미지정_어제날짜로_조회() throws Exception {
+    void previewSettlementTarget_날짜미지정_어제날짜로_조회() {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         SettlementTargetPreviewResponse response = makePreviewResponse(yesterday.toString(), 1, 1, 0);
         given(settlementServiceImpl.previewSettlementTarget(yesterday)).willReturn(response);
 
-        mockMvc.perform(get("/api/test/settlement-target/preview"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.targetDate").value(yesterday.toString()));
+        ResponseEntity<SettlementTargetPreviewResponse> result =
+            settlementController.previewSettlementTarget(null);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().targetDate()).isEqualTo(yesterday.toString());
     }
 
     @Test
-    void previewSettlementTarget_종료이벤트없음_빈응답() throws Exception {
+    void previewSettlementTarget_종료이벤트없음_빈응답() {
         LocalDate date = LocalDate.of(2024, 1, 1);
         SettlementTargetPreviewResponse response = makePreviewResponse("2024-01-01", 0, 0, 0);
         given(settlementServiceImpl.previewSettlementTarget(date)).willReturn(response);
 
-        mockMvc.perform(get("/api/test/settlement-target/preview")
-                .param("date", "2024-01-01"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.totalEventCount").value(0))
-            .andExpect(jsonPath("$.items").isEmpty());
+        ResponseEntity<SettlementTargetPreviewResponse> result =
+            settlementController.previewSettlementTarget(date);
+
+        assertThat(result.getBody().totalEventCount()).isEqualTo(0);
+        assertThat(result.getBody().items()).isEmpty();
     }
 
     // ────────────────────────────────────────────────
@@ -85,7 +86,7 @@ class SettlementControllerTest {
     // ────────────────────────────────────────────────
 
     @Test
-    void getSellerSettlements_성공() throws Exception {
+    void getSellerSettlements_성공() {
         List<SettlementResponse> settlements = List.of(
             new SettlementResponse(settlementId, "2024-01-01", "2024-01-31",
                 100000, 0, 3000, 97000, SettlementStatus.COMPLETED, "2024-02-01T10:00:00"),
@@ -94,23 +95,25 @@ class SettlementControllerTest {
         );
         given(settlementServiceImpl.getSellerSettlements(sellerId)).willReturn(settlements);
 
-        mockMvc.perform(get("/api/seller/settlements")
-                .header("X-User-Id", sellerId.toString()))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.length()").value(2))
-            .andExpect(jsonPath("$[0].totalSalesAmount").value(100000))
-            .andExpect(jsonPath("$[0].status").value("COMPLETED"))
-            .andExpect(jsonPath("$[1].status").value("PENDING"));
+        ResponseEntity<List<SettlementResponse>> result =
+            settlementController.getSellerSettlements(sellerId);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody()).hasSize(2);
+        assertThat(result.getBody().get(0).totalSalesAmount()).isEqualTo(100000);
+        assertThat(result.getBody().get(0).status()).isEqualTo(SettlementStatus.COMPLETED);
+        assertThat(result.getBody().get(1).status()).isEqualTo(SettlementStatus.PENDING);
     }
 
     @Test
-    void getSellerSettlements_빈목록_빈배열반환() throws Exception {
+    void getSellerSettlements_빈목록_빈배열반환() {
         given(settlementServiceImpl.getSellerSettlements(sellerId)).willReturn(List.of());
 
-        mockMvc.perform(get("/api/seller/settlements")
-                .header("X-User-Id", sellerId.toString()))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.length()").value(0));
+        ResponseEntity<List<SettlementResponse>> result =
+            settlementController.getSellerSettlements(sellerId);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody()).isEmpty();
     }
 
     // ────────────────────────────────────────────────
@@ -118,42 +121,43 @@ class SettlementControllerTest {
     // ────────────────────────────────────────────────
 
     @Test
-    void getSellerSettlement_상세조회_성공() throws Exception {
+    void getSellerSettlement_상세조회_성공() {
         SellerSettlementDetailResponse detail = new SellerSettlementDetailResponse(
             settlementId.toString(), "2024-01-01T00:00:00", "2024-01-31T23:59:59",
             100000, 0, 3000, 97000, "COMPLETED", "2024-02-01T10:00:00", List.of()
         );
         given(settlementServiceImpl.getSellerSettlementDetail(sellerId, settlementId)).willReturn(detail);
 
-        mockMvc.perform(get("/api/seller/settlements/{settlementId}", settlementId)
-                .header("X-User-Id", sellerId.toString()))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.settlementId").value(settlementId.toString()))
-            .andExpect(jsonPath("$.totalSalesAmount").value(100000))
-            .andExpect(jsonPath("$.status").value("COMPLETED"));
+        ResponseEntity<SellerSettlementDetailResponse> result =
+            settlementController.getSellerSettlement(sellerId, settlementId);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().settlementId()).isEqualTo(settlementId.toString());
+        assertThat(result.getBody().totalSalesAmount()).isEqualTo(100000);
+        assertThat(result.getBody().status()).isEqualTo("COMPLETED");
     }
 
     @Test
-    void getSellerSettlement_정산없음_400반환() throws Exception {
-        given(settlementServiceImpl.getSellerSettlementDetail(any(UUID.class), eq(settlementId)))
+    void getSellerSettlement_정산없음_BusinessException발생() {
+        given(settlementServiceImpl.getSellerSettlementDetail(sellerId, settlementId))
             .willThrow(new BusinessException(SettlementErrorCode.SETTLEMENT_BAD_REQUEST));
 
-        mockMvc.perform(get("/api/seller/settlements/{settlementId}", settlementId)
-                .header("X-User-Id", sellerId.toString()))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.code").value("SETTLEMENT_002"));
+        assertThatThrownBy(() -> settlementController.getSellerSettlement(sellerId, settlementId))
+            .isInstanceOf(BusinessException.class)
+            .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                .isEqualTo(SettlementErrorCode.SETTLEMENT_BAD_REQUEST));
     }
 
     @Test
-    void getSellerSettlement_다른판매자접근_403반환() throws Exception {
+    void getSellerSettlement_다른판매자접근_BusinessException발생() {
         UUID anotherSellerId = UUID.randomUUID();
-        given(settlementServiceImpl.getSellerSettlementDetail(eq(anotherSellerId), eq(settlementId)))
+        given(settlementServiceImpl.getSellerSettlementDetail(anotherSellerId, settlementId))
             .willThrow(new BusinessException(CommonErrorCode.ACCESS_DENIED));
 
-        mockMvc.perform(get("/api/seller/settlements/{settlementId}", settlementId)
-                .header("X-User-Id", anotherSellerId.toString()))
-            .andExpect(status().isForbidden())
-            .andExpect(jsonPath("$.code").value("COMMON_005"));
+        assertThatThrownBy(() -> settlementController.getSellerSettlement(anotherSellerId, settlementId))
+            .isInstanceOf(BusinessException.class)
+            .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                .isEqualTo(CommonErrorCode.ACCESS_DENIED));
     }
 
     // ────────────────────────────────────────────────

--- a/settlement/src/test/java/com/devticket/settlement/presentation/scheduler/SettlementSchedulerTest.java
+++ b/settlement/src/test/java/com/devticket/settlement/presentation/scheduler/SettlementSchedulerTest.java
@@ -1,0 +1,79 @@
+package com.devticket.settlement.presentation.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.devticket.settlement.application.service.SettlementService;
+import com.devticket.settlement.common.exception.BusinessException;
+import com.devticket.settlement.common.exception.CommonErrorCode;
+import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementSchedulerTest {
+
+    @Mock
+    private SettlementService settlementService;
+
+    @InjectMocks
+    private SettlementScheduler settlementScheduler;
+
+    @Test
+    void collectDailySettlementTargets_성공_어제날짜로_서비스호출() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        SettlementTargetPreviewResponse response = new SettlementTargetPreviewResponse(
+            yesterday.toString(), 3, 3, 0, "PLATFORM_FEE", "0.03", List.of()
+        );
+        given(settlementService.collectSettlementTargets(yesterday)).willReturn(response);
+
+        settlementScheduler.collectDailySettlementTargets();
+
+        verify(settlementService).collectSettlementTargets(yesterday);
+    }
+
+    @Test
+    void collectDailySettlementTargets_성공_저장및스킵_건수확인() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        SettlementTargetPreviewResponse response = new SettlementTargetPreviewResponse(
+            yesterday.toString(), 5, 3, 2, "PLATFORM_FEE", "0.03", List.of()
+        );
+        given(settlementService.collectSettlementTargets(yesterday)).willReturn(response);
+
+        settlementScheduler.collectDailySettlementTargets();
+
+        verify(settlementService).collectSettlementTargets(yesterday);
+    }
+
+    @Test
+    void collectDailySettlementTargets_서비스예외발생_예외를_밖으로_전파하지않음() {
+        given(settlementService.collectSettlementTargets(any(LocalDate.class)))
+            .willThrow(new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR));
+
+        // 예외가 스케줄러 밖으로 전파되지 않아야 함
+        assertThatNoException().isThrownBy(
+            () -> settlementScheduler.collectDailySettlementTargets()
+        );
+    }
+
+    @Test
+    void collectDailySettlementTargets_종료이벤트없음_정상완료() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        SettlementTargetPreviewResponse emptyResponse = new SettlementTargetPreviewResponse(
+            yesterday.toString(), 0, 0, 0, "PLATFORM_FEE", "0.03", List.of()
+        );
+        given(settlementService.collectSettlementTargets(yesterday)).willReturn(emptyResponse);
+
+        settlementScheduler.collectDailySettlementTargets();
+
+        verify(settlementService).collectSettlementTargets(yesterday);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #388

## 작업 내용
- 정산대상 데이터 적재 스케줄링 작업 
- 매일 00:00:01 실행

## 변경 사항
- SettlementServiceImpl - previewSettlementTarget 
  수동으로 정산대상데이터 적재작업건 collectSettlementTargets 위임받아 사용으로 수정

- SettlementServiceImpl - collectSettlementTargets
  정산대상데이터 적재기능

- SettlementScheduler : 매일 00:00:01마다 collectSettlementTargets호출 

- 테스트 코드 추가 
  - SettlementControllerTest
  - SettlementSchedulerTest

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항

