### PR TITLE
[Event] fix : 종료이벤트 목록조회 API의 응답데이터에 이벤트개최일자 데이터 추가

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventInternalService.java
+++ b/event/src/main/java/com/devticket/event/application/EventInternalService.java
@@ -302,7 +302,7 @@ public class EventInternalService {
             eventRepository.findAllByEventDate(startOfDay, startOfNextDay)
                 .stream()
                 .map(e -> new InternalEndedEventsResponse.EndedEventItem(
-                    e.getId(), e.getEventId(), e.getSellerId()
+                    e.getId(), e.getEventId(), e.getSellerId(), e.getEventDateTime()
                 ))
                 .toList();
 

--- a/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalEndedEventsResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalEndedEventsResponse.java
@@ -1,5 +1,6 @@
 package com.devticket.event.presentation.dto.internal;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -10,6 +11,7 @@ public record InternalEndedEventsResponse(
     public record EndedEventItem(
         Long id,
         UUID eventId,
-        UUID sellerId
+        UUID sellerId,
+        LocalDateTime eventDateTime
     ) {}
 }


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- Settlement에서 호출하는 종료된 이벤트 목록 조회요청 API의 응답데이터에 eventDateTime추가 

## 변경 사항
- EventInternalService.getEndedEventsByDate :  eventDateTime필드 추가
- InternalEndedEventsResponse :  eventDateTime필드 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항