### PR TITLE
[Admin] feat: TechStack 전체 조회 Internal API 구현

### DIFF
--- a/admin/src/main/java/com/devticket/admin/presentation/controller/InternalTechStackController.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/controller/InternalTechStackController.java
@@ -1,0 +1,26 @@
+package com.devticket.admin.presentation.controller;
+
+import com.devticket.admin.application.service.TechStackService;
+import com.devticket.admin.presentation.dto.res.GetTechStackResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Internal TechStack", description = "TechStack Internal api")
+public class InternalTechStackController {
+
+    private final TechStackService techStackService;
+
+    @GetMapping("/internal/admin/tech-stacks")
+    @Operation(summary = "TechStack 전체 조회 (Internal)")
+    public ResponseEntity<List<GetTechStackResponse>> getTechStacks() {
+        return ResponseEntity.ok(techStackService.getTechStacks());
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- TechStack 전체 조회 Internal API 구현
- InternalTechStackController 추가

## 변경 사항
- `InternalTechStackController` 추가
  - `GET /internal/admin/techstacks`

## 테스트
- [ ] 단위 테스트 통과
- [ ] Swagger 동작 확인

## 참고 사항
- 메인 페이지 테크스택 필터링 용도
- 이벤트 등록 시 TechStack 목록 표시 용도
- Member Service getProfile() TechStack 이름 조회 용도