### PR TITLE
[Event] fix(ci): Elasticsearch service 추가 — 통합 테스트 복구

### DIFF
--- a/.github/workflows/ci-event.yml
+++ b/.github/workflows/ci-event.yml
@@ -13,6 +13,23 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
+    services:
+      # ElasticsearchIntegrationTestBase 가 localhost:9200 참조 (docs/~~, EventSearch*Test)
+      # xpack.security.enabled=false 로 HTTP 통신 사용 (인증 없이 테스트)
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:9.2.5
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: false
+          ES_JAVA_OPTS: -Xms512m -Xmx512m
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd "curl -sf http://localhost:9200/_cluster/health || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 20
+
     steps:
       - name: 1. Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- `.github/workflows/ci-event.yml` `build-and-test` job 에 Elasticsearch 9.2.5 service 블록 추가
- `xpack.security.enabled=false` (HTTP 통신, 인증 없이 테스트)
- Health check 포함 (`_cluster/health`, 20회 재시도)
- `ElasticsearchIntegrationTestBase` 가 참조하는 `localhost:9200` 제공 → `EventSearchFilterTest` / `EventSearchRepositoryTest` / `EventSyncElasticsearchTest` 복구

## 원인

Elasticsearch 통합 테스트 도입(이전 PR) 이후 CI workflow 에 ES service 설정이 누락 → PR #471 포함 이후 PR 의 CI 에서 `HttpHostConnectException` 로 전부 실패.

## 영향

- 복구되는 테스트: `EventSearchFilterTest` (20+), `EventSearchRepositoryTest` (8+), `EventSyncElasticsearchTest` (7+)
- 비즈니스 로직 변경 없음 — CI 환경 설정만 추가

## Test plan

- [ ] 본 PR CI `build-and-test` Green 확인 (ES service 기동 → 모든 ES 테스트 Green)
- [ ] 머지 후 PR #471 재빌드 트리거 → Green 복원 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)