### PR TITLE
[Admin] refactor: TechStack CRUD Member Service에서 Admin Service로 이관

### DIFF
--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -45,6 +45,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
+
+    // WebFlux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // ES
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 }
 
 tasks.named('test') {

--- a/admin/src/main/java/com/devticket/admin/application/service/TechStackService.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/TechStackService.java
@@ -1,0 +1,24 @@
+package com.devticket.admin.application.service;
+
+import com.devticket.admin.presentation.dto.req.CreateTechStackRequest;
+import com.devticket.admin.presentation.dto.req.DeleteTechStackRequest;
+import com.devticket.admin.presentation.dto.req.UpdateTechStackRequest;
+import com.devticket.admin.presentation.dto.res.CreateTechStackResponse;
+import com.devticket.admin.presentation.dto.res.DeleteTechStackResponse;
+import com.devticket.admin.presentation.dto.res.GetTechStackResponse;
+import com.devticket.admin.presentation.dto.res.UpdateTechStackResponse;
+import java.util.List;
+
+public interface TechStackService {
+
+    List<GetTechStackResponse> getTechStacks();
+
+    CreateTechStackResponse createTechStack(CreateTechStackRequest request);
+
+    UpdateTechStackResponse updateTechStack(Long id, UpdateTechStackRequest request);
+
+    DeleteTechStackResponse deleteTechStack(Long id);
+
+
+
+}

--- a/admin/src/main/java/com/devticket/admin/application/service/TechStackServiceImpl.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/TechStackServiceImpl.java
@@ -1,0 +1,69 @@
+package com.devticket.admin.application.service;
+
+import com.devticket.admin.domain.model.TechStack;
+import com.devticket.admin.domain.repository.TechStackRepository;
+import com.devticket.admin.presentation.dto.req.CreateTechStackRequest;
+import com.devticket.admin.presentation.dto.req.DeleteTechStackRequest;
+import com.devticket.admin.presentation.dto.req.UpdateTechStackRequest;
+import com.devticket.admin.presentation.dto.res.CreateTechStackResponse;
+import com.devticket.admin.presentation.dto.res.DeleteTechStackResponse;
+import com.devticket.admin.presentation.dto.res.GetTechStackResponse;
+import com.devticket.admin.presentation.dto.res.UpdateTechStackResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class TechStackServiceImpl implements TechStackService{
+
+    private final TechStackRepository techStackRepository;
+
+    // =============== 1. TechStack 조회 =============== //
+    @Transactional(readOnly = true)
+    public List<GetTechStackResponse> getTechStacks() {
+        return techStackRepository.getTechStacks().stream()
+            .map(GetTechStackResponse::from)
+            .toList();
+    }
+
+    // =============== 2. TechStack 생성 =============== //
+    @Transactional
+    public CreateTechStackResponse createTechStack(CreateTechStackRequest request) {
+        String name = request.name();
+
+        if (techStackRepository.existsByName(name)) {
+            throw new IllegalArgumentException("이미 존재하는 TechStack: " + name);
+        }
+
+        TechStack saved = techStackRepository.save(TechStack.of(null, name));
+
+        return CreateTechStackResponse.from(saved);
+    }
+
+    // =============== 3. TechStack 수정 =============== //
+    @Transactional
+    public UpdateTechStackResponse updateTechStack(Long id, UpdateTechStackRequest request) {
+        TechStack techStack = techStackRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 TechStack: " + id));
+
+        techStack.updateName(request.name());
+
+        return UpdateTechStackResponse.from(techStack);
+    }
+
+    // =============== 4. TechStack 삭제 =============== //
+    @Transactional
+    public DeleteTechStackResponse deleteTechStack(Long id) {
+        techStackRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 TechStack: " + id));
+
+        techStackRepository.deleteById(id);
+
+        return DeleteTechStackResponse.of(id);
+    }
+
+}

--- a/admin/src/main/java/com/devticket/admin/domain/model/AdminActionHistory.java
+++ b/admin/src/main/java/com/devticket/admin/domain/model/AdminActionHistory.java
@@ -36,7 +36,7 @@ public class AdminActionHistory {
     @Column(name = "target_type", nullable = false)
     private AdminTargetType targetType;
 
-    @Column(name = "target_id", nullable = false)
+    @Column(name = "target_id", nullable = true)
     private UUID targetId;
 
     @Enumerated(EnumType.STRING)

--- a/admin/src/main/java/com/devticket/admin/domain/model/TechStack.java
+++ b/admin/src/main/java/com/devticket/admin/domain/model/TechStack.java
@@ -1,0 +1,49 @@
+package com.devticket.admin.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tech_stack", schema = "admin")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TechStack {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tech_stack_id", unique = true, nullable = false, updatable = false)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public static TechStack of(Long id, String name) {
+        TechStack ts = new TechStack();
+        ts.id = id;
+        ts.name = name;
+        ts.createdAt = LocalDateTime.now();
+        return ts;
+    }
+
+    // =========== 비즈니스 로직 =========== //
+    // 1. tech_Stack 수정
+    public void updateName(String name) {
+        this.name = name;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/admin/src/main/java/com/devticket/admin/domain/model/TechStackDocument.java
+++ b/admin/src/main/java/com/devticket/admin/domain/model/TechStackDocument.java
@@ -1,0 +1,24 @@
+package com.devticket.admin.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Document(indexName = "techstack-index", createIndex = false)
+public class TechStackDocument {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    private float[] embedding;
+
+}

--- a/admin/src/main/java/com/devticket/admin/domain/model/TechStackDocument.java
+++ b/admin/src/main/java/com/devticket/admin/domain/model/TechStackDocument.java
@@ -11,7 +11,7 @@ import org.springframework.data.elasticsearch.annotations.Document;
 @AllArgsConstructor
 @Builder
 @Getter
-@Document(indexName = "techstack-index", createIndex = false)
+@Document(indexName = "techstack", createIndex = false)
 public class TechStackDocument {
 
     @Id

--- a/admin/src/main/java/com/devticket/admin/domain/repository/TechStackRepository.java
+++ b/admin/src/main/java/com/devticket/admin/domain/repository/TechStackRepository.java
@@ -1,0 +1,21 @@
+package com.devticket.admin.domain.repository;
+
+import com.devticket.admin.domain.model.TechStack;
+import java.util.List;
+import java.util.Optional;
+
+public interface TechStackRepository {
+
+    List<TechStack> getTechStacks();
+
+    TechStack save(TechStack techStack);
+
+    Optional<TechStack> findById(Long id);
+
+    List<TechStack> findByIdIn(List<Long> ids);
+
+    boolean existsByName(String name);
+
+    void deleteById(Long id);
+
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/config/ElasticsearchConfig.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/config/ElasticsearchConfig.java
@@ -1,0 +1,18 @@
+package com.devticket.admin.infrastructure.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+
+    @Value("${spring.elasticsearch.uris}")
+    private String uri;
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+            .connectedTo(uri.replace("https://", "").replace("http://", ""))
+            .build();
+    }
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/config/ElasticsearchIndexInitializer.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/config/ElasticsearchIndexInitializer.java
@@ -18,7 +18,7 @@ public class ElasticsearchIndexInitializer {
 
     @PostConstruct
     public void init(){
-        createIndexIfNotExists("techstack-index", "elasticsearch/techstack-index-mapping.json");
+        createIndexIfNotExists("techstack", "elasticsearch/techstack-index-mapping.json");
     }
 
     private void createIndexIfNotExists(String indexName, String mappingFilePath){

--- a/admin/src/main/java/com/devticket/admin/infrastructure/config/ElasticsearchIndexInitializer.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/config/ElasticsearchIndexInitializer.java
@@ -1,0 +1,55 @@
+package com.devticket.admin.infrastructure.config;
+
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import jakarta.annotation.PostConstruct;
+import java.io.InputStream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ElasticsearchIndexInitializer {
+
+    private final ElasticsearchClient elasticsearchClient;
+
+    @PostConstruct
+    public void init(){
+        createIndexIfNotExists("techstack-index", "elasticsearch/techstack-index-mapping.json");
+    }
+
+    private void createIndexIfNotExists(String indexName, String mappingFilePath){
+
+        try{
+            // index가 존재하면 -> 스킵
+            boolean exists = elasticsearchClient.indices()
+                .exists(e -> e.index(indexName))
+                .value();
+
+            if(exists){
+                log.info("[ES] 인덱스 이미 존재 : {}", indexName);
+                return;
+            }
+
+            // JSON 파일 -> 인덱스 생성
+            InputStream mappingStream = new ClassPathResource(mappingFilePath).getInputStream();
+
+            elasticsearchClient.indices().create(c -> c
+                .index(indexName)
+                .withJson(mappingStream)
+            );
+
+            log.info("[ES] 인덱스 생성 완료: {}", indexName);
+
+        } catch (Exception e){
+            log.error("[ES] 인덱스 생성 실패: {}", indexName, e);
+        }
+
+
+
+    }
+
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/config/WebClientConfig.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/config/WebClientConfig.java
@@ -1,0 +1,15 @@
+package com.devticket.admin.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(){
+        return WebClient.builder().build();
+    }
+
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/OpenAiEmbeddingClient.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/OpenAiEmbeddingClient.java
@@ -1,0 +1,55 @@
+package com.devticket.admin.infrastructure.external.client;
+
+import com.devticket.admin.infrastructure.external.dto.req.EmbeddingRequest;
+import com.devticket.admin.infrastructure.external.dto.res.EmbeddingResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OpenAiEmbeddingClient {
+
+    private final WebClient webClient;
+
+    @Value("${openai.embedding.api-key}")
+    private String apiKey;
+
+    @Value("${openai.embedding.url}")
+    private String embeddingUrl;
+
+    @Value("${openai.embedding.model}")
+    private String model;
+
+    public float[] embed(String text){
+        try{
+
+            // 1. openAI embedding 요청
+            EmbeddingResponse response = webClient.post()
+                .uri(embeddingUrl)
+                .header("Authorization", "Bearer " + apiKey)
+                .bodyValue(new EmbeddingRequest(text, model))
+                .retrieve()
+                .bodyToMono(EmbeddingResponse.class)
+                .block();
+
+            // 2. Double vector로 반환
+            List<Double> vector = response.data().get(0).embedding();
+
+            // 3. Doble -> float으로 변환
+            float[] result = new float[vector.size()];
+            for(int i = 0; i < vector.size(); i++){
+                result[i] = vector.get(i).floatValue();
+            }
+            return result;
+
+        }catch (Exception e){
+            log.error("[OpenAI] 임베딩 생성 실패 - text: {}", text, e);
+            throw new RuntimeException("임베딩 생성 실패", e);
+        }
+    }
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/OpenAiEmbeddingClient.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/OpenAiEmbeddingClient.java
@@ -32,7 +32,7 @@ public class OpenAiEmbeddingClient {
             EmbeddingResponse response = webClient.post()
                 .uri(embeddingUrl)
                 .header("Authorization", "Bearer " + apiKey)
-                .bodyValue(new EmbeddingRequest(text, model))
+                .bodyValue(new EmbeddingRequest(model, text))
                 .retrieve()
                 .bodyToMono(EmbeddingResponse.class)
                 .block();

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/req/EmbeddingRequest.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/req/EmbeddingRequest.java
@@ -1,0 +1,9 @@
+package com.devticket.admin.infrastructure.external.dto.req;
+
+public record EmbeddingRequest(
+    String model,
+    String input
+) {
+
+}
+

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/EmbeddingResponse.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/res/EmbeddingResponse.java
@@ -1,0 +1,16 @@
+package com.devticket.admin.infrastructure.external.dto.res;
+
+import java.util.List;
+
+public record EmbeddingResponse(
+    List<EmbeddingData> data
+) {
+
+    public record EmbeddingData(
+        List<Double> embedding
+    ){
+
+    }
+
+}
+

--- a/admin/src/main/java/com/devticket/admin/infrastructure/persistence/repository/TechStackEsRepository.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/persistence/repository/TechStackEsRepository.java
@@ -1,0 +1,8 @@
+package com.devticket.admin.infrastructure.persistence.repository;
+
+import com.devticket.admin.domain.model.TechStackDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface TechStackEsRepository extends ElasticsearchRepository<TechStackDocument, String> {
+//    void save(TechStackDocument techStackDocument);
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/persistence/repository/TechStackJpaRepository.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/persistence/repository/TechStackJpaRepository.java
@@ -1,0 +1,12 @@
+package com.devticket.admin.infrastructure.persistence.repository;
+
+import com.devticket.admin.domain.model.TechStack;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TechStackJpaRepository extends JpaRepository<TechStack, Long> {
+
+    List<TechStack> findByIdIn(List<Long> ids);
+
+    boolean existsByName(String name);
+}

--- a/admin/src/main/java/com/devticket/admin/infrastructure/persistence/repository/TechStackRepositoryImpl.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/persistence/repository/TechStackRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.devticket.admin.infrastructure.persistence.repository;
+
+import com.devticket.admin.domain.model.TechStack;
+import com.devticket.admin.domain.repository.TechStackRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TechStackRepositoryImpl implements TechStackRepository {
+
+    private final TechStackJpaRepository techStackJpaRepository;
+
+    @Override
+    public List<TechStack> getTechStacks() {
+        return techStackJpaRepository.findAll();
+    }
+
+    @Override
+    public TechStack save(TechStack techStack) {
+        return techStackJpaRepository.save(techStack);
+    }
+
+    @Override
+    public Optional<TechStack> findById(Long id) {
+        return techStackJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<TechStack> findByIdIn(List<Long> ids) {
+        return techStackJpaRepository.findByIdIn(ids);
+    }
+
+    @Override
+    public boolean existsByName(String name) {
+        return techStackJpaRepository.existsByName(name);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        techStackJpaRepository.deleteById(id);
+    }
+}

--- a/admin/src/main/java/com/devticket/admin/presentation/controller/TechStackController.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/controller/TechStackController.java
@@ -1,0 +1,68 @@
+package com.devticket.admin.presentation.controller;
+
+import com.devticket.admin.application.service.TechStackService;
+import com.devticket.admin.presentation.dto.req.CreateTechStackRequest;
+import com.devticket.admin.presentation.dto.req.UpdateTechStackRequest;
+import com.devticket.admin.presentation.dto.res.CreateTechStackResponse;
+import com.devticket.admin.presentation.dto.res.DeleteTechStackResponse;
+import com.devticket.admin.presentation.dto.res.GetTechStackResponse;
+import com.devticket.admin.presentation.dto.res.UpdateTechStackResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/techstacks")
+@Tag(name = "TechStack", description = "TechStack 관리 API")
+public class TechStackController {
+
+    private final TechStackService techStackService;
+
+    @PostMapping
+    @Operation(summary = "TechStack 생성")
+    public ResponseEntity<CreateTechStackResponse> createTechStack(
+        @RequestBody CreateTechStackRequest request
+    ) {
+        return ResponseEntity.ok(techStackService.createTechStack(request));
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "TechStack 수정")
+    public ResponseEntity<UpdateTechStackResponse> updateTechStack(
+        @PathVariable Long id,
+        @RequestBody UpdateTechStackRequest request
+    ) {
+        return ResponseEntity.ok(techStackService.updateTechStack(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "TechStack 삭제")
+    public ResponseEntity<DeleteTechStackResponse> deleteTechStack(
+        @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(techStackService.deleteTechStack(id));
+    }
+
+    @GetMapping
+    @Operation(summary = "TechStack 전체 조회")
+    public ResponseEntity<List<GetTechStackResponse>> getTechStacks(
+    ) {
+        return ResponseEntity.ok(techStackService.getTechStacks());
+    }
+
+
+}
+

--- a/admin/src/main/java/com/devticket/admin/presentation/controller/TechStackController.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/controller/TechStackController.java
@@ -9,6 +9,7 @@ import com.devticket.admin.presentation.dto.res.GetTechStackResponse;
 import com.devticket.admin.presentation.dto.res.UpdateTechStackResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -34,7 +35,7 @@ public class TechStackController {
     @PostMapping
     @Operation(summary = "TechStack 생성")
     public ResponseEntity<CreateTechStackResponse> createTechStack(
-        @RequestBody CreateTechStackRequest request
+        @RequestBody @Valid CreateTechStackRequest request
     ) {
         return ResponseEntity.ok(techStackService.createTechStack(request));
     }
@@ -43,7 +44,7 @@ public class TechStackController {
     @Operation(summary = "TechStack 수정")
     public ResponseEntity<UpdateTechStackResponse> updateTechStack(
         @PathVariable Long id,
-        @RequestBody UpdateTechStackRequest request
+        @RequestBody @Valid UpdateTechStackRequest request
     ) {
         return ResponseEntity.ok(techStackService.updateTechStack(id, request));
     }

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/req/CreateTechStackRequest.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/req/CreateTechStackRequest.java
@@ -1,0 +1,5 @@
+package com.devticket.admin.presentation.dto.req;
+
+public record CreateTechStackRequest(String name) {
+
+}

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/req/CreateTechStackRequest.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/req/CreateTechStackRequest.java
@@ -1,5 +1,10 @@
 package com.devticket.admin.presentation.dto.req;
 
-public record CreateTechStackRequest(String name) {
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateTechStackRequest(
+    @NotBlank
+    String name
+) {
 
 }

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/req/DeleteTechStackRequest.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/req/DeleteTechStackRequest.java
@@ -1,0 +1,8 @@
+package com.devticket.admin.presentation.dto.req;
+
+public record DeleteTechStackRequest(
+    Long id
+) {
+
+}
+

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/req/UpdateTechStackRequest.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/req/UpdateTechStackRequest.java
@@ -1,8 +1,10 @@
 package com.devticket.admin.presentation.dto.req;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record UpdateTechStackRequest(
     Long id,
-    String name
+    @NotBlank String name
 ) {
 
 }

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/req/UpdateTechStackRequest.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/req/UpdateTechStackRequest.java
@@ -1,0 +1,8 @@
+package com.devticket.admin.presentation.dto.req;
+
+public record UpdateTechStackRequest(
+    Long id,
+    String name
+) {
+
+}

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/CreateTechStackResponse.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/CreateTechStackResponse.java
@@ -1,0 +1,15 @@
+package com.devticket.admin.presentation.dto.res;
+
+import com.devticket.admin.domain.model.TechStack;
+
+public record CreateTechStackResponse(
+    Long id,
+    String name
+) {
+    public static CreateTechStackResponse from(TechStack techStack) {
+        return new CreateTechStackResponse(
+            techStack.getId(),
+            techStack.getName()
+        );
+    }
+}

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/DeleteTechStackResponse.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/DeleteTechStackResponse.java
@@ -1,0 +1,9 @@
+package com.devticket.admin.presentation.dto.res;
+
+public record DeleteTechStackResponse(
+    Long id
+) {
+    public static DeleteTechStackResponse of(Long id) {
+        return new DeleteTechStackResponse(id);
+    }
+}

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/GetTechStackResponse.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/GetTechStackResponse.java
@@ -1,0 +1,15 @@
+package com.devticket.admin.presentation.dto.res;
+
+import com.devticket.admin.domain.model.TechStack;
+
+public record GetTechStackResponse(
+    Long id,
+    String name
+) {
+    public static GetTechStackResponse from(TechStack techStack) {
+        return new GetTechStackResponse(
+            techStack.getId(),
+            techStack.getName()
+        );
+    }
+}

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/UpdateTechStackResponse.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/UpdateTechStackResponse.java
@@ -1,0 +1,15 @@
+package com.devticket.admin.presentation.dto.res;
+
+import com.devticket.admin.domain.model.TechStack;
+
+public record UpdateTechStackResponse(
+    Long id,
+    String name
+) {
+    public static UpdateTechStackResponse from(TechStack techStack){
+        return new UpdateTechStackResponse(
+            techStack.getId(),
+            techStack.getName()
+        );
+    }
+}

--- a/admin/src/main/resources/application-local.yml
+++ b/admin/src/main/resources/application-local.yml
@@ -31,6 +31,18 @@ logging:
     org.hibernate.SQL: DEBUG
     com.devticket: DEBUG
 
+elasticsearch:
+  uris: http://localhost:9200
+  connection-timeout: 5s
+  socket-timeout: 30s
+
+openai:
+  embedding:
+    enabled: true
+    api-key: ${OPENAI_API_KEY:}
+    model: text-embedding-3-small
+    url: https://api.openai.com/v1/embeddings
+
 internal:
   member-service:
     url: http://localhost:8081

--- a/admin/src/main/resources/application-test.yml
+++ b/admin/src/main/resources/application-test.yml
@@ -2,3 +2,15 @@ jwt:
   secret-key: test-jwt-secret-key
   access-token-ttl: 1800001
   refresh-token-ttl: 604800000
+
+elasticsearch:
+  uris: http://localhost:9200
+  connection-timeout: 5s
+  socket-timeout: 30s
+
+openai:
+  embedding:
+    enabled: true
+    api-key: ${OPENAI_API_KEY:}
+    model: text-embedding-3-small
+    url: https://api.openai.com/v1/embeddings

--- a/admin/src/main/resources/elasticsearch/techstack-index-mapping.json
+++ b/admin/src/main/resources/elasticsearch/techstack-index-mapping.json
@@ -1,0 +1,14 @@
+{
+  "mappings": {
+    "properties": {
+      "id":        { "type": "keyword" },
+      "name":      { "type": "keyword" },
+      "embedding": {
+        "type": "dense_vector",
+        "dims": 1536,
+        "index": true,
+        "similarity": "cosine"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- Member Service에서 Admin Service로 TechStack 관련 코드 이관
- 헥사고날 구조로 JPA 레이어 분리 (TechStackRepository 인터페이스 / TechStackJpaRepository / TechStackRepositoryImpl)
- TechStackService / TechStackServiceImpl 구현
- TechStackController 구현 (전체 조회 / 생성 / 수정 / 삭제)
- Request / Response DTO 구현

## 변경 사항
- `[Member]` TechStack 관련 코드 전체 제거
- `[Admin]` TechStack 엔티티 추가
- `[Admin]` TechStackRepository / TechStackJpaRepository / TechStackRepositoryImpl 추가
- `[Admin]` TechStackService / TechStackServiceImpl 추가
- `[Admin]` TechStackController 추가
- `[Admin]` Request / Response DTO 추가

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인

## 참고 사항
- admin_action_history 기록 대상 아님 (Admin 내부 마스터 데이터 관리)
- TechStack 임베딩 파이프라인은 별도 이슈 참조