### PR TITLE
[Commerce] feat: 폴링용 order status 확인 api 추가

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -36,6 +36,7 @@ import com.devticket.commerce.order.presentation.dto.res.OrderCancelResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderDetailResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderListResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
+import com.devticket.commerce.order.presentation.dto.res.OrderStatusResponse;
 import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
 import com.devticket.commerce.ticket.domain.enums.TicketStatus;
 import com.devticket.commerce.ticket.domain.exception.TicketErrorCode;
@@ -163,6 +164,19 @@ public class OrderService implements OrderUsecase {
             .collect(Collectors.toMap(InternalEventInfoResponse::eventId, InternalEventInfoResponse::title));
 
         return OrderResponse.of(order, savedOrderItems, eventTitles);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public OrderStatusResponse getOrderStatus(UUID userId, UUID orderId) {
+        Order order = orderRepository.findByOrderId(orderId)
+            .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.getUserId().equals(userId)) {
+            throw new BusinessException(OrderErrorCode.ORDER_FORBIDDEN);
+        }
+
+        return OrderStatusResponse.of(order);
     }
 
     @Override

--- a/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
@@ -10,6 +10,7 @@ import com.devticket.commerce.order.presentation.dto.res.OrderCancelResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderDetailResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderListResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
+import com.devticket.commerce.order.presentation.dto.res.OrderStatusResponse;
 import java.util.UUID;
 
 public interface OrderUsecase {
@@ -22,6 +23,9 @@ public interface OrderUsecase {
 
     //주문 상세 조회
     OrderDetailResponse getOrderDetail(UUID userId, UUID orderId);
+
+    //주문 상태 폴링
+    OrderStatusResponse getOrderStatus(UUID userId, UUID orderId);
 
     InternalOrderInfoResponse getOrderInfo(UUID orderId);
 

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java
@@ -7,6 +7,7 @@ import com.devticket.commerce.order.presentation.dto.res.OrderCancelResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderDetailResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderListResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
+import com.devticket.commerce.order.presentation.dto.res.OrderStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
@@ -51,6 +52,16 @@ public class OrderController {
         @ModelAttribute OrderListRequest request
     ) {
         OrderListResponse response = orderUsecase.getOrderList(userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{orderId}/status")
+    @Operation(description = "주문 상태 폴링 : 재고 차감 완료 여부 확인 (CREATED → PAYMENT_PENDING)")
+    public ResponseEntity<OrderStatusResponse> getOrderStatus(
+        @RequestHeader("X-User-Id") UUID userId,
+        @PathVariable UUID orderId
+    ) {
+        OrderStatusResponse response = orderUsecase.getOrderStatus(userId, orderId);
         return ResponseEntity.ok(response);
     }
 

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderStatusResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderStatusResponse.java
@@ -1,0 +1,21 @@
+package com.devticket.commerce.order.presentation.dto.res;
+
+import com.devticket.commerce.common.enums.OrderStatus;
+import com.devticket.commerce.order.domain.model.Order;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record OrderStatusResponse(
+    UUID orderId,
+    OrderStatus status,
+    LocalDateTime updatedAt
+) {
+
+    public static OrderStatusResponse of(Order order) {
+        return new OrderStatusResponse(
+            order.getOrderId(),
+            order.getStatus(),
+            order.getUpdatedAt()
+        );
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/order/application/service/OrderServiceTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/order/application/service/OrderServiceTest.java
@@ -27,8 +27,10 @@ import com.devticket.commerce.order.domain.model.OrderItem;
 import com.devticket.commerce.order.domain.repository.OrderItemRepository;
 import com.devticket.commerce.order.domain.repository.OrderRepository;
 import com.devticket.commerce.order.infrastructure.external.client.OrderToEventClient;
+import com.devticket.commerce.order.domain.exception.OrderErrorCode;
 import com.devticket.commerce.order.presentation.dto.req.CartOrderRequest;
 import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
+import com.devticket.commerce.order.presentation.dto.res.OrderStatusResponse;
 import com.devticket.commerce.ticket.application.usecase.TicketUsecase;
 import com.devticket.commerce.ticket.domain.repository.TicketRepository;
 import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalEventInfoResponse;
@@ -37,6 +39,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -47,6 +50,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class OrderServiceTest {
@@ -483,6 +487,69 @@ class OrderServiceTest {
     }
 
     // ── ProcessStockFailed ────────────────────────────────────────────
+
+    @Nested
+    class 주문_상태_폴링 {
+
+        @Test
+        void CREATED_상태와_updatedAt을_반환한다() {
+            UUID userId = UUID.randomUUID();
+            Order order = Order.create(userId, 10_000, "hash");
+            LocalDateTime now = LocalDateTime.now();
+            ReflectionTestUtils.setField(order, "updatedAt", now);
+            UUID orderId = UUID.randomUUID();
+
+            given(orderRepository.findByOrderId(orderId)).willReturn(Optional.of(order));
+
+            OrderStatusResponse response = orderService.getOrderStatus(userId, orderId);
+
+            assertThat(response.status()).isEqualTo(OrderStatus.CREATED);
+            assertThat(response.orderId()).isEqualTo(order.getOrderId());
+            assertThat(response.updatedAt()).isEqualTo(now);
+        }
+
+        @Test
+        void PAYMENT_PENDING_상태를_반환한다() {
+            UUID userId = UUID.randomUUID();
+            Order order = Order.create(userId, 10_000, "hash");
+            order.pendingPayment();
+            UUID orderId = UUID.randomUUID();
+
+            given(orderRepository.findByOrderId(orderId)).willReturn(Optional.of(order));
+
+            OrderStatusResponse response = orderService.getOrderStatus(userId, orderId);
+
+            assertThat(response.status()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+        }
+
+        @Test
+        void 존재하지_않는_주문이면_ORDER_NOT_FOUND_예외를_던진다() {
+            UUID userId = UUID.randomUUID();
+            UUID orderId = UUID.randomUUID();
+
+            given(orderRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> orderService.getOrderStatus(userId, orderId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(OrderErrorCode.ORDER_NOT_FOUND));
+        }
+
+        @Test
+        void 다른_유저의_주문이면_ORDER_FORBIDDEN_예외를_던진다() {
+            UUID userId = UUID.randomUUID();
+            UUID otherUserId = UUID.randomUUID();
+            UUID orderId = UUID.randomUUID();
+            Order order = Order.create(otherUserId, 10_000, "hash");
+
+            given(orderRepository.findByOrderId(orderId)).willReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> orderService.getOrderStatus(userId, orderId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(OrderErrorCode.ORDER_FORBIDDEN));
+        }
+    }
 
     @Nested
     class ProcessStockFailed {


### PR DESCRIPTION
## 개요

주문 생성 후 재고 차감 완료 여부를 클라이언트가 확인할 수 있는 폴링용 API를 추가합니다.

## 배경

주문 흐름은 아래와 같습니다.

```
주문 생성 (POST /api/orders) → CREATED
  ↓ Kafka: stock.deduct 자동 발행
재고 차감 완료 → PAYMENT_PENDING
  ↓
사용자가 결제 버튼 클릭 → 결제 API 호출
```

재고 차감은 Kafka 비동기로 처리되기 때문에, 클라이언트는 주문 생성 직후 `CREATED → PAYMENT_PENDING` 전이를 알 수 없습니다.

## 변경 사항

### 신규 엔드포인트

```
GET /api/orders/{orderId}/status
Header: X-User-Id: {userId}
```

**응답**

| 필드 | 타입 | 설명 |
|---|---|---|
| `orderId` | UUID | 주문 ID |
| `status` | OrderStatus | 현재 주문 상태 |
| `updatedAt` | LocalDateTime | 마지막 상태 변경 시각 |

**폴링 중단 조건 (클라이언트 기준)**

| 상태 | 동작 |
|---|---|
| `PAYMENT_PENDING` | 폴링 중단 → 결제 버튼 활성화 |
| `FAILED` | 폴링 중단 → 재고 부족 안내 |
| `CANCELLED` | 폴링 중단 → 오류 안내 |
| `CREATED` | 계속 폴링 |

### 추가된 파일

- `OrderStatusResponse.java` — 폴링 응답 DTO

### 수정된 파일

- `OrderUsecase.java` — `getOrderStatus()` 메서드 추가
- `OrderService.java` — `getOrderStatus()` 구현 (Order 단건 조회 + 본인 검증)
- `OrderController.java` — `GET /api/orders/{orderId}/status` 엔드포인트 추가
- `OrderServiceTest.java` — 폴링 관련 단위 테스트 4개 추가

## 테스트

- `CREATED` 상태와 `updatedAt` 정확히 매핑되는지 검증
- `PAYMENT_PENDING` 상태 반환 검증
- 존재하지 않는 `orderId` → `ORDER_NOT_FOUND` 예외
- 타인의 주문 조회 → `ORDER_FORBIDDEN` 예외