### PR TITLE
[Payment] feat: PaymentCompletedEvent에 orderItems 필드 추가

### DIFF
--- a/payment/src/main/java/com/devticket/payment/common/config/JacksonConfig.java
+++ b/payment/src/main/java/com/devticket/payment/common/config/JacksonConfig.java
@@ -1,5 +1,6 @@
 package com.devticket.payment.common.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -13,6 +14,7 @@ public class JacksonConfig {
     public ObjectMapper objectMapper() {
         return new ObjectMapper()
             .registerModule(new JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 }

--- a/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
@@ -87,7 +87,12 @@ public class PaymentServiceImpl implements PaymentService {
         // WALLET 결제
         Payment payment = Payment.create(order.id(), userId, PaymentMethod.WALLET, order.totalAmount());
         paymentRepository.save(payment);
-        walletService.processWalletPayment(userId, request.orderId(), order.totalAmount());
+        List<PaymentCompletedEvent.OrderItem> walletOrderItems = order.orderItems() == null
+            ? List.of()
+            : order.orderItems().stream()
+                .map(item -> new PaymentCompletedEvent.OrderItem(item.eventId(), item.quantity()))
+                .toList();
+        walletService.processWalletPayment(userId, request.orderId(), order.totalAmount(), walletOrderItems);
         Payment updated = paymentRepository.findByOrderId(order.id())
             .orElseThrow(() -> new PaymentException(PaymentErrorCode.INVALID_PAYMENT_REQUEST));
         return PaymentReadyResponse.from(updated, request.orderId(), order.orderNumber(), order.status());
@@ -138,12 +143,19 @@ public class PaymentServiceImpl implements PaymentService {
         paymentRepository.save(payment);
 
         // payment.completed Outbox 발행 (트랜잭션 내)
+        List<PaymentCompletedEvent.OrderItem> orderItems = order.orderItems() == null
+            ? List.of()
+            : order.orderItems().stream()
+                .map(item -> new PaymentCompletedEvent.OrderItem(item.eventId(), item.quantity()))
+                .toList();
+
         PaymentCompletedEvent event = PaymentCompletedEvent.builder()
             .orderId(payment.getOrderId())
             .userId(payment.getUserId())
             .paymentId(payment.getPaymentId())
             .paymentMethod(payment.getPaymentMethod())
             .totalAmount(payment.getAmount())
+            .orderItems(orderItems)
             .timestamp(Instant.now())
             .build();
         outboxService.save(

--- a/payment/src/main/java/com/devticket/payment/wallet/application/event/PaymentCompletedEvent.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/event/PaymentCompletedEvent.java
@@ -1,18 +1,26 @@
 package com.devticket.payment.wallet.application.event;
 
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 
 @Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record PaymentCompletedEvent(
     UUID orderId,
     UUID userId,
     UUID paymentId,
     PaymentMethod paymentMethod,
     int totalAmount,
+    List<OrderItem> orderItems,
     Instant timestamp
 ) {
-
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OrderItem(
+        UUID eventId,
+        int quantity
+    ) {}
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
@@ -1,5 +1,6 @@
 package com.devticket.payment.wallet.application.service;
 
+import com.devticket.payment.wallet.application.event.PaymentCompletedEvent;
 import com.devticket.payment.wallet.presentation.dto.WalletBalanceResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmResponse;
@@ -8,6 +9,7 @@ import com.devticket.payment.wallet.presentation.dto.WalletChargeResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletTransactionListResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletWithdrawRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletWithdrawResponse;
+import java.util.List;
 import java.util.UUID;
 
 public interface WalletService {
@@ -24,7 +26,8 @@ public interface WalletService {
 
     WalletTransactionListResponse getTransactions(UUID userId, int page, int size);
 
-    void processWalletPayment(UUID userId, UUID orderId, int amount);
+    void processWalletPayment(UUID userId, UUID orderId, int amount,
+        List<PaymentCompletedEvent.OrderItem> orderItems);
 
     void restoreBalance(UUID userId, int amount, UUID refundId, UUID orderId);
 

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -306,7 +306,8 @@ public class WalletServiceImpl implements WalletService {
 
     @Override
     @Transactional
-    public void processWalletPayment(UUID userId, UUID orderId, int amount) {
+    public void processWalletPayment(UUID userId, UUID orderId, int amount,
+        List<PaymentCompletedEvent.OrderItem> orderItems) {
         String transactionKey = "USE_" + orderId;
 
         //토스 paymentKey = WalletTransaction의 transactionKey
@@ -344,6 +345,7 @@ public class WalletServiceImpl implements WalletService {
             .paymentId(payment.getPaymentId())
             .paymentMethod(PaymentMethod.WALLET)
             .totalAmount(amount)
+            .orderItems(orderItems == null ? List.of() : orderItems)
             .timestamp(Instant.now())
             .build();
         outboxService.save(

--- a/payment/src/test/java/com/devticket/payment/application/service/PaymentServiceImplTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/PaymentServiceImplTest.java
@@ -3,6 +3,7 @@ package com.devticket.payment.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
@@ -27,6 +28,7 @@ import com.devticket.payment.payment.presentation.dto.PaymentFailRequest;
 import com.devticket.payment.payment.presentation.dto.PaymentFailResponse;
 import com.devticket.payment.payment.presentation.dto.PaymentReadyRequest;
 import com.devticket.payment.payment.presentation.dto.PaymentReadyResponse;
+import com.devticket.payment.wallet.application.event.PaymentCompletedEvent;
 import com.devticket.payment.wallet.application.service.WalletService;
 import java.util.List;
 import java.time.LocalDateTime;
@@ -37,6 +39,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -104,7 +107,7 @@ public class PaymentServiceImplTest {
         @DisplayName("PG 결제 준비 성공 — READY 상태 반환")
         void PG_결제_준비_성공() {
             // given
-            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG);
+            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG, null);
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.save(any(Payment.class)))
@@ -126,7 +129,7 @@ public class PaymentServiceImplTest {
         @DisplayName("다른 사용자의 주문 — 예외")
         void 다른_사용자의_주문() {
             // given
-            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG);
+            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG, null);
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
 
@@ -141,7 +144,7 @@ public class PaymentServiceImplTest {
         @DisplayName("주문 상태가 PAYMENT_PENDING이 아닌 경우 — 예외")
         void 주문_상태가_결제_대기가_아닌_경우() {
             // given
-            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG);
+            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.PG, null);
             InternalOrderInfoResponse paidOrder = new InternalOrderInfoResponse(
                 ORDER_ID, USER_ID, "ORD-001", 130000, "PAID",
                 LocalDateTime.of(2025, 8, 15, 14, 30).toString(),
@@ -161,21 +164,67 @@ public class PaymentServiceImplTest {
         @DisplayName("예치금 결제 준비 성공 — WalletService로 위임")
         void 예치금_결제_준비_성공() {
             // given
-            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.WALLET);
+            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.WALLET, null);
             Payment savedPayment = createReadyPayment();
             savedPayment.approve("WALLET-" + savedPayment.getPaymentId());
 
             given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderInfo);
             given(paymentRepository.save(any(Payment.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
-            given(paymentRepository.findByOrderId(orderInfo.id())).willReturn(Optional.of(savedPayment));
+            // 첫 호출(멱등성 가드): empty → 통과, 두 번째 호출(wallet 처리 후 재조회): SUCCESS Payment 반환
+            given(paymentRepository.findByOrderId(orderInfo.id()))
+                .willReturn(Optional.empty(), Optional.of(savedPayment));
 
             // when
             PaymentReadyResponse response = paymentService.readyPayment(USER_ID, request);
 
             // then
-            verify(walletService).processWalletPayment(USER_ID, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+            verify(walletService).processWalletPayment(eq(USER_ID), eq(EXTERNAL_ORDER_ID), eq(orderInfo.totalAmount()), any());
             assertThat(response.paymentStatus()).isEqualTo(PaymentStatus.SUCCESS);
+        }
+
+        @Test
+        @DisplayName("예치금 결제 준비 — order.orderItems가 WalletService로 매핑되어 전달된다")
+        void 예치금_결제_준비_orderItems_전달() {
+            // given
+            UUID eventId1 = UUID.randomUUID();
+            UUID eventId2 = UUID.randomUUID();
+            InternalOrderInfoResponse orderWithItems = new InternalOrderInfoResponse(
+                ORDER_ID, USER_ID, "ORD-001", orderInfo.totalAmount(), "PAYMENT_PENDING",
+                LocalDateTime.of(2025, 8, 15, 14, 30).toString(),
+                List.of(
+                    new InternalOrderInfoResponse.OrderItem(eventId1, 4),
+                    new InternalOrderInfoResponse.OrderItem(eventId2, 1)
+                )
+            );
+            PaymentReadyRequest request = new PaymentReadyRequest(EXTERNAL_ORDER_ID, PaymentMethod.WALLET, null);
+            Payment savedPayment = createReadyPayment();
+            savedPayment.approve("WALLET-" + savedPayment.getPaymentId());
+
+            given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderWithItems);
+            given(paymentRepository.save(any(Payment.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+            given(paymentRepository.findByOrderId(orderWithItems.id()))
+                .willReturn(Optional.empty(), Optional.of(savedPayment));
+
+            // when
+            paymentService.readyPayment(USER_ID, request);
+
+            // then: WalletService.processWalletPayment에 전달된 orderItems 검증
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<PaymentCompletedEvent.OrderItem>> itemsCaptor =
+                ArgumentCaptor.forClass(List.class);
+            verify(walletService).processWalletPayment(
+                eq(USER_ID), eq(EXTERNAL_ORDER_ID), eq(orderWithItems.totalAmount()),
+                itemsCaptor.capture()
+            );
+
+            List<PaymentCompletedEvent.OrderItem> captured = itemsCaptor.getValue();
+            assertThat(captured).hasSize(2);
+            assertThat(captured.get(0).eventId()).isEqualTo(eventId1);
+            assertThat(captured.get(0).quantity()).isEqualTo(4);
+            assertThat(captured.get(1).eventId()).isEqualTo(eventId2);
+            assertThat(captured.get(1).quantity()).isEqualTo(1);
         }
     }
 
@@ -333,6 +382,121 @@ public class PaymentServiceImplTest {
             // then
             assertThat(payment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
             verify(outboxService).save(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("confirmPgPayment → PaymentCompletedEvent 에 orderItems가 포함된다")
+        void confirmPgPayment_orderItems_Outbox_전달() {
+            // given
+            Payment payment = createReadyPayment();
+            UUID eventId1 = UUID.randomUUID();
+            UUID eventId2 = UUID.randomUUID();
+            InternalOrderInfoResponse orderWithItems = new InternalOrderInfoResponse(
+                ORDER_ID, USER_ID, "ORD-001", orderInfo.totalAmount(), "PAYMENT_PENDING",
+                LocalDateTime.of(2025, 8, 15, 14, 30).toString(),
+                List.of(
+                    new InternalOrderInfoResponse.OrderItem(eventId1, 2),
+                    new InternalOrderInfoResponse.OrderItem(eventId2, 1)
+                )
+            );
+            PaymentConfirmRequest request = new PaymentConfirmRequest(
+                PAYMENT_KEY, PAYMENT_ID, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+
+            given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderWithItems);
+            given(paymentRepository.findByOrderId(orderWithItems.id())).willReturn(Optional.of(payment));
+            given(pgPaymentClient.confirm(any())).willReturn(createPgConfirmResult());
+            given(paymentRepository.save(any(Payment.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            paymentService.confirmPgPayment(USER_ID, request);
+
+            // then: outboxService.save에 전달된 PaymentCompletedEvent 페이로드 검증
+            ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+            verify(outboxService).save(any(), any(), any(), any(), payloadCaptor.capture());
+
+            Object captured = payloadCaptor.getValue();
+            assertThat(captured).isInstanceOf(PaymentCompletedEvent.class);
+            PaymentCompletedEvent event = (PaymentCompletedEvent) captured;
+            assertThat(event.orderItems()).hasSize(2);
+            assertThat(event.orderItems().get(0).eventId()).isEqualTo(eventId1);
+            assertThat(event.orderItems().get(0).quantity()).isEqualTo(2);
+            assertThat(event.orderItems().get(1).eventId()).isEqualTo(eventId2);
+            assertThat(event.orderItems().get(1).quantity()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("WALLET_PG 결제 승인 시에도 orderItems가 PaymentCompletedEvent에 포함된다")
+        void WALLET_PG_confirmPgPayment_orderItems_포함() {
+            // given: WALLET_PG 결제 — totalAmount=100,000, walletAmount=30,000, pgAmount=70,000
+            int totalAmount = 100_000;
+            int walletAmount = 30_000;
+            int pgAmount = 70_000;
+            Payment walletPgPayment = Payment.create(
+                ORDER_ID, USER_ID, PaymentMethod.WALLET_PG, totalAmount, walletAmount, pgAmount
+            );
+
+            UUID eventId = UUID.randomUUID();
+            InternalOrderInfoResponse orderWithItems = new InternalOrderInfoResponse(
+                ORDER_ID, USER_ID, "ORD-WPG-001", totalAmount, "PAYMENT_PENDING",
+                LocalDateTime.of(2025, 8, 15, 14, 30).toString(),
+                List.of(new InternalOrderInfoResponse.OrderItem(eventId, 5))
+            );
+            // WALLET_PG: request.amount()는 pgAmount와 비교됨
+            PaymentConfirmRequest request = new PaymentConfirmRequest(
+                PAYMENT_KEY, PAYMENT_ID, EXTERNAL_ORDER_ID, pgAmount);
+
+            given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderWithItems);
+            given(paymentRepository.findByOrderId(orderWithItems.id())).willReturn(Optional.of(walletPgPayment));
+            given(pgPaymentClient.confirm(any())).willReturn(new PgPaymentConfirmResult(
+                PAYMENT_KEY, EXTERNAL_ORDER_ID.toString(), "카드", "DONE", pgAmount, APPROVED_AT
+            ));
+            given(paymentRepository.save(any(Payment.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            paymentService.confirmPgPayment(USER_ID, request);
+
+            // then: totalAmount는 payment.getAmount()(총액), orderItems는 그대로 전달
+            ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+            verify(outboxService).save(any(), any(), any(), any(), payloadCaptor.capture());
+
+            PaymentCompletedEvent event = (PaymentCompletedEvent) payloadCaptor.getValue();
+            assertThat(event.paymentMethod()).isEqualTo(PaymentMethod.WALLET_PG);
+            assertThat(event.totalAmount()).isEqualTo(totalAmount);
+            assertThat(event.orderItems()).hasSize(1);
+            assertThat(event.orderItems().get(0).eventId()).isEqualTo(eventId);
+            assertThat(event.orderItems().get(0).quantity()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("order.orderItems가 null이면 빈 리스트로 매핑된다")
+        void confirmPgPayment_orderItems_null_빈_리스트() {
+            // given
+            Payment payment = createReadyPayment();
+            InternalOrderInfoResponse orderWithNullItems = new InternalOrderInfoResponse(
+                ORDER_ID, USER_ID, "ORD-001", orderInfo.totalAmount(), "PAYMENT_PENDING",
+                LocalDateTime.of(2025, 8, 15, 14, 30).toString(),
+                null
+            );
+            PaymentConfirmRequest request = new PaymentConfirmRequest(
+                PAYMENT_KEY, PAYMENT_ID, EXTERNAL_ORDER_ID, orderInfo.totalAmount());
+
+            given(commerceInternalClient.getOrderInfo(EXTERNAL_ORDER_ID)).willReturn(orderWithNullItems);
+            given(paymentRepository.findByOrderId(orderWithNullItems.id())).willReturn(Optional.of(payment));
+            given(pgPaymentClient.confirm(any())).willReturn(createPgConfirmResult());
+            given(paymentRepository.save(any(Payment.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            paymentService.confirmPgPayment(USER_ID, request);
+
+            // then
+            ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+            verify(outboxService).save(any(), any(), any(), any(), payloadCaptor.capture());
+
+            PaymentCompletedEvent event = (PaymentCompletedEvent) payloadCaptor.getValue();
+            assertThat(event.orderItems()).isNotNull().isEmpty();
         }
     }
 

--- a/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
@@ -20,6 +20,7 @@ import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
 import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
+import com.devticket.payment.wallet.application.event.PaymentCompletedEvent;
 import com.devticket.payment.wallet.application.service.WalletServiceImpl;
 import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentStatusResponse;
 import com.devticket.payment.wallet.domain.enums.WalletChargeStatus;
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -297,7 +299,7 @@ class WalletServiceTest {
             given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.of(payment));
 
             // when
-            walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000);
+            walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000, List.of());
 
             // then
             then(walletRepository).should(times(1)).useBalanceAtomic(USER_ID, 50_000);
@@ -310,7 +312,7 @@ class WalletServiceTest {
             given(walletTransactionRepository.existsByTransactionKey("USE_" + ORDER_ID)).willReturn(true);
 
             // when
-            walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000);
+            walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000, List.of());
 
             // then: atomic update 및 이벤트 발행 없음
             then(walletRepository).should(never()).useBalanceAtomic(any(), anyInt());
@@ -325,7 +327,7 @@ class WalletServiceTest {
             given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(walletWithBalance(10_000)));
 
             // when & then
-            assertThatThrownBy(() -> walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000))
+            assertThatThrownBy(() -> walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000, List.of()))
                 .isInstanceOf(WalletException.class)
                 .extracting(e -> ((WalletException) e).getErrorCode())
                 .isEqualTo(WalletErrorCode.INSUFFICIENT_BALANCE);
@@ -341,10 +343,79 @@ class WalletServiceTest {
             given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000))
+            assertThatThrownBy(() -> walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000, List.of()))
                 .isInstanceOf(WalletException.class)
                 .extracting(e -> ((WalletException) e).getErrorCode())
                 .isEqualTo(WalletErrorCode.WALLET_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("orderItems가 PaymentCompletedEvent에 포함되어 Outbox에 저장된다")
+        void orderItems가_Outbox에_전달된다() {
+            // given
+            Wallet wallet = walletWithBalance(50_000);
+            Payment payment = paymentOf(ORDER_ID, 50_000, PaymentMethod.WALLET, PaymentStatus.READY);
+
+            UUID eventId1 = UUID.randomUUID();
+            UUID eventId2 = UUID.randomUUID();
+            List<PaymentCompletedEvent.OrderItem> items = List.of(
+                new PaymentCompletedEvent.OrderItem(eventId1, 2),
+                new PaymentCompletedEvent.OrderItem(eventId2, 1)
+            );
+
+            given(walletTransactionRepository.existsByTransactionKey("USE_" + ORDER_ID)).willReturn(false);
+            given(walletRepository.useBalanceAtomic(USER_ID, 50_000)).willReturn(1);
+            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(wallet));
+            given(walletTransactionRepository.save(any())).willReturn(
+                WalletTransaction.createUse(1L, USER_ID, "USE_" + ORDER_ID, 50_000, 50_000, ORDER_ID));
+            given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.of(payment));
+
+            // when
+            walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000, items);
+
+            // then: outboxService.save에 전달된 payload 검증
+            ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+            then(outboxService).should(times(1)).save(
+                anyString(), eq(KafkaTopics.PAYMENT_COMPLETED),
+                eq(KafkaTopics.PAYMENT_COMPLETED), anyString(), payloadCaptor.capture()
+            );
+
+            Object captured = payloadCaptor.getValue();
+            assertThat(captured).isInstanceOf(PaymentCompletedEvent.class);
+            PaymentCompletedEvent event = (PaymentCompletedEvent) captured;
+            assertThat(event.orderItems()).hasSize(2);
+            assertThat(event.orderItems().get(0).eventId()).isEqualTo(eventId1);
+            assertThat(event.orderItems().get(0).quantity()).isEqualTo(2);
+            assertThat(event.orderItems().get(1).eventId()).isEqualTo(eventId2);
+            assertThat(event.orderItems().get(1).quantity()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("orderItems가 null이면 빈 리스트로 저장된다")
+        void null_orderItems는_빈_리스트로_저장() {
+            // given
+            Wallet wallet = walletWithBalance(50_000);
+            Payment payment = paymentOf(ORDER_ID, 50_000, PaymentMethod.WALLET, PaymentStatus.READY);
+
+            given(walletTransactionRepository.existsByTransactionKey("USE_" + ORDER_ID)).willReturn(false);
+            given(walletRepository.useBalanceAtomic(USER_ID, 50_000)).willReturn(1);
+            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(wallet));
+            given(walletTransactionRepository.save(any())).willReturn(
+                WalletTransaction.createUse(1L, USER_ID, "USE_" + ORDER_ID, 50_000, 50_000, ORDER_ID));
+            given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.of(payment));
+
+            // when
+            walletService.processWalletPayment(USER_ID, ORDER_ID, 50_000, null);
+
+            // then
+            ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+            then(outboxService).should(times(1)).save(
+                anyString(), eq(KafkaTopics.PAYMENT_COMPLETED),
+                eq(KafkaTopics.PAYMENT_COMPLETED), anyString(), payloadCaptor.capture()
+            );
+
+            PaymentCompletedEvent event = (PaymentCompletedEvent) payloadCaptor.getValue();
+            assertThat(event.orderItems()).isNotNull().isEmpty();
         }
     }
 

--- a/payment/src/test/java/com/devticket/payment/integration/PaymentKafkaIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/integration/PaymentKafkaIntegrationTest.java
@@ -96,6 +96,65 @@ class PaymentKafkaIntegrationTest {
     class OutboxToKafkaTest {
 
         @Test
+        @DisplayName("payment.completed Outbox orderItems → Kafka payload에 보존")
+        void payment_completed_orderItems_preserved_to_kafka() throws Exception {
+            // given: orderItems 포함 payload → Outbox INSERT
+            UUID orderId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            UUID eventId1 = UUID.randomUUID();
+            UUID eventId2 = UUID.randomUUID();
+
+            Payment payment = Payment.create(orderId, userId, PaymentMethod.PG, 80_000);
+            payment.approve("test-key-orderItems");
+            paymentRepository.save(payment);
+
+            String payload = objectMapper.writeValueAsString(new java.util.LinkedHashMap<>() {{
+                put("orderId", orderId.toString());
+                put("userId", userId.toString());
+                put("paymentId", payment.getPaymentId().toString());
+                put("paymentMethod", "PG");
+                put("totalAmount", 80_000);
+                put("orderItems", List.of(
+                    new java.util.LinkedHashMap<>() {{
+                        put("eventId", eventId1.toString());
+                        put("quantity", 2);
+                    }},
+                    new java.util.LinkedHashMap<>() {{
+                        put("eventId", eventId2.toString());
+                        put("quantity", 3);
+                    }}
+                ));
+                put("timestamp", java.time.Instant.now().toString());
+            }});
+
+            Outbox outbox = Outbox.create(
+                payment.getPaymentId().toString(),
+                "payment.completed",
+                "payment.completed",
+                orderId.toString(),
+                payload
+            );
+            outboxRepository.save(outbox);
+
+            // then: Kafka payload에 orderItems 배열과 각 eventId/quantity 보존
+            await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+                assertThat(completedRecords).anyMatch(r -> {
+                    try {
+                        JsonNode node = objectMapper.readTree(r.value());
+                        JsonNode p = objectMapper.readTree(node.get("payload").asText());
+                        if (!orderId.toString().equals(p.get("orderId").asText())) return false;
+                        JsonNode items = p.get("orderItems");
+                        if (items == null || !items.isArray() || items.size() != 2) return false;
+                        return eventId1.toString().equals(items.get(0).get("eventId").asText())
+                            && items.get(0).get("quantity").asInt() == 2
+                            && eventId2.toString().equals(items.get(1).get("eventId").asText())
+                            && items.get(1).get("quantity").asInt() == 3;
+                    } catch (Exception e) { return false; }
+                });
+            });
+        }
+
+        @Test
         @DisplayName("payment.completed Outbox 레코드 → 스케줄러가 Kafka로 발행")
         void payment_completed_outbox_to_kafka() throws Exception {
             // given: Payment 생성 + 승인 + Outbox 직접 INSERT (Commerce/PG 우회)
@@ -203,7 +262,7 @@ class PaymentKafkaIntegrationTest {
             paymentRepository.save(payment);
 
             // when: WalletService.processWalletPayment 호출 (Commerce 우회, 직접 호출)
-            walletService.processWalletPayment(userId, orderId, 30_000);
+            walletService.processWalletPayment(userId, orderId, 30_000, List.of());
 
             // then: 잔액 차감 확인
             Wallet updated = walletRepository.findByUserId(userId).orElseThrow();

--- a/payment/src/test/java/com/devticket/payment/wallet/application/event/PaymentCompletedEventSerializationTest.java
+++ b/payment/src/test/java/com/devticket/payment/wallet/application/event/PaymentCompletedEventSerializationTest.java
@@ -1,0 +1,114 @@
+package com.devticket.payment.wallet.application.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.devticket.payment.payment.domain.enums.PaymentMethod;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PaymentCompletedEventSerializationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule());
+
+    @Test
+    @DisplayName("orderItems가 JSON payload에 직렬화된다")
+    void orderItems_직렬화_포함() throws Exception {
+        UUID eventId1 = UUID.randomUUID();
+        UUID eventId2 = UUID.randomUUID();
+        PaymentCompletedEvent event = PaymentCompletedEvent.builder()
+            .orderId(UUID.randomUUID())
+            .userId(UUID.randomUUID())
+            .paymentId(UUID.randomUUID())
+            .paymentMethod(PaymentMethod.PG)
+            .totalAmount(50_000)
+            .orderItems(List.of(
+                new PaymentCompletedEvent.OrderItem(eventId1, 2),
+                new PaymentCompletedEvent.OrderItem(eventId2, 1)
+            ))
+            .timestamp(Instant.now())
+            .build();
+
+        String json = objectMapper.writeValueAsString(event);
+        JsonNode node = objectMapper.readTree(json);
+
+        assertThat(node.has("orderItems")).isTrue();
+        JsonNode items = node.get("orderItems");
+        assertThat(items.isArray()).isTrue();
+        assertThat(items).hasSize(2);
+        assertThat(items.get(0).get("eventId").asText()).isEqualTo(eventId1.toString());
+        assertThat(items.get(0).get("quantity").asInt()).isEqualTo(2);
+        assertThat(items.get(1).get("eventId").asText()).isEqualTo(eventId2.toString());
+        assertThat(items.get(1).get("quantity").asInt()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("orderItems가 빈 리스트여도 직렬화 가능")
+    void 빈_orderItems_직렬화() throws Exception {
+        PaymentCompletedEvent event = PaymentCompletedEvent.builder()
+            .orderId(UUID.randomUUID())
+            .userId(UUID.randomUUID())
+            .paymentId(UUID.randomUUID())
+            .paymentMethod(PaymentMethod.WALLET)
+            .totalAmount(10_000)
+            .orderItems(List.of())
+            .timestamp(Instant.now())
+            .build();
+
+        String json = objectMapper.writeValueAsString(event);
+        JsonNode node = objectMapper.readTree(json);
+
+        assertThat(node.has("orderItems")).isTrue();
+        assertThat(node.get("orderItems").isArray()).isTrue();
+        assertThat(node.get("orderItems")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("역직렬화 후 OrderItem 값이 보존된다")
+    void 역직렬화_orderItems_보존() throws Exception {
+        UUID eventId = UUID.randomUUID();
+        PaymentCompletedEvent original = PaymentCompletedEvent.builder()
+            .orderId(UUID.randomUUID())
+            .userId(UUID.randomUUID())
+            .paymentId(UUID.randomUUID())
+            .paymentMethod(PaymentMethod.WALLET_PG)
+            .totalAmount(70_000)
+            .orderItems(List.of(new PaymentCompletedEvent.OrderItem(eventId, 3)))
+            .timestamp(Instant.now())
+            .build();
+
+        String json = objectMapper.writeValueAsString(original);
+        PaymentCompletedEvent deserialized = objectMapper.readValue(json, PaymentCompletedEvent.class);
+
+        assertThat(deserialized.orderItems()).hasSize(1);
+        assertThat(deserialized.orderItems().get(0).eventId()).isEqualTo(eventId);
+        assertThat(deserialized.orderItems().get(0).quantity()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("알 수 없는 필드가 있어도 역직렬화 성공 (하위 호환성)")
+    void 알_수_없는_필드_무시() throws Exception {
+        String json = "{"
+            + "\"orderId\":\"" + UUID.randomUUID() + "\","
+            + "\"userId\":\"" + UUID.randomUUID() + "\","
+            + "\"paymentId\":\"" + UUID.randomUUID() + "\","
+            + "\"paymentMethod\":\"PG\","
+            + "\"totalAmount\":10000,"
+            + "\"orderItems\":[],"
+            + "\"timestamp\":\"2025-01-01T00:00:00Z\","
+            + "\"unknownFutureField\":\"some-value\","
+            + "\"anotherNewField\":123"
+            + "}";
+
+        PaymentCompletedEvent event = objectMapper.readValue(json, PaymentCompletedEvent.class);
+
+        assertThat(event.totalAmount()).isEqualTo(10000);
+        assertThat(event.orderItems()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- `PaymentCompletedEvent`에 `List<OrderItem> orderItems` 필드 추가 (nested `OrderItem(UUID eventId, int quantity)`)
- Log 서비스가 `payment.completed` 토픽을 직접 구독하여 `log.action_log`에 PURCHASE 레코드를 INSERT하는 정책(actionLog.md §2 #12) 지원
- 모든 Payment Producer 경로(PG/WALLET/WALLET_PG)에서 `order.orderItems()`를 이벤트에 매핑

## Why
Log 서비스가 PURCHASE 레코드를 작성하려면 event별 수량 정보가 필요한데, 기존 payload에는 `eventId`/`quantity`가 없어 매핑 불가. 본 변경이 PURCHASE 수집 체인의 블로커.

## Changes

### 이벤트 DTO
- `PaymentCompletedEvent`: `List<OrderItem> orderItems` 필드 + nested record 정의
- `@JsonIgnoreProperties(ignoreUnknown=true)` 적용 — 하위 Consumer DTO 복사본 동기화 지연 시 DLT 적재 방지
- `JacksonConfig`: `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES=false` 글로벌 설정

### 비즈니스 로직
- `PaymentServiceImpl.confirmPgPayment()`: `order.orderItems()` → `PaymentCompletedEvent.OrderItem` 매핑
- `PaymentServiceImpl.readyPayment()` WALLET 분기: orderItems를 `WalletService.processWalletPayment`로 전달
- `WalletService.processWalletPayment()`: 시그니처에 `List<PaymentCompletedEvent.OrderItem>` 파라미터 추가 (null 방어)
- `WalletPgTimeoutHandler`: `PaymentFailedEvent`만 발행하여 수정 불필요 확인

### 테스트 (총 +11 케이스, 모두 통과)
- 신규 `PaymentCompletedEventSerializationTest` (4): 직렬화 / 빈 리스트 / 역직렬화 / unknown 필드 하위호환
- `PaymentServiceImplTest.ConfirmPgPaymentTest` +3: PG · WALLET_PG · null orderItems 매핑
- `PaymentServiceImplTest.ReadyPaymentTest` +1: WALLET 분기 orderItems 전달 ArgumentCaptor 검증 (+ 기존 실패 테스트 `예치금_결제_준비_성공` mock 셋업 수정)
- `WalletServiceTest.ProcessWalletPayment` +2: Outbox payload orderItems 전달, null 방어
- `PaymentKafkaIntegrationTest` +1: Outbox → Scheduler → EmbeddedKafka E2E orderItems 보존

## ⚠️ 배포 순서 전제
**Commerce / Event 모듈의 `PaymentCompletedEvent` DTO 복사본 동기화가 본 PR 배포 이전에 선배포되어야 함.**
역순 배포 시 기존 Consumer 역직렬화 실패 → DLT 적재 위험. 하위 Consumer 측도 `FAIL_ON_UNKNOWN_PROPERTIES=false` 또는 `@JsonIgnoreProperties(ignoreUnknown=true)` 적용 확인 필수.

## Blocks
- [Log] \`feat: payment.completed 추가 구독 + PURCHASE 직접 INSERT\`

## Follow-up (별도 이슈 예정)
- [Commerce] \`PaymentCompletedEvent\` DTO 복사본에 \`orderItems\` 필드 동기화
- [Event] 동일

## Test plan
- [x] \`./gradlew test --tests "*PaymentServiceImplTest" --tests "*WalletServiceTest" --tests "*PaymentCompletedEventSerializationTest"\` — 단위 39/39 통과
- [x] \`./gradlew test --tests "*PaymentKafkaIntegrationTest"\` — 통합 9/9 통과 (EmbeddedKafka E2E 포함)
- [ ] 스테이징: Commerce DTO 동기화 선배포 확인 후 머지
- [ ] 스테이징: PG + WALLET + WALLET_PG 각각 결제 완료 → Kafka payload \`orderItems\` 검증
- [ ] 스테이징: 후속 Log 서비스 이슈 머지 후 PURCHASE INSERT 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)