### PR TITLE
[Event] refactor: tech_stack 조회 대상을 Admin 서비스로 변경

### DIFF
--- a/.github/workflows/ci-event.yml
+++ b/.github/workflows/ci-event.yml
@@ -13,6 +13,20 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: "false"
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd="curl -fsS http://localhost:9200/_cluster/health || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=30
+
     steps:
       - name: 1. Checkout Repository
         uses: actions/checkout@v4
@@ -31,6 +45,7 @@ jobs:
         run: cd event && ./gradlew test
         env:
           SPRING_PROFILES_ACTIVE: test
+          SPRING_ELASTICSEARCH_URIS: http://localhost:9200
 
       - name: 5. Gradle Build
         run: cd event && ./gradlew build -x test

--- a/.github/workflows/ci-event.yml
+++ b/.github/workflows/ci-event.yml
@@ -19,6 +19,8 @@ jobs:
         env:
           discovery.type: single-node
           xpack.security.enabled: "false"
+          xpack.security.http.ssl.enabled: "false"
+          xpack.security.transport.ssl.enabled: "false"
         ports:
           - 9200:9200
         options: >-

--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -16,6 +16,7 @@ import com.devticket.event.domain.exception.StockDeductionException;
 import com.devticket.event.domain.model.Event;
 import com.devticket.event.domain.model.EventImage;
 import com.devticket.event.domain.model.EventTechStack;
+import com.devticket.event.infrastructure.client.AdminClient;
 import com.devticket.event.infrastructure.client.MemberClient;
 import com.devticket.event.infrastructure.client.OpenAiEmbeddingClient;
 import com.devticket.event.infrastructure.client.dto.TechStackItem;
@@ -61,6 +62,7 @@ public class EventService {
 
     private final EventRepository eventRepository;
     private final MemberClient memberClient;
+    private final AdminClient adminClient;
     private final ElasticsearchOperations elasticsearchOperations;
     private final ElasticsearchClient esClient;
     private final OpenAiEmbeddingClient openAiEmbeddingClient;
@@ -122,7 +124,7 @@ public class EventService {
     }
 
     private Map<Long, String> buildTechStackMap() {
-        return memberClient.getTechStacks().stream()
+        return adminClient.getTechStacks().stream()
             .collect(Collectors.toMap(TechStackItem::techStackId, TechStackItem::name));
     }
 

--- a/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
+++ b/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
@@ -9,12 +9,14 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@Profile("!test")
 @RequiredArgsConstructor
 public class ElasticsearchIndexInitializer {
 

--- a/event/src/main/java/com/devticket/event/infrastructure/client/AdminClient.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/AdminClient.java
@@ -1,0 +1,35 @@
+package com.devticket.event.infrastructure.client;
+
+import com.devticket.event.infrastructure.client.dto.TechStackItem;
+import com.devticket.event.infrastructure.client.dto.TechStackListResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdminClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${service.admin.url}")
+    private String adminServiceUrl;
+
+    public List<TechStackItem> getTechStacks() {
+        try {
+            String url = adminServiceUrl + "/internal/admin/tech-stacks";
+            TechStackListResponse response = restTemplate.getForObject(url, TechStackListResponse.class);
+            if (response == null) {
+                return List.of();
+            }
+            return response.techStacks() != null ? response.techStacks() : List.of();
+        } catch (Exception e) {
+            log.warn("[기술스택 조회 실패] Admin 서비스 호출 오류", e);
+            return List.of();
+        }
+    }
+}

--- a/event/src/main/java/com/devticket/event/infrastructure/client/MemberClient.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/MemberClient.java
@@ -1,8 +1,6 @@
 package com.devticket.event.infrastructure.client;
 
 import com.devticket.event.infrastructure.client.dto.InternalMemberInfoResponse;
-import com.devticket.event.infrastructure.client.dto.TechStackItem;
-import com.devticket.event.infrastructure.client.dto.TechStackListResponse;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -61,17 +59,4 @@ public class MemberClient {
         }
     }
 
-    public List<TechStackItem> getTechStacks() {
-        try {
-            String url = memberServiceUrl + "/internal/members/tech-stacks";
-            TechStackListResponse response = restTemplate.getForObject(url, TechStackListResponse.class);
-            if (response == null) {
-                return List.of();
-            }
-            return response.techStacks() != null ? response.techStacks() : List.of();
-        } catch (Exception e) {
-            log.warn("[기술스택 조회 실패] Member 서비스 호출 오류", e);
-            return List.of();
-        }
-    }
 }

--- a/event/src/main/resources/application-local.yml
+++ b/event/src/main/resources/application-local.yml
@@ -35,6 +35,8 @@ openai:
 service:
   member:
     url: http://localhost:8081
+  admin:
+    url: http://localhost:8087
   ai:
     url: http://localhost:8088
 

--- a/event/src/main/resources/application-prod.yml
+++ b/event/src/main/resources/application-prod.yml
@@ -33,6 +33,8 @@ openai:
 service:
   member:
     url: http://member:8081
+  admin:
+    url: http://admin:8087
   ai:
     url: http://ai:8088
 

--- a/event/src/main/resources/application-test.yml
+++ b/event/src/main/resources/application-test.yml
@@ -23,3 +23,19 @@ spring:
     uris: http://localhost:9200
     connection-timeout: 1s
     socket-timeout: 1s
+  kafka:
+    bootstrap-servers: localhost:9093
+    consumer:
+      group-id: devticket-event
+      auto-offset-reset: earliest
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+service:
+  member:
+    url: http://member:8081
+  admin:
+    url: http://admin:8087
+  ai:
+    url: http://ai:8088

--- a/event/src/test/java/com/devticket/event/application/EventServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -19,8 +20,10 @@ import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.domain.exception.EventErrorCode;
 import com.devticket.event.domain.model.Event;
 import com.devticket.event.fixture.EventTestFixture;
+import com.devticket.event.infrastructure.client.AdminClient;
 import com.devticket.event.infrastructure.client.MemberClient;
 import com.devticket.event.infrastructure.client.OpenAiEmbeddingClient;
+import com.devticket.event.infrastructure.client.dto.TechStackItem;
 import com.devticket.event.infrastructure.persistence.EventRepository;
 import com.devticket.event.infrastructure.search.EventDocument;
 import com.devticket.event.presentation.dto.EventDetailResponse;
@@ -37,6 +40,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -61,6 +65,9 @@ class EventServiceTest {
     private MemberClient memberClient;
 
     @Mock
+    private AdminClient adminClient;
+
+    @Mock
     private ElasticsearchOperations elasticsearchOperations;
 
     @Mock
@@ -71,6 +78,15 @@ class EventServiceTest {
 
     @InjectMocks
     private EventService eventService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(adminClient.getTechStacks()).thenReturn(List.of(
+            new TechStackItem(1L, "Java"),
+            new TechStackItem(2L, "Spring"),
+            new TechStackItem(3L, "Kotlin")
+        ));
+    }
 
     // ── 검색 히트 목 헬퍼 ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## 작업 내용
- `AdminClient` 신규 생성 — `GET /internal/admin/tech-stacks` 호출
- `EventService.buildTechStackMap()`을 `memberClient` → `adminClient`로 교체
- `MemberClient.getTechStacks()` 메서드 제거
- `application-local.yml`, `application-prod.yml`에 `service.admin.url` 추가

## 변경 이유
tech_stack 마스터 데이터가 Admin 도메인으로 이관됨에 따라
Event 도메인의 조회 대상 서비스를 변경

close #468 