### PR TITLE
[Event] feat: action.log Kafka Producer 구현 + 통합 테스트

### DIFF
--- a/.github/workflows/ci-event.yml
+++ b/.github/workflows/ci-event.yml
@@ -13,6 +13,23 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
+    services:
+      # ElasticsearchIntegrationTestBase 가 localhost:9200 참조 (docs/~~, EventSearch*Test)
+      # xpack.security.enabled=false 로 HTTP 통신 사용 (인증 없이 테스트)
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:9.2.5
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: false
+          ES_JAVA_OPTS: -Xms512m -Xmx512m
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd "curl -sf http://localhost:9200/_cluster/health || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 20
+
     steps:
       - name: 1. Checkout Repository
         uses: actions/checkout@v4

--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -4,8 +4,10 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import com.devticket.event.application.event.ActionLogDomainEvent;
 import com.devticket.event.common.exception.BusinessException;
 import com.devticket.event.common.messaging.KafkaTopics;
+import com.devticket.event.common.messaging.event.ActionType;
 import com.devticket.event.common.messaging.event.OrderCreatedEvent;
 import com.devticket.event.common.messaging.event.StockDeductedEvent;
 import com.devticket.event.common.messaging.event.StockFailedEvent;
@@ -47,6 +49,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
@@ -67,6 +70,7 @@ public class EventService {
     private final OutboxService outboxService;
     private final MessageDeduplicationService deduplicationService;
     private final ObjectMapper objectMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public SellerEventCreateResponse createEvent(UUID sellerId, SellerEventCreateRequest request) {
@@ -134,6 +138,30 @@ public class EventService {
         String nickname = memberClient.getNickname(event.getSellerId());
 
         return EventDetailResponse.from(event, nickname);
+    }
+
+    public void logDetailView(UUID userId, UUID eventId) {
+        if (userId == null) {
+            return;
+        }
+        eventPublisher.publishEvent(new ActionLogDomainEvent(
+            userId, eventId, ActionType.DETAIL_VIEW,
+            null, null, null, null, null, Instant.now()));
+    }
+
+    public void logEventListView(UUID userId, EventListRequest request) {
+        if (userId == null) {
+            return;
+        }
+        String stackFilter = (request.techStacks() == null || request.techStacks().isEmpty())
+            ? null
+            : request.techStacks().stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(","));
+        eventPublisher.publishEvent(new ActionLogDomainEvent(
+            userId, null, ActionType.VIEW,
+            request.keyword(), stackFilter,
+            null, null, null, Instant.now()));
     }
 
     @Transactional(readOnly = true)

--- a/event/src/main/java/com/devticket/event/application/event/ActionLogDomainEvent.java
+++ b/event/src/main/java/com/devticket/event/application/event/ActionLogDomainEvent.java
@@ -1,0 +1,18 @@
+package com.devticket.event.application.event;
+
+import com.devticket.event.common.messaging.event.ActionType;
+import java.time.Instant;
+import java.util.UUID;
+
+public record ActionLogDomainEvent(
+        UUID userId,
+        UUID eventId,
+        ActionType actionType,
+        String searchKeyword,
+        String stackFilter,
+        Integer dwellTimeSeconds,
+        Integer quantity,
+        Long totalAmount,
+        Instant timestamp
+) {
+}

--- a/event/src/main/java/com/devticket/event/application/event/ActionLogKafkaPublisher.java
+++ b/event/src/main/java/com/devticket/event/application/event/ActionLogKafkaPublisher.java
@@ -1,0 +1,39 @@
+package com.devticket.event.application.event;
+
+import com.devticket.event.common.messaging.event.ActionLogEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ActionLogKafkaPublisher {
+
+    @Qualifier("actionLogKafkaTemplate")
+    private final KafkaTemplate<String, String> actionLogKafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void publish(ActionLogDomainEvent domain) {
+        // 본체 구현은 커밋 3 (Listener + @EnableAsync) 에서 완성
+    }
+
+    // Kafka DTO 매핑은 application → infrastructure 방향 준수 위해 Publisher 내부에 배치
+    // (ActionLogEvent 는 순수 record, 도메인 타입 참조 금지 — AGENTS.md §2.2)
+    private static ActionLogEvent toKafkaEvent(ActionLogDomainEvent domain) {
+        return new ActionLogEvent(
+                domain.userId().toString(),
+                domain.eventId() == null ? null : domain.eventId().toString(),
+                domain.actionType().name(),
+                domain.searchKeyword(),
+                domain.stackFilter(),
+                domain.dwellTimeSeconds(),
+                domain.quantity(),
+                domain.totalAmount(),
+                domain.timestamp()
+        );
+    }
+}

--- a/event/src/main/java/com/devticket/event/application/event/ActionLogKafkaPublisher.java
+++ b/event/src/main/java/com/devticket/event/application/event/ActionLogKafkaPublisher.java
@@ -1,12 +1,18 @@
 package com.devticket.event.application.event;
 
+import static com.devticket.event.common.messaging.KafkaTopics.ACTION_LOG;
+
 import com.devticket.event.common.messaging.event.ActionLogEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -17,8 +23,22 @@ public class ActionLogKafkaPublisher {
     private final KafkaTemplate<String, String> actionLogKafkaTemplate;
     private final ObjectMapper objectMapper;
 
+    // DB 미접근 리스너 — @Transactional 불요 (at-most-once 외부 발행 전용).
+    // 기존 도메인 리스너(StockStatusChangedListener 의 @Transactional(REQUIRES_NEW, readOnly))
+    // 패턴과 의도적 차이: 이 리스너의 주 책임은 내부 상태 동기화가 아닌 외부 Kafka 발행.
+    @Async("actionLogTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void publish(ActionLogDomainEvent domain) {
-        // 본체 구현은 커밋 3 (Listener + @EnableAsync) 에서 완성
+        try {
+            String payload = objectMapper.writeValueAsString(toKafkaEvent(domain));
+            actionLogKafkaTemplate.send(ACTION_LOG, domain.userId().toString(), payload);
+        } catch (JsonProcessingException e) {
+            log.warn("action.log 직렬화 실패 — skip (actionType={}, userId={})",
+                    domain.actionType(), domain.userId(), e);
+        } catch (Exception e) {
+            log.warn("action.log 발행 실패 — skip (actionType={}, userId={})",
+                    domain.actionType(), domain.userId(), e);
+        }
     }
 
     // Kafka DTO 매핑은 application → infrastructure 방향 준수 위해 Publisher 내부에 배치

--- a/event/src/main/java/com/devticket/event/application/event/ActionLogKafkaPublisher.java
+++ b/event/src/main/java/com/devticket/event/application/event/ActionLogKafkaPublisher.java
@@ -27,7 +27,7 @@ public class ActionLogKafkaPublisher {
     // 기존 도메인 리스너(StockStatusChangedListener 의 @Transactional(REQUIRES_NEW, readOnly))
     // 패턴과 의도적 차이: 이 리스너의 주 책임은 내부 상태 동기화가 아닌 외부 Kafka 발행.
     @Async("actionLogTaskExecutor")
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void publish(ActionLogDomainEvent domain) {
         try {
             String payload = objectMapper.writeValueAsString(toKafkaEvent(domain));

--- a/event/src/main/java/com/devticket/event/common/config/ActionLogKafkaProducerConfig.java
+++ b/event/src/main/java/com/devticket/event/common/config/ActionLogKafkaProducerConfig.java
@@ -4,39 +4,43 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 
+/**
+ * action.log 전용 Kafka Producer 설정 — fire-and-forget 정책.
+ * 기존 Saga Producer(acks=all, idempotence=true) 와 정책 상이 → 전용 Bean 분리.
+ * 상세: docs/actionLog.md §4 ② / docs/kafka-design.md §6.
+ */
 @Configuration
-public class KafkaProducerConfig {
+public class ActionLogKafkaProducerConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
 
     @Bean
-    @Primary
-    public ProducerFactory<String, String> producerFactory() {
+    public ProducerFactory<String, String> actionLogProducerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        // 모든 ISR에 쓰기 완료 확인 — 메시지 유실 방지
-        props.put(ProducerConfig.ACKS_CONFIG, "all");
-        // 프로듀서 레벨 멱등성 — 네트워크 재시도 시 중복 발행 방지
-        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        props.put(ProducerConfig.RETRIES_CONFIG, 3);
+        props.put(ProducerConfig.ACKS_CONFIG, "0");
+        props.put(ProducerConfig.RETRIES_CONFIG, 0);
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
+        props.put(ProducerConfig.LINGER_MS_CONFIG, 10);
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
+        props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "none");
         return new DefaultKafkaProducerFactory<>(props);
     }
 
-    @Bean
-    @Primary
-    public KafkaTemplate<String, String> kafkaTemplate() {
-        return new KafkaTemplate<>(producerFactory());
+    @Bean("actionLogKafkaTemplate")
+    public KafkaTemplate<String, String> actionLogKafkaTemplate(
+            @Qualifier("actionLogProducerFactory") ProducerFactory<String, String> pf) {
+        return new KafkaTemplate<>(pf);
     }
 }

--- a/event/src/main/java/com/devticket/event/common/config/AsyncConfig.java
+++ b/event/src/main/java/com/devticket/event/common/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package com.devticket.event.common.config;
+
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean("actionLogTaskExecutor")
+    public ThreadPoolTaskExecutor actionLogTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("action-log-");
+        // 큐 포화 시 손실 허용 — at-most-once 정책 일관 (Producer acks=0 과 동일 원칙)
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/event/src/main/java/com/devticket/event/common/config/JacksonConfig.java
+++ b/event/src/main/java/com/devticket/event/common/config/JacksonConfig.java
@@ -1,5 +1,6 @@
 package com.devticket.event.common.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -11,12 +12,15 @@ import org.springframework.context.annotation.Primary;
 @Configuration
 public class JacksonConfig {
 
+    // 상류 서비스가 이벤트 DTO 에 신규 필드를 추가해도 Consumer 역직렬화가 터지지 않도록
+    // unknown 필드 무시. 하위호환성 확보.
     @Bean
     @Primary
     public ObjectMapper objectMapper() {
         return JsonMapper.builder()
                 .addModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .build();
     }
 }

--- a/event/src/main/java/com/devticket/event/common/messaging/KafkaTopics.java
+++ b/event/src/main/java/com/devticket/event/common/messaging/KafkaTopics.java
@@ -17,4 +17,7 @@ public final class KafkaTopics {
     public static final String EVENT_SALE_STOPPED = "event.sale-stopped";
     public static final String REFUND_STOCK_DONE = "refund.stock.done";
     public static final String REFUND_STOCK_FAILED = "refund.stock.failed";
+
+    // action.log 전용 토픽 (AGENTS.md §6.10 별도 정책 — fire-and-forget, Outbox 미사용)
+    public static final String ACTION_LOG = "action.log";
 }

--- a/event/src/main/java/com/devticket/event/common/messaging/event/ActionLogEvent.java
+++ b/event/src/main/java/com/devticket/event/common/messaging/event/ActionLogEvent.java
@@ -1,0 +1,18 @@
+package com.devticket.event.common.messaging.event;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.Instant;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ActionLogEvent(
+        String userId,
+        String eventId,
+        String actionType,
+        String searchKeyword,
+        String stackFilter,
+        Integer dwellTimeSeconds,
+        Integer quantity,
+        Long totalAmount,
+        Instant timestamp
+) {
+}

--- a/event/src/main/java/com/devticket/event/common/messaging/event/ActionType.java
+++ b/event/src/main/java/com/devticket/event/common/messaging/event/ActionType.java
@@ -1,0 +1,11 @@
+package com.devticket.event.common.messaging.event;
+
+public enum ActionType {
+    VIEW,
+    DETAIL_VIEW,
+    CART_ADD,
+    CART_REMOVE,
+    PURCHASE,
+    DWELL_TIME,
+    REFUND
+}

--- a/event/src/main/java/com/devticket/event/presentation/controller/DwellController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/DwellController.java
@@ -3,6 +3,7 @@ package com.devticket.event.presentation.controller;
 import com.devticket.event.application.event.ActionLogDomainEvent;
 import com.devticket.event.common.messaging.event.ActionType;
 import com.devticket.event.presentation.dto.DwellRequest;
+import jakarta.validation.Valid;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +27,7 @@ public class DwellController {
     public ResponseEntity<Void> reportDwell(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @PathVariable("eventId") UUID eventId,
-            @RequestBody DwellRequest request) {
+            @Valid @RequestBody DwellRequest request) {
         if (userId != null) {
             eventPublisher.publishEvent(new ActionLogDomainEvent(
                     userId, eventId, ActionType.DWELL_TIME,

--- a/event/src/main/java/com/devticket/event/presentation/controller/DwellController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/DwellController.java
@@ -1,0 +1,37 @@
+package com.devticket.event.presentation.controller;
+
+import com.devticket.event.application.event.ActionLogDomainEvent;
+import com.devticket.event.common.messaging.event.ActionType;
+import com.devticket.event.presentation.dto.DwellRequest;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/events")
+@RequiredArgsConstructor
+public class DwellController {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @PostMapping("/{eventId}/dwell")
+    public ResponseEntity<Void> reportDwell(
+            @RequestHeader(value = "X-User-Id", required = false) UUID userId,
+            @PathVariable("eventId") UUID eventId,
+            @RequestBody DwellRequest request) {
+        if (userId != null) {
+            eventPublisher.publishEvent(new ActionLogDomainEvent(
+                    userId, eventId, ActionType.DWELL_TIME,
+                    null, null, request.dwellTimeSeconds(), null, null, Instant.now()));
+        }
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
@@ -1,12 +1,17 @@
 package com.devticket.event.presentation.controller;
 
 import com.devticket.event.application.EventService;
+import com.devticket.event.application.event.ActionLogDomainEvent;
+import com.devticket.event.common.messaging.event.ActionType;
+import com.devticket.event.common.response.SuccessResponse;
 import com.devticket.event.presentation.dto.EventDetailResponse;
 import com.devticket.event.presentation.dto.EventListRequest;
 import com.devticket.event.presentation.dto.EventListResponse;
-import com.devticket.event.common.response.SuccessResponse;
+import java.time.Instant;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -18,11 +23,18 @@ import org.springframework.web.bind.annotation.*;
 public class EventController {
 
     private final EventService eventService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @GetMapping("/{eventId}")
     public ResponseEntity<SuccessResponse<EventDetailResponse>> getEvent(
+        @RequestHeader(value = "X-User-Id", required = false) UUID currentUserId,
         @PathVariable("eventId") UUID eventId) {
         EventDetailResponse response = eventService.getEvent(eventId);
+        if (currentUserId != null) {
+            eventPublisher.publishEvent(new ActionLogDomainEvent(
+                currentUserId, eventId, ActionType.DETAIL_VIEW,
+                null, null, null, null, null, Instant.now()));
+        }
         return ResponseEntity.ok(SuccessResponse.success(response));
     }
 
@@ -32,6 +44,17 @@ public class EventController {
         @ModelAttribute EventListRequest request,
         @PageableDefault(size = 20) Pageable pageable) {
         EventListResponse response = eventService.getEventList(request, currentUserId, pageable);
+        if (currentUserId != null) {
+            String stackFilter = (request.techStacks() == null || request.techStacks().isEmpty())
+                ? null
+                : request.techStacks().stream()
+                    .map(String::valueOf)
+                    .collect(Collectors.joining(","));
+            eventPublisher.publishEvent(new ActionLogDomainEvent(
+                currentUserId, null, ActionType.VIEW,
+                request.keyword(), stackFilter,
+                null, null, null, Instant.now()));
+        }
         return ResponseEntity.ok(SuccessResponse.success(response));
     }
 

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
@@ -1,17 +1,12 @@
 package com.devticket.event.presentation.controller;
 
 import com.devticket.event.application.EventService;
-import com.devticket.event.application.event.ActionLogDomainEvent;
-import com.devticket.event.common.messaging.event.ActionType;
 import com.devticket.event.common.response.SuccessResponse;
 import com.devticket.event.presentation.dto.EventDetailResponse;
 import com.devticket.event.presentation.dto.EventListRequest;
 import com.devticket.event.presentation.dto.EventListResponse;
-import java.time.Instant;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -23,18 +18,13 @@ import org.springframework.web.bind.annotation.*;
 public class EventController {
 
     private final EventService eventService;
-    private final ApplicationEventPublisher eventPublisher;
 
     @GetMapping("/{eventId}")
     public ResponseEntity<SuccessResponse<EventDetailResponse>> getEvent(
         @RequestHeader(value = "X-User-Id", required = false) UUID currentUserId,
         @PathVariable("eventId") UUID eventId) {
         EventDetailResponse response = eventService.getEvent(eventId);
-        if (currentUserId != null) {
-            eventPublisher.publishEvent(new ActionLogDomainEvent(
-                currentUserId, eventId, ActionType.DETAIL_VIEW,
-                null, null, null, null, null, Instant.now()));
-        }
+        eventService.logDetailView(currentUserId, eventId);
         return ResponseEntity.ok(SuccessResponse.success(response));
     }
 
@@ -44,17 +34,7 @@ public class EventController {
         @ModelAttribute EventListRequest request,
         @PageableDefault(size = 20) Pageable pageable) {
         EventListResponse response = eventService.getEventList(request, currentUserId, pageable);
-        if (currentUserId != null) {
-            String stackFilter = (request.techStacks() == null || request.techStacks().isEmpty())
-                ? null
-                : request.techStacks().stream()
-                    .map(String::valueOf)
-                    .collect(Collectors.joining(","));
-            eventPublisher.publishEvent(new ActionLogDomainEvent(
-                currentUserId, null, ActionType.VIEW,
-                request.keyword(), stackFilter,
-                null, null, null, Instant.now()));
-        }
+        eventService.logEventListView(currentUserId, request);
         return ResponseEntity.ok(SuccessResponse.success(response));
     }
 

--- a/event/src/main/java/com/devticket/event/presentation/dto/DwellRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/DwellRequest.java
@@ -1,0 +1,4 @@
+package com.devticket.event.presentation.dto;
+
+public record DwellRequest(Integer dwellTimeSeconds) {
+}

--- a/event/src/main/java/com/devticket/event/presentation/dto/DwellRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/DwellRequest.java
@@ -1,4 +1,9 @@
 package com.devticket.event.presentation.dto;
 
-public record DwellRequest(Integer dwellTimeSeconds) {
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record DwellRequest(
+        @NotNull @Positive Integer dwellTimeSeconds
+) {
 }

--- a/event/src/main/resources/application-test.yml
+++ b/event/src/main/resources/application-test.yml
@@ -23,3 +23,8 @@ spring:
     uris: http://localhost:9200
     connection-timeout: 1s
     socket-timeout: 1s
+  kafka:
+    # placeholder resolution 전용 dummy — EventSearch*/EventSyncElasticsearchTest 등
+    # ES 계열 @SpringBootTest 컨텍스트 로드 시 KafkaProducerConfig @Value 실패 방지.
+    # @EmbeddedKafka 통합 테스트는 spring.embedded.kafka.brokers 로 override 됨.
+    bootstrap-servers: localhost:9092

--- a/event/src/main/resources/application-test.yml
+++ b/event/src/main/resources/application-test.yml
@@ -28,3 +28,10 @@ spring:
     # ES 계열 @SpringBootTest 컨텍스트 로드 시 KafkaProducerConfig @Value 실패 방지.
     # @EmbeddedKafka 통합 테스트는 spring.embedded.kafka.brokers 로 override 됨.
     bootstrap-servers: localhost:9092
+
+service:
+  # placeholder resolution 전용 dummy — AiClient/MemberClient @Value 실패 방지
+  member:
+    url: http://localhost:8081
+  ai:
+    url: http://localhost:8000

--- a/event/src/test/java/com/devticket/event/application/event/ActionLogKafkaPublisherTest.java
+++ b/event/src/test/java/com/devticket/event/application/event/ActionLogKafkaPublisherTest.java
@@ -1,0 +1,86 @@
+package com.devticket.event.application.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.devticket.event.common.messaging.event.ActionType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class ActionLogKafkaPublisherTest {
+
+    @Mock
+    KafkaTemplate<String, String> actionLogKafkaTemplate;
+
+    @Mock
+    ObjectMapper objectMapper;
+
+    @InjectMocks
+    ActionLogKafkaPublisher publisher;
+
+    @Test
+    void publish_정상_시나리오_send_호출_topic_key_payload_검증() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        ActionLogDomainEvent domain = new ActionLogDomainEvent(
+            userId, eventId, ActionType.DETAIL_VIEW,
+            null, null, null, null, null, Instant.now()
+        );
+        String payload = "{\"userId\":\"" + userId + "\"}";
+        given(objectMapper.writeValueAsString(any())).willReturn(payload);
+
+        publisher.publish(domain);
+
+        ArgumentCaptor<String> topic = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+        verify(actionLogKafkaTemplate).send(topic.capture(), key.capture(), body.capture());
+
+        assertThat(topic.getValue()).isEqualTo("action.log");
+        assertThat(key.getValue()).isEqualTo(userId.toString());
+        assertThat(body.getValue()).isEqualTo(payload);
+    }
+
+    @Test
+    void publish_직렬화_실패시_send_미호출_예외_전파_없음() throws Exception {
+        UUID userId = UUID.randomUUID();
+        ActionLogDomainEvent domain = new ActionLogDomainEvent(
+            userId, null, ActionType.VIEW,
+            null, null, null, null, null, Instant.now()
+        );
+        given(objectMapper.writeValueAsString(any())).willThrow(mock(JsonProcessingException.class));
+
+        assertThatCode(() -> publisher.publish(domain)).doesNotThrowAnyException();
+        verify(actionLogKafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void publish_Kafka_send_예외시_skip_예외_전파_없음() throws Exception {
+        UUID userId = UUID.randomUUID();
+        ActionLogDomainEvent domain = new ActionLogDomainEvent(
+            userId, null, ActionType.VIEW,
+            null, null, null, null, null, Instant.now()
+        );
+        given(objectMapper.writeValueAsString(any())).willReturn("{}");
+        given(actionLogKafkaTemplate.send(anyString(), anyString(), anyString()))
+            .willThrow(new RuntimeException("broker down"));
+
+        assertThatCode(() -> publisher.publish(domain)).doesNotThrowAnyException();
+    }
+}

--- a/event/src/test/java/com/devticket/event/common/config/JacksonConfigTest.java
+++ b/event/src/test/java/com/devticket/event/common/config/JacksonConfigTest.java
@@ -1,0 +1,92 @@
+package com.devticket.event.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.devticket.event.common.messaging.event.PaymentFailedEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("JacksonConfig — 하위호환성 역직렬화 검증")
+class JacksonConfigTest {
+
+    private final ObjectMapper objectMapper = new JacksonConfig().objectMapper();
+
+    @Test
+    void 알수없는_필드가_포함된_PaymentFailedEvent_JSON_역직렬화_성공() {
+        // given — 상류 서비스가 신규 필드(unknownField, futureField)를 추가한 payload
+        String json = """
+            {
+              "orderId": "123e4567-e89b-12d3-a456-426614174000",
+              "userId": "223e4567-e89b-12d3-a456-426614174000",
+              "orderItems": [
+                {"eventId": "323e4567-e89b-12d3-a456-426614174000", "quantity": 2}
+              ],
+              "reason": "PAYMENT_DECLINED",
+              "timestamp": "2026-04-20T10:00:00Z",
+              "unknownField": "future-added-by-upstream",
+              "futureField": 42
+            }
+            """;
+
+        // when & then — FAIL_ON_UNKNOWN_PROPERTIES=false 로 unknown 필드 무시
+        assertThatCode(() -> {
+            PaymentFailedEvent event = objectMapper.readValue(json, PaymentFailedEvent.class);
+            assertThat(event.orderId()).isNotNull();
+            assertThat(event.orderItems()).hasSize(1);
+            assertThat(event.orderItems().get(0).quantity()).isEqualTo(2);
+            assertThat(event.reason()).isEqualTo("PAYMENT_DECLINED");
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void 기존_필드만_포함된_PaymentFailedEvent_JSON_역직렬화_성공() {
+        // given — 확장 이전 payload (하위호환성 회귀 방어)
+        String json = """
+            {
+              "orderId": "123e4567-e89b-12d3-a456-426614174000",
+              "userId": "223e4567-e89b-12d3-a456-426614174000",
+              "orderItems": [
+                {"eventId": "323e4567-e89b-12d3-a456-426614174000", "quantity": 1}
+              ],
+              "reason": "PAYMENT_DECLINED",
+              "timestamp": "2026-04-20T10:00:00Z"
+            }
+            """;
+
+        // when & then
+        assertThatCode(() -> {
+            PaymentFailedEvent event = objectMapper.readValue(json, PaymentFailedEvent.class);
+            assertThat(event).isNotNull();
+            assertThat(event.orderItems()).hasSize(1);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void 중첩_OrderItem_에_unknown_필드_포함된_JSON_역직렬화_성공() {
+        // given — nested record 에도 동일 정책 적용되는지 검증
+        String json = """
+            {
+              "orderId": "123e4567-e89b-12d3-a456-426614174000",
+              "userId": "223e4567-e89b-12d3-a456-426614174000",
+              "orderItems": [
+                {
+                  "eventId": "323e4567-e89b-12d3-a456-426614174000",
+                  "quantity": 3,
+                  "unitPrice": 10000,
+                  "futureMeta": {"key": "value"}
+                }
+              ],
+              "reason": "PG_TIMEOUT",
+              "timestamp": "2026-04-20T10:00:00Z"
+            }
+            """;
+
+        // when & then
+        assertThatCode(() -> {
+            PaymentFailedEvent event = objectMapper.readValue(json, PaymentFailedEvent.class);
+            assertThat(event.orderItems().get(0).quantity()).isEqualTo(3);
+        }).doesNotThrowAnyException();
+    }
+}

--- a/event/src/test/java/com/devticket/event/integration/ActionLogProducerIntegrationTest.java
+++ b/event/src/test/java/com/devticket/event/integration/ActionLogProducerIntegrationTest.java
@@ -1,0 +1,140 @@
+package com.devticket.event.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.devticket.event.application.event.ActionLogDomainEvent;
+import com.devticket.event.application.event.ActionLogKafkaPublisher;
+import com.devticket.event.common.config.ActionLogKafkaProducerConfig;
+import com.devticket.event.common.config.AsyncConfig;
+import com.devticket.event.common.config.JacksonConfig;
+import com.devticket.event.common.messaging.event.ActionLogEvent;
+import com.devticket.event.common.messaging.event.ActionType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+
+@EmbeddedKafka(partitions = 1, topics = "action.log")
+@SpringBootTest(
+    classes = {
+        JacksonConfig.class,
+        ActionLogKafkaProducerConfig.class,
+        AsyncConfig.class,
+        ActionLogKafkaPublisher.class
+    },
+    properties = {
+        "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+        "spring.main.web-application-type=none",
+        "spring.autoconfigure.exclude="
+            + "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,"
+            + "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,"
+            + "org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration,"
+            + "org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration,"
+            + "org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientAutoConfiguration,"
+            + "org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration"
+    }
+)
+class ActionLogProducerIntegrationTest {
+
+    @Autowired
+    ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @Test
+    void VIEW_발행시_Kafka_메시지_도달_및_필드_매핑_검증() throws Exception {
+        UUID userId = UUID.randomUUID();
+        try (KafkaConsumer<String, String> consumer = newConsumer()) {
+            eventPublisher.publishEvent(new ActionLogDomainEvent(
+                userId, null, ActionType.VIEW,
+                "spring", "1,2", null, null, null, Instant.now()
+            ));
+
+            ConsumerRecord<String, String> record = pollByKey(consumer, userId.toString());
+            assertThat(record.key()).isEqualTo(userId.toString());
+
+            ActionLogEvent event = objectMapper.readValue(record.value(), ActionLogEvent.class);
+            assertThat(event.userId()).isEqualTo(userId.toString());
+            assertThat(event.eventId()).isNull();
+            assertThat(event.actionType()).isEqualTo("VIEW");
+            assertThat(event.searchKeyword()).isEqualTo("spring");
+            assertThat(event.stackFilter()).isEqualTo("1,2");
+        }
+    }
+
+    @Test
+    void DETAIL_VIEW_발행시_eventId_포함() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        try (KafkaConsumer<String, String> consumer = newConsumer()) {
+            eventPublisher.publishEvent(new ActionLogDomainEvent(
+                userId, eventId, ActionType.DETAIL_VIEW,
+                null, null, null, null, null, Instant.now()
+            ));
+
+            ConsumerRecord<String, String> record = pollByKey(consumer, userId.toString());
+            ActionLogEvent event = objectMapper.readValue(record.value(), ActionLogEvent.class);
+            assertThat(event.eventId()).isEqualTo(eventId.toString());
+            assertThat(event.actionType()).isEqualTo("DETAIL_VIEW");
+        }
+    }
+
+    @Test
+    void DWELL_TIME_발행시_dwellTimeSeconds_포함() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        try (KafkaConsumer<String, String> consumer = newConsumer()) {
+            eventPublisher.publishEvent(new ActionLogDomainEvent(
+                userId, eventId, ActionType.DWELL_TIME,
+                null, null, 30, null, null, Instant.now()
+            ));
+
+            ConsumerRecord<String, String> record = pollByKey(consumer, userId.toString());
+            ActionLogEvent event = objectMapper.readValue(record.value(), ActionLogEvent.class);
+            assertThat(event.dwellTimeSeconds()).isEqualTo(30);
+            assertThat(event.actionType()).isEqualTo("DWELL_TIME");
+        }
+    }
+
+    private KafkaConsumer<String, String> newConsumer() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, embeddedKafkaBroker.getBrokersAsString());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-" + UUID.randomUUID());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
+        consumer.subscribe(List.of("action.log"));
+        return consumer;
+    }
+
+    private ConsumerRecord<String, String> pollByKey(KafkaConsumer<String, String> consumer, String expectedKey) {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            for (ConsumerRecord<String, String> record : consumer.poll(Duration.ofMillis(500))) {
+                if (expectedKey.equals(record.key())) {
+                    return record;
+                }
+            }
+        }
+        throw new AssertionError("Kafka 메시지 10초 내 미수신 (expected key=" + expectedKey + ")");
+    }
+}


### PR DESCRIPTION
## Summary

### action.log Kafka Producer 신규 구현 (Phase 5)
- 전용 `ActionLogKafkaProducerConfig` Bean 격리 — `acks=0` / `retries=0` / `enable.idempotence=false` / `linger.ms=10` / `compression=none` (fire-and-forget, Outbox 미사용)
- `ActionLogKafkaPublisher` 비동기 발행 — `@Async("actionLogTaskExecutor")` + `@TransactionalEventListener(AFTER_COMMIT, fallbackExecution=true)` + 예외 스킵 (at-most-once)
- VIEW / DETAIL_VIEW / DWELL_TIME 3종 — Event 담당 (CART_ADD / CART_REMOVE 는 Commerce 별도 PR)
- DwellController 신규 — `POST /api/events/{eventId}/dwell`, `204 No Content`, 비로그인 skip (AI팀 수집 정책 반영)
- 기존 `kafkaTemplate` / `producerFactory` `@Primary` 부여 — Saga Producer 주입부 무수정

### 선행 작업
- Jackson `FAIL_ON_UNKNOWN_PROPERTIES=false` — DTO 하위호환 (신규 필드 추가 시 Consumer 무영향)

### CI 환경 수정 (본 PR 포함)
- `.github/workflows/ci-event.yml` 에 Elasticsearch 9.2.5 service 추가 — `ElasticsearchIntegrationTestBase` 가 참조하는 `localhost:9200` 제공, 기존 ES 통합 테스트 CI 복구

### 설계 근거 (BE_log 설계 레포 참조)
- `actionLog.md §4` 구현 지시서
- `action-log-producer-plan.md` Event 모듈 커밋 5분해
- 루트 `AGENTS.md §6.10` 체크리스트 8항 준수

## Test plan

- [x] 단위 테스트: `ActionLogKafkaPublisherTest` 3 Green (정상 / JsonProcessingException skip / Kafka 예외 skip)
- [x] 통합 테스트: `ActionLogProducerIntegrationTest` `@EmbeddedKafka` 3 Green (VIEW / DETAIL_VIEW / DWELL_TIME 메시지 도달 + 필드 매핑)
- [x] 컴파일 Green (`./gradlew :event:compileJava`)
- [x] 기존 Outbox Producer 경로 무회귀 — baseline 비교 동일 결과
- [x] **전체 회귀 테스트 (2026-04-21)**: action.log 관련 + Payment Consumer / StockRestore / EventService / Controller / Jackson 전부 PASS. ES 3종(31건)은 `application-test.yml` 의 `spring.kafka.bootstrap-servers` 미정의로 인한 기존 broken — action.log PR 회귀 아님 (아래 CI workflow 항목에서 해결 예정)
- [x] **실 브로커 E2E (2026-04-21)**: `devticket-kafka:9093` + Log 서비스 연동 — VIEW / DETAIL_VIEW / DWELL_TIME 샘플 메시지 → `log.action_log` INSERT 확인 (searchKeyword / stackFilter / dwellTimeSeconds 정확 매핑). Partition Key=userId console-consumer 실측
- [ ] CI workflow ES service 추가 반영 후 `EventSearch*` / `EventSyncElasticsearchTest` 복구 확인

## 외부 트랙 (본 PR 범위 밖)

- Commerce 모듈 action.log Producer (`CART_ADD` / `CART_REMOVE`) — `BE_commerce` 별도 PR 에서 동일 정책 적용 예정 (테스트 요청서 별도 공유)
- DWELL_TIME 프론트 API 스펙 최종 합의 — 프론트·PO 트랙

## 주의 사항

- **AGENTS.md §2.1 패키지 위치 충돌**: `common/config/` 유지 (기존 구현 일관성 우선) — 별도 리팩터링 트랙으로 추적
- **설계 문서 별도 관리**: BE_log 설계 레포 `docs/` 가 단일 진실 원천. 본 레포 `docs/` 사본은 이번 PR 미포함 (작업자 참조용 로컬만 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
