### PR TITLE
[Commerce] fix: Outbox 이중 발행 완화 (lockAtMostFor + producer timeout 정합)

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
@@ -19,12 +19,17 @@ import com.devticket.commerce.cart.presentation.dto.res.CartItemQuantityResponse
 import com.devticket.commerce.cart.presentation.dto.res.CartItemResponse;
 import com.devticket.commerce.cart.presentation.dto.res.CartResponse;
 import com.devticket.commerce.common.exception.BusinessException;
+import com.devticket.commerce.common.messaging.event.ActionLogDomainEvent;
+import com.devticket.commerce.common.messaging.event.ActionType;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
@@ -36,6 +41,7 @@ public class CartService implements CartUseCase, CartItemUseCase {
     private final CartItemRepository cartItemRepository;
     private final EventClient eventClient;
     private final TransactionTemplate transactionTemplate;
+    private final ApplicationEventPublisher eventPublisher;
 
     // =========================================================================
     // Public Methods (Main Flow)
@@ -57,9 +63,13 @@ public class CartService implements CartUseCase, CartItemUseCase {
         //Cart와 CartItem -> 객체참조x, 연관관계 매핑 없이 식별자참조.
         Cart cart = findOrCreateCart(userId);
 
-        CartItem cartItem = transactionTemplate.execute(status ->
-            addOrUpdateCartItem(cart.getId(), request)
-        );
+        CartItem cartItem = transactionTemplate.execute(status -> {
+            CartItem item = addOrUpdateCartItem(cart.getId(), request);
+            // action.log 발행 (트랜잭션 활성 상태에서 호출 — AFTER_COMMIT 트리거)
+            publishCartActionLog(userId, request.eventId(), ActionType.CART_ADD,
+                request.quantity(), event.price());
+            return item;
+        });
 
         //응답데이터 구성
         return CartItemResponse.of(cart, cartItem, event.title(), event.price());
@@ -87,6 +97,7 @@ public class CartService implements CartUseCase, CartItemUseCase {
 
     // 장바구니 비우기 — Cart row가 없으면 멱등 성공 반환 (#416: 이미 비어있음도 성공으로 취급)
     @Override
+    @Transactional
     public CartClearResponse clearCart(UUID userId) {
         Cart cart = cartRepository.findByUserId(userId).orElse(null);
         if (cart == null) {
@@ -94,6 +105,12 @@ public class CartService implements CartUseCase, CartItemUseCase {
         }
         List<CartItem> cartItems = cartItemRepository.findAllByCartId(cart.getId());
         if (!cartItems.isEmpty()) {
+            // N회 CART_REMOVE 발행 (아이템별 eventId 보존 — AI 이탈 분석 용)
+            for (CartItem item : cartItems) {
+                Integer price = fetchEventPriceSafely(item.getEventId(), userId, item.getQuantity());
+                publishCartActionLog(userId, item.getEventId(), ActionType.CART_REMOVE,
+                    item.getQuantity(), price);
+            }
             cartItemRepository.deleteAllInBatch(cartItems);
         }
         return CartClearResponse.of();
@@ -101,6 +118,7 @@ public class CartService implements CartUseCase, CartItemUseCase {
 
     // 장바구니 아이템 갯수 증감
     @Override
+    @Transactional
     public CartItemQuantityResponse updateTicket(UUID userId, Long cartItemId, CartItemQuantityRequest request) {
         // 장바구니 가져오기 — Cart 없으면 ITEM_NOT_FOUND (#416)
         Cart cart = getCartOrThrowItemNotFound(userId);
@@ -125,11 +143,20 @@ public class CartService implements CartUseCase, CartItemUseCase {
 
         CartItem savedCartItem = cartItemRepository.save(cartItem);
 
+        // 양수 → CART_ADD, 음수 → CART_REMOVE, 0 → 미발행 (publishCartActionLog 내부 처리)
+        int delta = request.quantity();
+        if (delta != 0) {
+            ActionType actionType = delta > 0 ? ActionType.CART_ADD : ActionType.CART_REMOVE;
+            publishCartActionLog(userId, cartItem.getEventId(), actionType,
+                Math.abs(delta), event.price());
+        }
+
         return CartItemQuantityResponse.of(savedCartItem);
     }
 
     // 장바구니 아이템 삭제
     @Override
+    @Transactional
     public CartItemDeleteResponse deleteTicket(UUID userId, Long cartItemId) {
         // 장바구니 가져오기 — Cart 없으면 ITEM_NOT_FOUND (#416)
         Cart cart = getCartOrThrowItemNotFound(userId);
@@ -141,6 +168,11 @@ public class CartService implements CartUseCase, CartItemUseCase {
             throw new BusinessException(CartErrorCode.ITEM_NOT_FOUND);
         }
 
+        // action.log CART_REMOVE 발행 (price 조회는 totalAmount 산출 목적만 — 실패 시 null)
+        Integer price = fetchEventPriceSafely(cartItem.getEventId(), userId, cartItem.getQuantity());
+        publishCartActionLog(userId, cartItem.getEventId(), ActionType.CART_REMOVE,
+            cartItem.getQuantity(), price);
+
         cartItemRepository.deleteAllInBatch(List.of(cartItem));
         return CartItemDeleteResponse.of();
     }
@@ -148,6 +180,30 @@ public class CartService implements CartUseCase, CartItemUseCase {
     // =========================================================================
     // Private Helpers (Logic & Validation)
     // =========================================================================
+
+    // action.log Spring 이벤트 발행. quantity=0 미발행. price null 시 totalAmount=null.
+    private void publishCartActionLog(UUID userId, UUID eventId, ActionType actionType,
+                                      int quantity, Integer price) {
+        if (quantity == 0) {
+            return;
+        }
+        Long totalAmount = (price != null) ? (long) price * quantity : null;
+        eventPublisher.publishEvent(new ActionLogDomainEvent(
+            userId, eventId, actionType,
+            null, null, null,
+            quantity, totalAmount, Instant.now()
+        ));
+    }
+
+    // totalAmount 산출용 price 조회 — 실패 시 null (비즈니스 영향 없음, action.log 선택 필드 누락만)
+    private Integer fetchEventPriceSafely(UUID eventId, UUID userId, int quantity) {
+        try {
+            return eventClient.getValidateEventStatus(eventId, userId, quantity).price();
+        } catch (Exception e) {
+            log.warn("[CartService] action.log price 조회 실패 — totalAmount=null. eventId={}", eventId, e);
+            return null;
+        }
+    }
 
     private Cart findOrCreateCart(UUID userId) {
         // 동시성문제 고려하기

--- a/commerce/src/main/java/com/devticket/commerce/common/config/ActionLogKafkaProducerConfig.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/config/ActionLogKafkaProducerConfig.java
@@ -1,0 +1,49 @@
+package com.devticket.commerce.common.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+/**
+ * action.log 토픽 전용 Producer 설정 — fire-and-forget 정책 (at-most-once).
+ * 기존 Saga용 {@link KafkaProducerConfig}와 설정이 완전히 다르므로 Bean 격리 필수.
+ * 상세 정책: BE_log/docs/actionLog.md §4 ②, kafka-design.md §6
+ */
+@Configuration
+public class ActionLogKafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> actionLogProducerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        // fire-and-forget — 브로커 응답 대기 없음, 손실 허용
+        props.put(ProducerConfig.ACKS_CONFIG, "0");
+        props.put(ProducerConfig.RETRIES_CONFIG, 0);
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
+        // 비동기 발행 전제 — UX 무영향 + batch 효율 ↑
+        props.put(ProducerConfig.LINGER_MS_CONFIG, 10);
+        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
+        // 1차 기능 검증 우선 — lz4 전환은 성능 테스트 후 별도 Task로 분리
+        props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "none");
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean("actionLogKafkaTemplate")
+    public KafkaTemplate<String, String> actionLogKafkaTemplate(
+            @Qualifier("actionLogProducerFactory") ProducerFactory<String, String> pf) {
+        return new KafkaTemplate<>(pf);
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/common/config/AsyncConfig.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/config/AsyncConfig.java
@@ -1,0 +1,29 @@
+package com.devticket.commerce.common.config;
+
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * 비동기 처리용 TaskExecutor 설정.
+ * {@code actionLogTaskExecutor}는 action.log Kafka Publisher 전용 — 큐 포화 시 DiscardPolicy로
+ * 신규 task를 폐기하여 at-most-once 정책과 일관성 유지 (손실 허용).
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean("actionLogTaskExecutor")
+    public ThreadPoolTaskExecutor actionLogTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("action-log-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/common/config/JacksonConfig.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/config/JacksonConfig.java
@@ -1,5 +1,6 @@
 package com.devticket.commerce.common.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -12,11 +13,13 @@ public class JacksonConfig {
 
     // Kafka 이벤트 DTO 직렬화/역직렬화용
     // Instant 타입을 ISO-8601 문자열로 직렬화 — 서비스 간 timezone 안전
+    // FAIL_ON_UNKNOWN_PROPERTIES=false — 상류 Producer가 DTO 필드 확장해도 Consumer 배포 지연 시 DLT 적재 방지
     @Bean
     public ObjectMapper objectMapper() {
         return JsonMapper.builder()
                 .addModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .build();
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/common/config/JacksonConfig.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/config/JacksonConfig.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 @Configuration
 public class JacksonConfig {
@@ -15,6 +16,7 @@ public class JacksonConfig {
     // Instant 타입을 ISO-8601 문자열로 직렬화 — 서비스 간 timezone 안전
     // FAIL_ON_UNKNOWN_PROPERTIES=false — 상류 Producer가 DTO 필드 확장해도 Consumer 배포 지연 시 DLT 적재 방지
     @Bean
+    @Primary
     public ObjectMapper objectMapper() {
         return JsonMapper.builder()
                 .addModule(new JavaTimeModule())

--- a/commerce/src/main/java/com/devticket/commerce/common/config/KafkaProducerConfig.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/config/KafkaProducerConfig.java
@@ -7,6 +7,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
@@ -18,6 +19,7 @@ public class KafkaProducerConfig {
     private String bootstrapServers;
 
     @Bean
+    @Primary
     public ProducerFactory<String, String> producerFactory() {
         Map<String, Object> config = new HashMap<>();
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -31,6 +33,7 @@ public class KafkaProducerConfig {
     }
 
     @Bean
+    @Primary
     public KafkaTemplate<String, String> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }

--- a/commerce/src/main/java/com/devticket/commerce/common/config/KafkaProducerConfig.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/config/KafkaProducerConfig.java
@@ -29,6 +29,11 @@ public class KafkaProducerConfig {
         config.put(ProducerConfig.ACKS_CONFIG, "all");
         // Producer 멱등성 — 재전송 시 중복 발행 방지 (acks=all 필수)
         config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        // OutboxEventProducer.get(2s)와 정합 — 앱 타임아웃 이전에 Producer 재시도 확정 종료
+        // 일시 실패는 Outbox markFailed() 지수 백오프가 단일 재시도 메커니즘으로 수행
+        config.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 1500);
+        config.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000);
+        config.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 500);
         return new DefaultKafkaProducerFactory<>(config);
     }
 

--- a/commerce/src/main/java/com/devticket/commerce/common/config/KafkaProducerConfig.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/config/KafkaProducerConfig.java
@@ -18,6 +18,18 @@ public class KafkaProducerConfig {
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
 
+    // OutboxEventProducer.get(2s)와 정합 — 앱 타임아웃 이전에 Producer 재시도 확정 종료
+    // 운영 기본: max.block(500) < request(1000) ≤ delivery(1500) < SEND_TIMEOUT*1000(2000)
+    // 테스트는 application-test.yml에서 완화값 오버라이드 (EmbeddedKafka 첫 발행 워밍 허용)
+    @Value("${devticket.kafka.producer.delivery-timeout-ms:1500}")
+    private int deliveryTimeoutMs;
+
+    @Value("${devticket.kafka.producer.request-timeout-ms:1000}")
+    private int requestTimeoutMs;
+
+    @Value("${devticket.kafka.producer.max-block-ms:500}")
+    private int maxBlockMs;
+
     @Bean
     @Primary
     public ProducerFactory<String, String> producerFactory() {
@@ -29,11 +41,10 @@ public class KafkaProducerConfig {
         config.put(ProducerConfig.ACKS_CONFIG, "all");
         // Producer 멱등성 — 재전송 시 중복 발행 방지 (acks=all 필수)
         config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        // OutboxEventProducer.get(2s)와 정합 — 앱 타임아웃 이전에 Producer 재시도 확정 종료
         // 일시 실패는 Outbox markFailed() 지수 백오프가 단일 재시도 메커니즘으로 수행
-        config.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 1500);
-        config.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000);
-        config.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 500);
+        config.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, deliveryTimeoutMs);
+        config.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs);
+        config.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, maxBlockMs);
         return new DefaultKafkaProducerFactory<>(config);
     }
 

--- a/commerce/src/main/java/com/devticket/commerce/common/messaging/KafkaTopics.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/messaging/KafkaTopics.java
@@ -19,6 +19,9 @@ public final class KafkaTopics {
     public static final String EVENT_FORCE_CANCELLED = "event.force-cancelled";
     public static final String EVENT_SALE_STOPPED    = "event.sale-stopped";
 
+    // action.log (analytics — fire-and-forget, Bean 격리)
+    public static final String ACTION_LOG = "action.log";
+
     // Refund Saga Orchestration
     public static final String REFUND_REQUESTED         = "refund.requested";
     public static final String REFUND_ORDER_CANCEL      = "refund.order.cancel";

--- a/commerce/src/main/java/com/devticket/commerce/common/messaging/ProcessedMessage.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/messaging/ProcessedMessage.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,7 +15,14 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "processed_message", schema = "commerce")
+@Table(
+    name = "processed_message",
+    schema = "commerce",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_processed_message_message_id_topic",
+        columnNames = "message_id"
+    )
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProcessedMessage {
 
@@ -23,8 +31,8 @@ public class ProcessedMessage {
     private Long id;
 
     // Outbox message_id (Kafka 헤더 X-Message-Id에서 추출)
-    // UNIQUE 제약 — 레이스 컨디션 최종 방어선
-    @Column(name = "message_id", nullable = false, unique = true, length = 36)
+    // UNIQUE 제약명 고정 — Consumer의 isProcessedMessageUniqueConflict()가 제약명으로 판별
+    @Column(name = "message_id", nullable = false, length = 36)
     private String messageId;
 
     // 운영 디버깅용

--- a/commerce/src/main/java/com/devticket/commerce/common/messaging/event/ActionLogDomainEvent.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/messaging/event/ActionLogDomainEvent.java
@@ -1,0 +1,21 @@
+package com.devticket.commerce.common.messaging.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Spring 내부 도메인 이벤트 — Kafka 직렬화 대상 아님 (레이어 경계 보존).
+ * ApplicationEventPublisher.publishEvent() → @TransactionalEventListener(AFTER_COMMIT)로 소비.
+ * Kafka 발행 payload는 {@link ActionLogEvent}로 변환.
+ */
+public record ActionLogDomainEvent(
+        UUID userId,
+        UUID eventId,
+        ActionType actionType,
+        String searchKeyword,
+        String stackFilter,
+        Integer dwellTimeSeconds,
+        Integer quantity,
+        Long totalAmount,
+        Instant timestamp
+) {}

--- a/commerce/src/main/java/com/devticket/commerce/common/messaging/event/ActionLogEvent.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/messaging/event/ActionLogEvent.java
@@ -1,0 +1,37 @@
+package com.devticket.commerce.common.messaging.event;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * action.log 토픽 Kafka 발행 DTO.
+ * BE_log(fastify-log/kafkajs)가 소비 — Java↔Node 이종 스택 계약.
+ * {@code @JsonIgnoreProperties(ignoreUnknown = true)} 필수 (kafka-design.md §3).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ActionLogEvent(
+        UUID userId,
+        UUID eventId,
+        ActionType actionType,
+        String searchKeyword,
+        String stackFilter,
+        Integer dwellTimeSeconds,
+        Integer quantity,
+        Long totalAmount,
+        Instant timestamp
+) {
+    public static ActionLogEvent from(ActionLogDomainEvent domain) {
+        return new ActionLogEvent(
+                domain.userId(),
+                domain.eventId(),
+                domain.actionType(),
+                domain.searchKeyword(),
+                domain.stackFilter(),
+                domain.dwellTimeSeconds(),
+                domain.quantity(),
+                domain.totalAmount(),
+                domain.timestamp()
+        );
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/common/messaging/event/ActionLogKafkaPublisher.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/messaging/event/ActionLogKafkaPublisher.java
@@ -1,15 +1,22 @@
 package com.devticket.commerce.common.messaging.event;
 
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
- * action.log 토픽 전용 Kafka Publisher (뼈대 — 본체 구현은 커밋 3).
- * 커밋 3에서 {@code @TransactionalEventListener(AFTER_COMMIT) + @Async} 적용,
- * {@code JsonProcessingException} 포함 전 예외 로깅 후 스킵 (at-most-once).
+ * action.log 토픽 전용 Kafka Publisher — fire-and-forget (at-most-once).
+ * 비즈니스 {@code @Transactional} 커밋 후 비동기 발행 → API 응답 지연 제로.
+ * 예외는 로깅 후 스킵 (재시도·DLT·throw 금지).
  */
+@Slf4j
 @Component
 public class ActionLogKafkaPublisher {
 
@@ -23,7 +30,22 @@ public class ActionLogKafkaPublisher {
         this.objectMapper = objectMapper;
     }
 
+    @Async("actionLogTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void publish(ActionLogDomainEvent domain) {
-        // 본체 구현: 커밋 3
+        try {
+            String payload = objectMapper.writeValueAsString(ActionLogEvent.from(domain));
+            actionLogKafkaTemplate.send(
+                    KafkaTopics.ACTION_LOG,
+                    domain.userId().toString(),
+                    payload
+            );
+        } catch (JsonProcessingException e) {
+            log.warn("action.log 직렬화 실패 — skip: actionType={}, userId={}",
+                    domain.actionType(), domain.userId(), e);
+        } catch (Exception e) {
+            log.warn("action.log 발행 실패 — skip: actionType={}, userId={}",
+                    domain.actionType(), domain.userId(), e);
+        }
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/common/messaging/event/ActionLogKafkaPublisher.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/messaging/event/ActionLogKafkaPublisher.java
@@ -30,8 +30,9 @@ public class ActionLogKafkaPublisher {
         this.objectMapper = objectMapper;
     }
 
+    // fallbackExecution=true: 트랜잭션 없는 호출자도 지원 (이중 안전장치 — 원자성은 호출 측 @Transactional로 해결)
     @Async("actionLogTaskExecutor")
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void publish(ActionLogDomainEvent domain) {
         try {
             String payload = objectMapper.writeValueAsString(ActionLogEvent.from(domain));

--- a/commerce/src/main/java/com/devticket/commerce/common/messaging/event/ActionLogKafkaPublisher.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/messaging/event/ActionLogKafkaPublisher.java
@@ -1,0 +1,29 @@
+package com.devticket.commerce.common.messaging.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * action.log 토픽 전용 Kafka Publisher (뼈대 — 본체 구현은 커밋 3).
+ * 커밋 3에서 {@code @TransactionalEventListener(AFTER_COMMIT) + @Async} 적용,
+ * {@code JsonProcessingException} 포함 전 예외 로깅 후 스킵 (at-most-once).
+ */
+@Component
+public class ActionLogKafkaPublisher {
+
+    private final KafkaTemplate<String, String> actionLogKafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    public ActionLogKafkaPublisher(
+            @Qualifier("actionLogKafkaTemplate") KafkaTemplate<String, String> actionLogKafkaTemplate,
+            ObjectMapper objectMapper) {
+        this.actionLogKafkaTemplate = actionLogKafkaTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public void publish(ActionLogDomainEvent domain) {
+        // 본체 구현: 커밋 3
+    }
+}

--- a/commerce/src/main/java/com/devticket/commerce/common/messaging/event/ActionType.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/messaging/event/ActionType.java
@@ -1,0 +1,15 @@
+package com.devticket.commerce.common.messaging.event;
+
+/**
+ * 사용자 행동 로그 action.log 토픽의 actionType 7종.
+ * BE_log/fastify-log/src/enum/action-type.enum.ts와 문자열 일치 (AGENTS.md §11).
+ */
+public enum ActionType {
+    VIEW,
+    DETAIL_VIEW,
+    CART_ADD,
+    CART_REMOVE,
+    PURCHASE,
+    DWELL_TIME,
+    REFUND
+}

--- a/commerce/src/main/java/com/devticket/commerce/common/messaging/event/PaymentCompletedEvent.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/messaging/event/PaymentCompletedEvent.java
@@ -2,6 +2,7 @@ package com.devticket.commerce.common.messaging.event;
 
 import com.devticket.commerce.common.enums.PaymentMethod;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 public record PaymentCompletedEvent(
@@ -10,5 +11,11 @@ public record PaymentCompletedEvent(
         UUID paymentId,
         PaymentMethod paymentMethod,
         int totalAmount,
+        List<OrderItem> orderItems,
         Instant timestamp
-) {}
+) {
+    public record OrderItem(
+            UUID eventId,
+            int quantity
+    ) {}
+}

--- a/commerce/src/main/java/com/devticket/commerce/common/outbox/OutboxEventProducer.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/outbox/OutboxEventProducer.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
@@ -17,14 +18,19 @@ import org.springframework.stereotype.Component;
 public class OutboxEventProducer {
 
     private static final String MESSAGE_ID_HEADER = "X-Message-Id";
-    private static final long SEND_TIMEOUT_SECONDS = 2L;
 
     private final KafkaTemplate<String, String> kafkaTemplate;
+
+    // 앱 타임아웃 — Producer delivery.timeout.ms 보다 커야 이중 발행 위험 차단
+    // 불변식: max.block < request.timeout ≤ delivery.timeout < sendTimeoutMs
+    // 초기값 2000은 Spring 주입 실패 시(@InjectMocks 단위 테스트 등) 폴백
+    @Value("${devticket.outbox.send-timeout-ms:2000}")
+    private long sendTimeoutMs = 2000;
 
     public void publish(OutboxEventMessage message) {
         ProducerRecord<String, String> record = buildRecord(message);
         try {
-            kafkaTemplate.send(record).get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            kafkaTemplate.send(record).get(sendTimeoutMs, TimeUnit.MILLISECONDS);
             log.debug("Outbox 발행 성공 — topic={}, messageId={}", message.topic(), message.messageId());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/commerce/src/main/java/com/devticket/commerce/common/outbox/OutboxScheduler.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/outbox/OutboxScheduler.java
@@ -19,7 +19,7 @@ public class OutboxScheduler {
     // @Transactional 없음 — Kafka 발행은 트랜잭션 밖에서 처리
     // 건당 독립 처리: OutboxService.processOne()에 위임
     @Scheduled(fixedDelay = 3_000)
-    @SchedulerLock(name = "outbox-scheduler", lockAtMostFor = "30s", lockAtLeastFor = "5s")
+    @SchedulerLock(name = "outbox-scheduler", lockAtMostFor = "5m", lockAtLeastFor = "5s")
     public void publishPendingEvents() {
         List<Outbox> pendingList = outboxRepository
                 .findPendingToPublish(OutboxStatus.PENDING, Instant.now());

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -219,7 +219,8 @@ public class OrderService implements OrderUsecase {
     public InternalOrderInfoResponse getOrderInfo(UUID orderId) {
         Order order = orderRepository.findByOrderId(orderId)
             .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
-        return InternalOrderInfoResponse.from(order);
+        List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(order.getId());
+        return InternalOrderInfoResponse.from(order, orderItems);
     }
 
     @Override

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -205,9 +205,14 @@ public class OrderService implements OrderUsecase {
     @Override
     @Transactional(readOnly = true)
     public OrderListResponse getOrderList(UUID userId, OrderListRequest request) {
-        OrderStatus status = (request.status() != null && !request.status().isBlank())
-            ? OrderStatus.valueOf(request.status())
-            : null;
+        OrderStatus status = null;
+        if (request.status() != null && !request.status().isBlank()) {
+            try {
+                status = OrderStatus.valueOf(request.status());
+            } catch (IllegalArgumentException e) {
+                throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS_FILTER);
+            }
+        }
 
         PageRequest pageable = PageRequest.of(request.page() - 1, request.size(), Sort.by("id").descending());
         Page<Order> orderPage = orderRepository.findAllByUserId(userId, status, pageable);
@@ -362,6 +367,7 @@ public class OrderService implements OrderUsecase {
 
     // 결제 전 주문 취소
     @Override
+    @Transactional
     public OrderCancelResponse cancelOrder(UUID userId, UUID orderId) {
         // 1. 주문 정보 확인
         Order order = orderRepository.findByOrderId(orderId)
@@ -370,16 +376,16 @@ public class OrderService implements OrderUsecase {
         if (!order.getUserId().equals(userId)) {
             throw new BusinessException(OrderErrorCode.ORDER_FORBIDDEN);
         }
-        // 3. 결제 상태 체크
+        // 3. 결제 상태 체크 (환불 흐름은 별도 경로 — API로는 PAID 취소 차단)
         if (order.getStatus().equals(OrderStatus.PAID)) {
             throw new BusinessException(OrderErrorCode.ALREADY_PAID_ORDER);
         }
-        // 4. 주문 아이템 조회
-        List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(order.getId());
-        // 5. 재고 복구
-        orderToEventClient.adjustStocks(InternalBulkStockAdjustmentRequest.createForCancelByOrderItems(orderItems));
-        // 6. 주문 취소
+        // 4. 상태 전이 선수행 — canTransitionTo(CANCELLED) 위반 시 외부 호출 전에 throw
         order.cancel();
+
+        // 5. 전이 성공 후에만 재고 복구 — 종단 상태(FAILED/CANCELLED 등) 재진입으로 인한 over-restore 차단
+        List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(order.getId());
+        orderToEventClient.adjustStocks(InternalBulkStockAdjustmentRequest.createForCancelByOrderItems(orderItems));
 
         orderRepository.save(order);
 

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/exception/OrderErrorCode.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/exception/OrderErrorCode.java
@@ -23,7 +23,8 @@ public enum OrderErrorCode implements ErrorCode {
     EMPTY_ORDER_ITEMS(400, "ORDER_012", "주문한 상품이 존재하지 않습니다."),
     INVALID_TOTAL_AMOUNT(400, "ORDER_013", "총 주문 금액이 유효하지 않습니다."),
     ORDER_CREATION_FAILED(500, "ORDER_014", "주문 생성 중 내부 오류가 발생했습니다."),
-    INVALID_ORDER_STATUS_TRANSITION(400, "ORDER_015", "현재 주문 상태에서 허용되지 않는 전이입니다.");
+    INVALID_ORDER_STATUS_TRANSITION(400, "ORDER_015", "현재 주문 상태에서 허용되지 않는 전이입니다."),
+    INVALID_ORDER_STATUS_FILTER(400, "ORDER_016", "유효하지 않은 주문 상태 필터 값입니다.");
 
 
     private final int status;

--- a/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/OrderToEventClient.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/infrastructure/external/client/OrderToEventClient.java
@@ -8,6 +8,7 @@ import com.devticket.commerce.order.infrastructure.external.client.dto.InternalS
 import com.devticket.commerce.order.infrastructure.external.client.dto.InternalStockAdjustmentResponse;
 import com.devticket.commerce.order.infrastructure.external.client.dto.InternalStockAdjustmentWrapper;
 import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalBulkEventInfoRequest;
+import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalBulkEventInfoResponse;
 import com.devticket.commerce.ticket.infrastructure.external.client.dto.InternalEventInfoResponse;
 import java.util.List;
 import java.util.UUID;
@@ -62,9 +63,9 @@ public class OrderToEventClient {
                 .onStatus(HttpStatusCode::isError, (req, res) -> {
                     throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
                 })
-                .body(new ParameterizedTypeReference<EventSuccessResponse<List<InternalEventInfoResponse>>>() {
+                .body(new ParameterizedTypeReference<EventSuccessResponse<InternalBulkEventInfoResponse>>() {
                 });
-            return response.data();
+            return response.data().events();
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderInfoResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderInfoResponse.java
@@ -1,6 +1,7 @@
 package com.devticket.commerce.order.presentation.dto.res;
 
 import com.devticket.commerce.order.domain.model.Order;
+import java.util.List;
 import java.util.UUID;
 
 public record InternalOrderInfoResponse(
@@ -10,10 +11,19 @@ public record InternalOrderInfoResponse(
     String paymentMethod,
     Integer totalAmount,
     String status,
-    String orderedAt
+    String orderedAt,
+    List<OrderItem> orderItems
 ) {
 
-    public static InternalOrderInfoResponse from(Order order) {
+    public record OrderItem(UUID eventId, int quantity) {}
+
+    public static InternalOrderInfoResponse from(
+        Order order,
+        List<com.devticket.commerce.order.domain.model.OrderItem> orderItemEntities
+    ) {
+        List<OrderItem> items = orderItemEntities.stream()
+            .map(entity -> new OrderItem(entity.getEventId(), entity.getQuantity()))
+            .toList();
         return new InternalOrderInfoResponse(
             order.getOrderId(),
             order.getUserId(),
@@ -21,7 +31,8 @@ public record InternalOrderInfoResponse(
             order.getPaymentMethod() != null ? order.getPaymentMethod().name() : null,
             order.getTotalAmount(),
             order.getStatus().name(),
-            order.getOrderedAt().toString()
+            order.getOrderedAt().toString(),
+            items
         );
     }
 }

--- a/commerce/src/test/java/com/devticket/commerce/common/config/KafkaProducerConfigTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/common/config/KafkaProducerConfigTest.java
@@ -1,0 +1,76 @@
+package com.devticket.commerce.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.devticket.commerce.common.outbox.OutboxEventProducer;
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Outbox 이중 발행 완화(Issue #481, commit 5e2c3d5) — Producer 타임아웃과
+ * OutboxEventProducer.SEND_TIMEOUT_SECONDS 간 정합성 회귀 방지.
+ *
+ * 불변식:
+ *   max.block.ms  <  request.timeout.ms  <=  delivery.timeout.ms  <  SEND_TIMEOUT_SECONDS * 1000
+ * 하나라도 깨지면 앱 타임아웃 이전에 Producer 재시도가 종료되지 않아 이중 발행 위험 재발.
+ */
+class KafkaProducerConfigTest {
+
+    @Test
+    void producerFactory_타임아웃_설정이_커밋된_기준값과_일치한다() {
+        // given
+        KafkaProducerConfig config = new KafkaProducerConfig();
+        ReflectionTestUtils.setField(config, "bootstrapServers", "localhost:9092");
+
+        // when
+        ProducerFactory<String, String> factory = config.producerFactory();
+        Map<String, Object> props =
+                ((DefaultKafkaProducerFactory<String, String>) factory).getConfigurationProperties();
+
+        // then
+        assertThat(props)
+                .containsEntry(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 1500)
+                .containsEntry(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000)
+                .containsEntry(ProducerConfig.MAX_BLOCK_MS_CONFIG, 500)
+                .containsEntry(ProducerConfig.ACKS_CONFIG, "all")
+                .containsEntry(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+    }
+
+    @Test
+    void delivery_timeout_ms는_OutboxEventProducer_SEND_TIMEOUT_SECONDS_미만으로_설정된다() throws Exception {
+        // given
+        KafkaProducerConfig config = new KafkaProducerConfig();
+        ReflectionTestUtils.setField(config, "bootstrapServers", "localhost:9092");
+        Map<String, Object> props = ((DefaultKafkaProducerFactory<String, String>) config.producerFactory())
+                .getConfigurationProperties();
+
+        Field sendTimeoutField = OutboxEventProducer.class.getDeclaredField("SEND_TIMEOUT_SECONDS");
+        sendTimeoutField.setAccessible(true);
+        long sendTimeoutMs = (long) sendTimeoutField.get(null) * 1000L;
+
+        int deliveryTimeoutMs = (int) props.get(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG);
+        int requestTimeoutMs = (int) props.get(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG);
+        int maxBlockMs = (int) props.get(ProducerConfig.MAX_BLOCK_MS_CONFIG);
+
+        // then — 앱 .get(SEND_TIMEOUT_SECONDS) 이전에 Producer 재시도가 확정 종료되어야 함
+        assertThat((long) deliveryTimeoutMs)
+                .as("delivery.timeout.ms(%d) < SEND_TIMEOUT_SECONDS*1000(%d) — 앱 타임아웃 이전 종료 보장",
+                        deliveryTimeoutMs, sendTimeoutMs)
+                .isLessThan(sendTimeoutMs);
+
+        assertThat(requestTimeoutMs)
+                .as("request.timeout.ms(%d) <= delivery.timeout.ms(%d) — Kafka 클라이언트 필수 제약",
+                        requestTimeoutMs, deliveryTimeoutMs)
+                .isLessThanOrEqualTo(deliveryTimeoutMs);
+
+        assertThat(maxBlockMs)
+                .as("max.block.ms(%d) < request.timeout.ms(%d) — 메타데이터 블로킹 조기 이탈",
+                        maxBlockMs, requestTimeoutMs)
+                .isLessThan(requestTimeoutMs);
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/common/config/KafkaProducerConfigTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/common/config/KafkaProducerConfigTest.java
@@ -3,74 +3,90 @@ package com.devticket.commerce.common.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.devticket.commerce.common.outbox.OutboxEventProducer;
-import java.lang.reflect.Field;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
-import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * Outbox 이중 발행 완화(Issue #481, commit 5e2c3d5) — Producer 타임아웃과
- * OutboxEventProducer.SEND_TIMEOUT_SECONDS 간 정합성 회귀 방지.
+ * OutboxEventProducer.sendTimeoutMs 간 정합성 회귀 방지.
  *
  * 불변식:
- *   max.block.ms  <  request.timeout.ms  <=  delivery.timeout.ms  <  SEND_TIMEOUT_SECONDS * 1000
+ *   max.block.ms < request.timeout.ms ≤ delivery.timeout.ms < sendTimeoutMs
  * 하나라도 깨지면 앱 타임아웃 이전에 Producer 재시도가 종료되지 않아 이중 발행 위험 재발.
+ *
+ * 운영값(@Value default)은 500/1000/1500 + sendTimeoutMs 2000.
+ * 테스트 프로파일(application-test.yml)은 3000/5000/8000 + sendTimeoutMs 10000.
+ * 두 세트 모두 불변식을 만족해야 한다.
  */
 class KafkaProducerConfigTest {
 
     @Test
-    void producerFactory_타임아웃_설정이_커밋된_기준값과_일치한다() {
-        // given
-        KafkaProducerConfig config = new KafkaProducerConfig();
-        ReflectionTestUtils.setField(config, "bootstrapServers", "localhost:9092");
+    void OutboxEventProducer_sendTimeoutMs_기본값이_운영값_2000ms이다() {
+        OutboxEventProducer producer = new OutboxEventProducer(null);
 
-        // when
-        ProducerFactory<String, String> factory = config.producerFactory();
-        Map<String, Object> props =
-                ((DefaultKafkaProducerFactory<String, String>) factory).getConfigurationProperties();
+        long sendTimeoutMs = (long) ReflectionTestUtils.getField(producer, "sendTimeoutMs");
 
-        // then
+        assertThat(sendTimeoutMs)
+                .as("Spring 주입 실패 시 폴백 초기값 — @Value default 와도 일치해야 함")
+                .isEqualTo(2000L);
+    }
+
+    @Test
+    void producerFactory_운영_기본값이_적용되고_ACKS_idempotence가_고정된다() {
+        Map<String, Object> props = buildProps(500, 1000, 1500);
+
         assertThat(props)
-                .containsEntry(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 1500)
-                .containsEntry(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000)
                 .containsEntry(ProducerConfig.MAX_BLOCK_MS_CONFIG, 500)
+                .containsEntry(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000)
+                .containsEntry(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 1500)
                 .containsEntry(ProducerConfig.ACKS_CONFIG, "all")
                 .containsEntry(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
     }
 
     @Test
-    void delivery_timeout_ms는_OutboxEventProducer_SEND_TIMEOUT_SECONDS_미만으로_설정된다() throws Exception {
-        // given
+    void 운영_기본값은_불변식을_만족한다() {
+        Map<String, Object> props = buildProps(500, 1000, 1500);
+
+        assertInvariant(props, 2000L);
+    }
+
+    @Test
+    void 테스트_프로파일_완화값도_불변식을_만족한다() {
+        Map<String, Object> props = buildProps(3000, 5000, 8000);
+
+        assertInvariant(props, 10000L);
+    }
+
+    private Map<String, Object> buildProps(int maxBlockMs, int requestTimeoutMs, int deliveryTimeoutMs) {
         KafkaProducerConfig config = new KafkaProducerConfig();
         ReflectionTestUtils.setField(config, "bootstrapServers", "localhost:9092");
-        Map<String, Object> props = ((DefaultKafkaProducerFactory<String, String>) config.producerFactory())
+        ReflectionTestUtils.setField(config, "maxBlockMs", maxBlockMs);
+        ReflectionTestUtils.setField(config, "requestTimeoutMs", requestTimeoutMs);
+        ReflectionTestUtils.setField(config, "deliveryTimeoutMs", deliveryTimeoutMs);
+
+        return ((DefaultKafkaProducerFactory<String, String>) config.producerFactory())
                 .getConfigurationProperties();
+    }
 
-        Field sendTimeoutField = OutboxEventProducer.class.getDeclaredField("SEND_TIMEOUT_SECONDS");
-        sendTimeoutField.setAccessible(true);
-        long sendTimeoutMs = (long) sendTimeoutField.get(null) * 1000L;
+    private void assertInvariant(Map<String, Object> props, long sendTimeoutMs) {
+        int maxBlock = (int) props.get(ProducerConfig.MAX_BLOCK_MS_CONFIG);
+        int request = (int) props.get(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG);
+        int delivery = (int) props.get(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG);
 
-        int deliveryTimeoutMs = (int) props.get(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG);
-        int requestTimeoutMs = (int) props.get(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG);
-        int maxBlockMs = (int) props.get(ProducerConfig.MAX_BLOCK_MS_CONFIG);
-
-        // then — 앱 .get(SEND_TIMEOUT_SECONDS) 이전에 Producer 재시도가 확정 종료되어야 함
-        assertThat((long) deliveryTimeoutMs)
-                .as("delivery.timeout.ms(%d) < SEND_TIMEOUT_SECONDS*1000(%d) — 앱 타임아웃 이전 종료 보장",
-                        deliveryTimeoutMs, sendTimeoutMs)
-                .isLessThan(sendTimeoutMs);
-
-        assertThat(requestTimeoutMs)
-                .as("request.timeout.ms(%d) <= delivery.timeout.ms(%d) — Kafka 클라이언트 필수 제약",
-                        requestTimeoutMs, deliveryTimeoutMs)
-                .isLessThanOrEqualTo(deliveryTimeoutMs);
-
-        assertThat(maxBlockMs)
+        assertThat(maxBlock)
                 .as("max.block.ms(%d) < request.timeout.ms(%d) — 메타데이터 블로킹 조기 이탈",
-                        maxBlockMs, requestTimeoutMs)
-                .isLessThan(requestTimeoutMs);
+                        maxBlock, request)
+                .isLessThan(request);
+        assertThat(request)
+                .as("request.timeout.ms(%d) ≤ delivery.timeout.ms(%d) — Kafka 클라이언트 필수 제약",
+                        request, delivery)
+                .isLessThanOrEqualTo(delivery);
+        assertThat((long) delivery)
+                .as("delivery.timeout.ms(%d) < sendTimeoutMs(%d) — 앱 타임아웃 이전 Producer 재시도 확정 종료",
+                        delivery, sendTimeoutMs)
+                .isLessThan(sendTimeoutMs);
     }
 }

--- a/commerce/src/test/java/com/devticket/commerce/common/messaging/event/ActionLogEventTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/common/messaging/event/ActionLogEventTest.java
@@ -1,0 +1,124 @@
+package com.devticket.commerce.common.messaging.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.devticket.commerce.common.config.JacksonConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ActionLogEventTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        // 운영 ObjectMapper 동일 설정 — JavaTimeModule + WRITE_DATES_AS_TIMESTAMPS=false + FAIL_ON_UNKNOWN_PROPERTIES=false
+        objectMapper = new JacksonConfig().objectMapper();
+    }
+
+    @Test
+    @DisplayName("from(ActionLogDomainEvent) — 9필드 매핑 정확성")
+    void from_9필드_매핑_정확성() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        Instant now = Instant.parse("2026-04-21T00:00:00Z");
+        ActionLogDomainEvent domain = new ActionLogDomainEvent(
+                userId, eventId, ActionType.CART_ADD,
+                "concert", "rock", 30,
+                2, 20000L, now);
+
+        // when
+        ActionLogEvent event = ActionLogEvent.from(domain);
+
+        // then
+        assertThat(event.userId()).isEqualTo(userId);
+        assertThat(event.eventId()).isEqualTo(eventId);
+        assertThat(event.actionType()).isEqualTo(ActionType.CART_ADD);
+        assertThat(event.searchKeyword()).isEqualTo("concert");
+        assertThat(event.stackFilter()).isEqualTo("rock");
+        assertThat(event.dwellTimeSeconds()).isEqualTo(30);
+        assertThat(event.quantity()).isEqualTo(2);
+        assertThat(event.totalAmount()).isEqualTo(20000L);
+        assertThat(event.timestamp()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("Instant ISO-8601 직렬화 — WRITE_DATES_AS_TIMESTAMPS=false 적용")
+    void Instant_ISO_8601_직렬화() throws Exception {
+        // given
+        Instant fixed = Instant.parse("2026-04-21T00:00:00Z");
+        ActionLogEvent event = new ActionLogEvent(
+                UUID.randomUUID(), UUID.randomUUID(), ActionType.VIEW,
+                null, null, null, null, null, fixed);
+
+        // when
+        String json = objectMapper.writeValueAsString(event);
+
+        // then — 숫자 timestamp가 아닌 ISO-8601 문자열
+        assertThat(json).contains("\"timestamp\":\"2026-04-21T00:00:00Z\"");
+    }
+
+    @Test
+    @DisplayName("nullable 필드 직렬화 안전 — eventId/quantity/totalAmount null")
+    void nullable_필드_직렬화_안전() throws Exception {
+        // given
+        ActionLogEvent event = new ActionLogEvent(
+                UUID.randomUUID(), null, ActionType.VIEW,
+                null, null, null, null, null, Instant.now());
+
+        // when
+        String json = objectMapper.writeValueAsString(event);
+
+        // then — JSON null로 직렬화 (kafkajs가 null/undefined 처리 가능)
+        assertThat(json).contains("\"eventId\":null");
+        assertThat(json).contains("\"quantity\":null");
+        assertThat(json).contains("\"totalAmount\":null");
+    }
+
+    @Test
+    @DisplayName("미지 필드 포함 payload 역직렬화 성공 — @JsonIgnoreProperties(ignoreUnknown=true)")
+    void 미지_필드_포함_payload_역직렬화_성공() throws Exception {
+        // given — 미래 Producer가 추가할 수 있는 미지 필드 포함
+        UUID userId = UUID.randomUUID();
+        String payload = "{"
+                + "\"userId\":\"" + userId + "\","
+                + "\"eventId\":null,"
+                + "\"actionType\":\"VIEW\","
+                + "\"searchKeyword\":null,"
+                + "\"stackFilter\":null,"
+                + "\"dwellTimeSeconds\":null,"
+                + "\"quantity\":null,"
+                + "\"totalAmount\":null,"
+                + "\"timestamp\":\"2026-04-21T00:00:00Z\","
+                + "\"futureField\":\"ignored\","
+                + "\"anotherUnknown\":42"
+                + "}";
+
+        // when & then — 미지 필드 무시하고 역직렬화 성공
+        ActionLogEvent event = objectMapper.readValue(payload, ActionLogEvent.class);
+        assertThat(event.userId()).isEqualTo(userId);
+        assertThat(event.actionType()).isEqualTo(ActionType.VIEW);
+        assertThat(event.timestamp()).isEqualTo(Instant.parse("2026-04-21T00:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("CART_ADD 7종 actionType round-trip — 직렬화·역직렬화 대칭")
+    void actionType_7종_round_trip() throws Exception {
+        for (ActionType type : ActionType.values()) {
+            ActionLogEvent original = new ActionLogEvent(
+                    UUID.randomUUID(), UUID.randomUUID(), type,
+                    null, null, null, null, null,
+                    Instant.parse("2026-04-21T00:00:00Z"));
+
+            String json = objectMapper.writeValueAsString(original);
+            ActionLogEvent restored = objectMapper.readValue(json, ActionLogEvent.class);
+
+            assertThat(restored.actionType()).isEqualTo(type);
+        }
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/common/messaging/event/ActionLogKafkaPublisherTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/common/messaging/event/ActionLogKafkaPublisherTest.java
@@ -1,0 +1,122 @@
+package com.devticket.commerce.common.messaging.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class ActionLogKafkaPublisherTest {
+
+    @Mock
+    private KafkaTemplate<String, String> actionLogKafkaTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    private ActionLogKafkaPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new ActionLogKafkaPublisher(actionLogKafkaTemplate, objectMapper);
+    }
+
+    @Test
+    @DisplayName("정상 발행 — topic=action.log, key=userId, value=JSON payload")
+    void publish_정상_발행시_topic_key_payload를_포함해_전송한다() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        ActionLogDomainEvent domain = createDomain(userId, ActionType.CART_ADD, 2, 20000L);
+        String expectedPayload = "{\"userId\":\"" + userId + "\"}";
+        given(objectMapper.writeValueAsString(any(ActionLogEvent.class))).willReturn(expectedPayload);
+
+        // when
+        publisher.publish(domain);
+
+        // then
+        verify(actionLogKafkaTemplate).send("action.log", userId.toString(), expectedPayload);
+    }
+
+    @Test
+    @DisplayName("JsonProcessingException 발생 시 예외 전파 없이 스킵 — send 미호출")
+    void publish_JsonProcessingException_발생시_스킵한다() throws Exception {
+        // given
+        ActionLogDomainEvent domain = createDomain(UUID.randomUUID(), ActionType.CART_ADD, 1, 1000L);
+        given(objectMapper.writeValueAsString(any(ActionLogEvent.class)))
+                .willThrow(new JsonProcessingException("직렬화 실패") {});
+
+        // when — 예외 전파 없음
+        publisher.publish(domain);
+
+        // then — send 미호출 (at-most-once)
+        verifyNoInteractions(actionLogKafkaTemplate);
+    }
+
+    @Test
+    @DisplayName("KafkaTemplate.send RuntimeException 발생 시 예외 전파 없이 스킵")
+    void publish_RuntimeException_발생시_스킵한다() throws Exception {
+        // given — send()에서 RuntimeException
+        ActionLogDomainEvent domain = createDomain(UUID.randomUUID(), ActionType.CART_REMOVE, 1, 1000L);
+        given(objectMapper.writeValueAsString(any(ActionLogEvent.class))).willReturn("{}");
+        given(actionLogKafkaTemplate.send(anyString(), anyString(), anyString()))
+                .willThrow(new RuntimeException("broker down"));
+
+        // when — 예외 전파 없음
+        publisher.publish(domain);
+
+        // then — send 1회 호출 후 예외 소화 (비즈니스 영향 없음)
+        verify(actionLogKafkaTemplate).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("ActionLogEvent.from() 매핑 — 9필드 정확히 ObjectMapper에 전달된다")
+    void publish_ActionLogEvent_9필드_매핑을_ObjectMapper에_전달한다() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        Instant now = Instant.parse("2026-04-21T00:00:00Z");
+        ActionLogDomainEvent domain = new ActionLogDomainEvent(
+                userId, eventId, ActionType.CART_ADD,
+                "concert", "rock", null,
+                2, 20000L, now);
+        ArgumentCaptor<ActionLogEvent> captor = ArgumentCaptor.forClass(ActionLogEvent.class);
+        given(objectMapper.writeValueAsString(captor.capture())).willReturn("{}");
+
+        // when
+        publisher.publish(domain);
+
+        // then
+        ActionLogEvent event = captor.getValue();
+        assertThat(event.userId()).isEqualTo(userId);
+        assertThat(event.eventId()).isEqualTo(eventId);
+        assertThat(event.actionType()).isEqualTo(ActionType.CART_ADD);
+        assertThat(event.searchKeyword()).isEqualTo("concert");
+        assertThat(event.stackFilter()).isEqualTo("rock");
+        assertThat(event.dwellTimeSeconds()).isNull();
+        assertThat(event.quantity()).isEqualTo(2);
+        assertThat(event.totalAmount()).isEqualTo(20000L);
+        assertThat(event.timestamp()).isEqualTo(now);
+    }
+
+    private ActionLogDomainEvent createDomain(UUID userId, ActionType type, int quantity, Long totalAmount) {
+        return new ActionLogDomainEvent(
+                userId, UUID.randomUUID(), type,
+                null, null, null,
+                quantity, totalAmount, Instant.now());
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/common/messaging/event/PaymentCompletedEventTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/common/messaging/event/PaymentCompletedEventTest.java
@@ -1,0 +1,113 @@
+package com.devticket.commerce.common.messaging.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.devticket.commerce.common.config.JacksonConfig;
+import com.devticket.commerce.common.enums.PaymentMethod;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PaymentCompletedEventTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        // 운영 ObjectMapper와 동일 설정 — FAIL_ON_UNKNOWN_PROPERTIES=false 포함
+        objectMapper = new JacksonConfig().objectMapper();
+    }
+
+    @Test
+    @DisplayName("신버전 payload(orderItems 포함) 역직렬화 성공")
+    void orderItems_포함_payload_역직렬화_성공() throws Exception {
+        // given — Payment Producer 신버전 발행 payload
+        UUID orderId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID paymentId = UUID.randomUUID();
+        UUID eventId1 = UUID.randomUUID();
+        UUID eventId2 = UUID.randomUUID();
+        String payload = "{"
+                + "\"orderId\":\"" + orderId + "\","
+                + "\"userId\":\"" + userId + "\","
+                + "\"paymentId\":\"" + paymentId + "\","
+                + "\"paymentMethod\":\"PG\","
+                + "\"totalAmount\":30000,"
+                + "\"orderItems\":["
+                + "{\"eventId\":\"" + eventId1 + "\",\"quantity\":2},"
+                + "{\"eventId\":\"" + eventId2 + "\",\"quantity\":1}"
+                + "],"
+                + "\"timestamp\":\"2026-04-20T10:00:00Z\""
+                + "}";
+
+        // when
+        PaymentCompletedEvent event = objectMapper.readValue(payload, PaymentCompletedEvent.class);
+
+        // then
+        assertThat(event.orderId()).isEqualTo(orderId);
+        assertThat(event.userId()).isEqualTo(userId);
+        assertThat(event.paymentId()).isEqualTo(paymentId);
+        assertThat(event.paymentMethod()).isEqualTo(PaymentMethod.PG);
+        assertThat(event.totalAmount()).isEqualTo(30000);
+        assertThat(event.orderItems()).hasSize(2);
+        assertThat(event.orderItems().get(0).eventId()).isEqualTo(eventId1);
+        assertThat(event.orderItems().get(0).quantity()).isEqualTo(2);
+        assertThat(event.orderItems().get(1).eventId()).isEqualTo(eventId2);
+        assertThat(event.orderItems().get(1).quantity()).isEqualTo(1);
+        assertThat(event.timestamp()).isEqualTo(Instant.parse("2026-04-20T10:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("구버전 payload(orderItems 없음) 역직렬화 성공 — 배포 순서 역전 방어")
+    void orderItems_없는_구버전_payload_역직렬화_성공() throws Exception {
+        // given — Payment Producer 구버전 payload (orderItems 필드 없음)
+        UUID orderId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID paymentId = UUID.randomUUID();
+        String payload = "{"
+                + "\"orderId\":\"" + orderId + "\","
+                + "\"userId\":\"" + userId + "\","
+                + "\"paymentId\":\"" + paymentId + "\","
+                + "\"paymentMethod\":\"WALLET\","
+                + "\"totalAmount\":20000,"
+                + "\"timestamp\":\"2026-04-20T10:00:00Z\""
+                + "}";
+
+        // when
+        PaymentCompletedEvent event = objectMapper.readValue(payload, PaymentCompletedEvent.class);
+
+        // then — orderItems 생략 시 Record 기본 null
+        assertThat(event.orderId()).isEqualTo(orderId);
+        assertThat(event.userId()).isEqualTo(userId);
+        assertThat(event.paymentMethod()).isEqualTo(PaymentMethod.WALLET);
+        assertThat(event.totalAmount()).isEqualTo(20000);
+        assertThat(event.orderItems()).isNull();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 필드 포함 payload 역직렬화 성공 — FAIL_ON_UNKNOWN_PROPERTIES=false 효과")
+    void 알수없는_필드_포함_payload_역직렬화_성공() throws Exception {
+        // given — 미래 Producer가 추가할 수 있는 미지 필드 포함
+        UUID orderId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID paymentId = UUID.randomUUID();
+        String payload = "{"
+                + "\"orderId\":\"" + orderId + "\","
+                + "\"userId\":\"" + userId + "\","
+                + "\"paymentId\":\"" + paymentId + "\","
+                + "\"paymentMethod\":\"PG\","
+                + "\"totalAmount\":15000,"
+                + "\"timestamp\":\"2026-04-20T10:00:00Z\","
+                + "\"futureField\":\"unexpectedValue\","
+                + "\"anotherUnknown\":123"
+                + "}";
+
+        // when & then — 알 수 없는 필드 무시하고 역직렬화 성공
+        PaymentCompletedEvent event = objectMapper.readValue(payload, PaymentCompletedEvent.class);
+        assertThat(event.orderId()).isEqualTo(orderId);
+        assertThat(event.totalAmount()).isEqualTo(15000);
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/common/outbox/OutboxEventProducerTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/common/outbox/OutboxEventProducerTest.java
@@ -40,7 +40,7 @@ class OutboxEventProducerTest {
         );
         ArgumentCaptor<ProducerRecord<String, String>> recordCaptor = ArgumentCaptor.forClass(ProducerRecord.class);
         given(kafkaTemplate.send(recordCaptor.capture())).willReturn(sendFuture);
-        given(sendFuture.get(2L, TimeUnit.SECONDS)).willReturn(null);
+        given(sendFuture.get(2000L, TimeUnit.MILLISECONDS)).willReturn(null);
 
         // when
         outboxEventProducer.publish(message);
@@ -61,7 +61,7 @@ class OutboxEventProducerTest {
         // given
         OutboxEventMessage message = new OutboxEventMessage(1L, "message-1", "payment.completed", "order-1", "{}");
         given(kafkaTemplate.send(any(ProducerRecord.class))).willReturn(sendFuture);
-        given(sendFuture.get(2L, TimeUnit.SECONDS)).willThrow(new ExecutionException(new RuntimeException("fail")));
+        given(sendFuture.get(2000L, TimeUnit.MILLISECONDS)).willThrow(new ExecutionException(new RuntimeException("fail")));
 
         // when & then
         assertThatThrownBy(() -> outboxEventProducer.publish(message))
@@ -74,7 +74,7 @@ class OutboxEventProducerTest {
         // given
         OutboxEventMessage message = new OutboxEventMessage(1L, "message-1", "payment.completed", "order-1", "{}");
         given(kafkaTemplate.send(any(ProducerRecord.class))).willReturn(sendFuture);
-        given(sendFuture.get(2L, TimeUnit.SECONDS)).willThrow(new TimeoutException("timeout"));
+        given(sendFuture.get(2000L, TimeUnit.MILLISECONDS)).willThrow(new TimeoutException("timeout"));
 
         // when & then
         assertThatThrownBy(() -> outboxEventProducer.publish(message))
@@ -87,7 +87,7 @@ class OutboxEventProducerTest {
         // given
         OutboxEventMessage message = new OutboxEventMessage(1L, "message-1", "payment.completed", "order-1", "{}");
         given(kafkaTemplate.send(any(ProducerRecord.class))).willReturn(sendFuture);
-        given(sendFuture.get(2L, TimeUnit.SECONDS)).willThrow(new InterruptedException("interrupted"));
+        given(sendFuture.get(2000L, TimeUnit.MILLISECONDS)).willThrow(new InterruptedException("interrupted"));
 
         // when
         Throwable thrown = null;

--- a/commerce/src/test/java/com/devticket/commerce/common/outbox/OutboxSchedulerIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/common/outbox/OutboxSchedulerIntegrationTest.java
@@ -2,8 +2,6 @@ package com.devticket.commerce.common.outbox;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 
 import java.time.Duration;
 import java.util.Map;
@@ -19,13 +17,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -37,8 +37,18 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 )
 class OutboxSchedulerIntegrationTest {
 
-    @MockitoBean
-    private LockProvider lockProvider;
+    // ShedLock JdbcTemplateLockProvider 는 H2(테스트 프로파일)에서 usingDbTime 등
+    // 호환성 이슈가 있고, @MockitoBean Mock stub 타이밍이 AOP 첫 tick 전에
+    // 반영되지 않아 "It's locked" 로 건너뛰는 케이스가 발생함.
+    // 테스트에서는 @Primary NoOp Provider 로 대체해 매 tick 락 획득 성공을 보장.
+    @TestConfiguration
+    static class NoOpLockProviderConfig {
+        @Bean
+        @Primary
+        LockProvider testLockProvider() {
+            return lockConfiguration -> Optional.of(() -> {});
+        }
+    }
 
     @Autowired
     private OutboxRepository outboxRepository;
@@ -50,8 +60,6 @@ class OutboxSchedulerIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        given(lockProvider.lock(any())).willReturn(Optional.of(() -> {}));
-
         Map<String, Object> consumerProperties =
                 KafkaTestUtils.consumerProps("outbox-scheduler-test", "true", embeddedKafkaBroker);
         consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
@@ -84,22 +92,28 @@ class OutboxSchedulerIntegrationTest {
         );
 
         // when & then
-        await()
+        // Kafka 레코드 도착 검증 — poll 후 offset 이동하므로 1회만
+        ConsumerRecord<String, String> record = await()
                 .atMost(Duration.ofSeconds(10))
                 .pollInterval(Duration.ofMillis(500))
+                .until(
+                        () -> {
+                            ConsumerRecords<String, String> records = KafkaTestUtils.getRecords(
+                                    consumer, Duration.ofSeconds(1));
+                            return records.count() > 0 ? records.iterator().next() : null;
+                        },
+                        r -> r != null
+                );
+
+        assertThat(record.key()).isEqualTo("partition-1");
+        assertThat(record.value()).isEqualTo("{\"orderId\":1}");
+        assertThat(record.headers().lastHeader("X-Message-Id")).isNotNull();
+
+        // Outbox 상태 갱신은 발행 직후 별도 트랜잭션으로 커밋되므로 독립 대기
+        await()
+                .atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(200))
                 .untilAsserted(() -> {
-                    ConsumerRecords<String, String> records = KafkaTestUtils.getRecords(
-                            consumer,
-                            Duration.ofSeconds(1)
-                    );
-
-                    assertThat(records.count()).isGreaterThan(0);
-
-                    ConsumerRecord<String, String> record = records.iterator().next();
-                    assertThat(record.key()).isEqualTo("partition-1");
-                    assertThat(record.value()).isEqualTo("{\"orderId\":1}");
-                    assertThat(record.headers().lastHeader("X-Message-Id")).isNotNull();
-
                     Outbox outbox = outboxRepository.findById(saved.getId()).orElseThrow();
                     assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.SENT);
                     assertThat(outbox.getSentAt()).isNotNull();

--- a/commerce/src/test/java/com/devticket/commerce/common/outbox/OutboxSchedulerIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/common/outbox/OutboxSchedulerIntegrationTest.java
@@ -19,13 +19,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -37,72 +37,72 @@ import org.springframework.test.context.ActiveProfiles;
 )
 class OutboxSchedulerIntegrationTest {
 
-//    @MockitoBean
-//    private LockProvider lockProvider;
-//
-//    @Autowired
-//    private OutboxRepository outboxRepository;
-//
-//    @Autowired
-//    private EmbeddedKafkaBroker embeddedKafkaBroker;
-//
-//    private Consumer<String, String> consumer;
-//
-//    @BeforeEach
-//    void setUp() {
-//        given(lockProvider.lock(any())).willReturn(Optional.of(() -> {}));
-//
-//        Map<String, Object> consumerProperties =
-//                KafkaTestUtils.consumerProps("outbox-scheduler-test", "true", embeddedKafkaBroker);
-//        consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-//        consumer = new DefaultKafkaConsumerFactory<>(
-//                consumerProperties,
-//                new StringDeserializer(),
-//                new StringDeserializer()
-//        ).createConsumer();
-//        embeddedKafkaBroker.consumeFromAnEmbeddedTopic(consumer, "payment.completed");
-//    }
-//
-//    @AfterEach
-//    void tearDown() {
-//        if (consumer != null) {
-//            consumer.close();
-//        }
-//    }
-//
-//    @Test
-//    void publishPendingEvents_대기중인_레코드를_발행하고_SENT로_변경한다() {
-//        // given
-//        Outbox saved = outboxRepository.save(
-//                Outbox.create(
-//                        "aggregate-1",
-//                        "partition-1",
-//                        "PaymentCompleted",
-//                        "payment.completed",
-//                        "{\"orderId\":1}"
-//                )
-//        );
-//
-//        // when & then
-//        await()
-//                .atMost(Duration.ofSeconds(10))
-//                .pollInterval(Duration.ofMillis(500))
-//                .untilAsserted(() -> {
-//                    ConsumerRecords<String, String> records = KafkaTestUtils.getRecords(
-//                            consumer,
-//                            Duration.ofSeconds(1)
-//                    );
-//
-//                    assertThat(records.count()).isGreaterThan(0);
-//
-//                    ConsumerRecord<String, String> record = records.iterator().next();
-//                    assertThat(record.key()).isEqualTo("partition-1");
-//                    assertThat(record.value()).isEqualTo("{\"orderId\":1}");
-//                    assertThat(record.headers().lastHeader("X-Message-Id")).isNotNull();
-//
-//                    Outbox outbox = outboxRepository.findById(saved.getId()).orElseThrow();
-//                    assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.SENT);
-//                    assertThat(outbox.getSentAt()).isNotNull();
-//                });
-//    }
+    @MockitoBean
+    private LockProvider lockProvider;
+
+    @Autowired
+    private OutboxRepository outboxRepository;
+
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    private Consumer<String, String> consumer;
+
+    @BeforeEach
+    void setUp() {
+        given(lockProvider.lock(any())).willReturn(Optional.of(() -> {}));
+
+        Map<String, Object> consumerProperties =
+                KafkaTestUtils.consumerProps("outbox-scheduler-test", "true", embeddedKafkaBroker);
+        consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumer = new DefaultKafkaConsumerFactory<>(
+                consumerProperties,
+                new StringDeserializer(),
+                new StringDeserializer()
+        ).createConsumer();
+        embeddedKafkaBroker.consumeFromAnEmbeddedTopic(consumer, "payment.completed");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (consumer != null) {
+            consumer.close();
+        }
+    }
+
+    @Test
+    void publishPendingEvents_대기중인_레코드를_발행하고_SENT로_변경한다() {
+        // given
+        Outbox saved = outboxRepository.save(
+                Outbox.create(
+                        "aggregate-1",
+                        "partition-1",
+                        "PaymentCompleted",
+                        "payment.completed",
+                        "{\"orderId\":1}"
+                )
+        );
+
+        // when & then
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    ConsumerRecords<String, String> records = KafkaTestUtils.getRecords(
+                            consumer,
+                            Duration.ofSeconds(1)
+                    );
+
+                    assertThat(records.count()).isGreaterThan(0);
+
+                    ConsumerRecord<String, String> record = records.iterator().next();
+                    assertThat(record.key()).isEqualTo("partition-1");
+                    assertThat(record.value()).isEqualTo("{\"orderId\":1}");
+                    assertThat(record.headers().lastHeader("X-Message-Id")).isNotNull();
+
+                    Outbox outbox = outboxRepository.findById(saved.getId()).orElseThrow();
+                    assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.SENT);
+                    assertThat(outbox.getSentAt()).isNotNull();
+                });
+    }
 }

--- a/commerce/src/test/java/com/devticket/commerce/integration/ActionLogProducerIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/ActionLogProducerIntegrationTest.java
@@ -1,0 +1,237 @@
+package com.devticket.commerce.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+
+import com.devticket.commerce.cart.application.usecase.CartItemUseCase;
+import com.devticket.commerce.cart.application.usecase.CartUseCase;
+import com.devticket.commerce.cart.domain.model.Cart;
+import com.devticket.commerce.cart.domain.model.CartItem;
+import com.devticket.commerce.cart.domain.repository.CartItemRepository;
+import com.devticket.commerce.cart.domain.repository.CartRepository;
+import com.devticket.commerce.cart.infrastructure.external.client.EventClient;
+import com.devticket.commerce.cart.infrastructure.external.client.dto.InternalPurchaseValidationResponse;
+import com.devticket.commerce.cart.presentation.dto.req.CartItemRequest;
+import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.common.messaging.event.ActionLogEvent;
+import com.devticket.commerce.common.messaging.event.ActionType;
+import com.devticket.commerce.common.outbox.OutboxRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import net.javacrumbs.shedlock.core.LockProvider;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * action.log Producer 통합 테스트.
+ *
+ * <p>검증 대상:
+ * <ul>
+ *   <li>CartService → ApplicationEventPublisher → @TransactionalEventListener(AFTER_COMMIT) → Kafka 도달
+ *   <li>clearCart N회 발행 정책 (아이템별 eventId 보존)
+ *   <li>Bean 격리 — actionLogKafkaTemplate acks=0 설정 런타임 검증
+ *   <li>Outbox 미개입 — action.log 발행이 outbox 테이블에 INSERT하지 않음
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(
+        partitions = 1,
+        topics = {KafkaTopics.ACTION_LOG, KafkaTopics.ORDER_CREATED},
+        bootstrapServersProperty = "spring.kafka.bootstrap-servers"
+)
+@DirtiesContext
+class ActionLogProducerIntegrationTest {
+
+    @MockitoBean private LockProvider lockProvider;
+    @MockitoBean private EventClient eventClient;
+
+    @Autowired private CartUseCase cartUseCase;
+    @Autowired private CartItemUseCase cartItemUseCase;
+    @Autowired private CartRepository cartRepository;
+    @Autowired private CartItemRepository cartItemRepository;
+    @Autowired private OutboxRepository outboxRepository;
+    @Autowired private EmbeddedKafkaBroker embeddedKafka;
+    @Autowired private ObjectMapper objectMapper;
+
+    @Autowired
+    @Qualifier("actionLogKafkaTemplate")
+    private KafkaTemplate<String, String> actionLogKafkaTemplate;
+
+    private Consumer<String, String> consumer;
+
+    @BeforeEach
+    void setUp() {
+        given(lockProvider.lock(any())).willReturn(Optional.of(() -> {}));
+        consumer = createTestConsumer(KafkaTopics.ACTION_LOG);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (consumer != null) {
+            consumer.close();
+        }
+    }
+
+    @Test
+    @DisplayName("save() → CART_ADD 1건 발행 (quantity + totalAmount 포함)")
+    void save_CART_ADD_1건_발행() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        stubEventPrice(eventId, 10_000);
+
+        // when
+        cartUseCase.save(userId, new CartItemRequest(eventId, 2));
+
+        // then
+        ActionLogEvent event = awaitSingleActionLog(userId);
+        assertThat(event.actionType()).isEqualTo(ActionType.CART_ADD);
+        assertThat(event.eventId()).isEqualTo(eventId);
+        assertThat(event.quantity()).isEqualTo(2);
+        assertThat(event.totalAmount()).isEqualTo(20_000L); // 10,000 × 2
+    }
+
+    @Test
+    @DisplayName("clearCart() 2개 아이템 → N회(2회) CART_REMOVE 발행 — eventId별 보존")
+    void clearCart_N회_발행() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID eventA = UUID.randomUUID();
+        UUID eventB = UUID.randomUUID();
+
+        Cart cart = cartRepository.save(Cart.create(userId));
+        cartItemRepository.save(CartItem.create(cart.getId(), eventA, 1));
+        cartItemRepository.save(CartItem.create(cart.getId(), eventB, 3));
+
+        stubEventPrice(eventA, 5_000);
+        stubEventPrice(eventB, 7_000);
+
+        // when
+        cartUseCase.clearCart(userId);
+
+        // then — 2건 수신, eventId별 1건씩
+        List<ActionLogEvent> events = awaitActionLogs(userId, 2);
+        assertThat(events).hasSize(2);
+        assertThat(events).allSatisfy(e -> assertThat(e.actionType()).isEqualTo(ActionType.CART_REMOVE));
+        assertThat(events).extracting(ActionLogEvent::eventId)
+                .containsExactlyInAnyOrder(eventA, eventB);
+    }
+
+    @Test
+    @DisplayName("deleteTicket() → CART_REMOVE 1건 발행 (eventClient 추가 조회로 totalAmount 산출)")
+    void deleteTicket_CART_REMOVE_발행() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+
+        Cart cart = cartRepository.save(Cart.create(userId));
+        CartItem item = cartItemRepository.save(CartItem.create(cart.getId(), eventId, 3));
+
+        stubEventPrice(eventId, 8_000);
+
+        // when
+        cartItemUseCase.deleteTicket(userId, item.getId());
+
+        // then
+        ActionLogEvent event = awaitSingleActionLog(userId);
+        assertThat(event.actionType()).isEqualTo(ActionType.CART_REMOVE);
+        assertThat(event.eventId()).isEqualTo(eventId);
+        assertThat(event.quantity()).isEqualTo(3);
+        assertThat(event.totalAmount()).isEqualTo(24_000L); // 8,000 × 3
+    }
+
+    @Test
+    @DisplayName("Bean 격리 검증 — actionLogKafkaTemplate은 acks=0 (기존 @Primary kafkaTemplate과 분리)")
+    void Bean_격리_actionLogKafkaTemplate_acks_0() {
+        ProducerFactory<String, String> pf = actionLogKafkaTemplate.getProducerFactory();
+        Map<String, Object> config = pf.getConfigurationProperties();
+
+        assertThat(config.get("acks")).isEqualTo("0");
+        assertThat(config.get("retries")).isEqualTo(0);
+        assertThat(config.get("enable.idempotence")).isEqualTo(false);
+        assertThat(config.get("linger.ms")).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("Outbox 미개입 — action.log 발행이 outbox 테이블에 INSERT하지 않음")
+    void Outbox_미개입() throws Exception {
+        // given
+        long outboxCountBefore = outboxRepository.count();
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        stubEventPrice(eventId, 10_000);
+
+        // when
+        cartUseCase.save(userId, new CartItemRequest(eventId, 1));
+
+        // then — Kafka 메시지 수신 확인 후 outbox count 불변
+        awaitSingleActionLog(userId);
+        assertThat(outboxRepository.count()).isEqualTo(outboxCountBefore);
+    }
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────
+
+    private void stubEventPrice(UUID eventId, int price) {
+        given(eventClient.getValidateEventStatus(any(), any(), anyInt()))
+                .willReturn(new InternalPurchaseValidationResponse(
+                        eventId, Boolean.TRUE, null, 10, "테스트-이벤트", price));
+    }
+
+    private ActionLogEvent awaitSingleActionLog(UUID expectedUserId) throws Exception {
+        List<ActionLogEvent> events = awaitActionLogs(expectedUserId, 1);
+        return events.get(0);
+    }
+
+    private List<ActionLogEvent> awaitActionLogs(UUID expectedUserId, int expectedCount) throws Exception {
+        long deadline = System.currentTimeMillis() + 10_000L;
+        java.util.List<ActionLogEvent> collected = new java.util.ArrayList<>();
+
+        while (System.currentTimeMillis() < deadline && collected.size() < expectedCount) {
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(500));
+            for (ConsumerRecord<String, String> record : records) {
+                if (expectedUserId.toString().equals(record.key())) {
+                    collected.add(objectMapper.readValue(record.value(), ActionLogEvent.class));
+                }
+            }
+        }
+
+        assertThat(collected).hasSize(expectedCount);
+        return collected;
+    }
+
+    private Consumer<String, String> createTestConsumer(String topic) {
+        Map<String, Object> props = org.springframework.kafka.test.utils.KafkaTestUtils.consumerProps(
+                "action-log-it-" + UUID.randomUUID(), "true", embeddedKafka);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        Consumer<String, String> c = new DefaultKafkaConsumerFactory<>(
+                props, new StringDeserializer(), new StringDeserializer()
+        ).createConsumer();
+        c.subscribe(List.of(topic));
+        return c;
+    }
+}

--- a/commerce/src/test/java/com/devticket/commerce/integration/ActionLogProducerIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/ActionLogProducerIntegrationTest.java
@@ -13,13 +13,16 @@ import com.devticket.commerce.cart.domain.repository.CartItemRepository;
 import com.devticket.commerce.cart.domain.repository.CartRepository;
 import com.devticket.commerce.cart.infrastructure.external.client.EventClient;
 import com.devticket.commerce.cart.infrastructure.external.client.dto.InternalPurchaseValidationResponse;
+import com.devticket.commerce.cart.presentation.dto.req.CartItemQuantityRequest;
 import com.devticket.commerce.cart.presentation.dto.req.CartItemRequest;
 import com.devticket.commerce.common.messaging.KafkaTopics;
+import com.devticket.commerce.common.messaging.event.ActionLogDomainEvent;
 import com.devticket.commerce.common.messaging.event.ActionLogEvent;
 import com.devticket.commerce.common.messaging.event.ActionType;
 import com.devticket.commerce.common.outbox.OutboxRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -37,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
@@ -45,6 +49,7 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * action.log Producer 통합 테스트.
@@ -77,6 +82,8 @@ class ActionLogProducerIntegrationTest {
     @Autowired private OutboxRepository outboxRepository;
     @Autowired private EmbeddedKafkaBroker embeddedKafka;
     @Autowired private ObjectMapper objectMapper;
+    @Autowired private ApplicationEventPublisher eventPublisher;
+    @Autowired private TransactionTemplate transactionTemplate;
 
     @Autowired
     @Qualifier("actionLogKafkaTemplate")
@@ -194,6 +201,110 @@ class ActionLogProducerIntegrationTest {
         assertThat(outboxRepository.count()).isEqualTo(outboxCountBefore);
     }
 
+    @Test
+    @DisplayName("롤백 시 미발행 — @TransactionalEventListener(AFTER_COMMIT) 정책 증명")
+    void rollback_시_action_log_미발행() {
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+
+        transactionTemplate.execute(status -> {
+            eventPublisher.publishEvent(new ActionLogDomainEvent(
+                    userId, eventId, ActionType.CART_ADD,
+                    null, null, null, 1, 1_000L, Instant.now()));
+            status.setRollbackOnly();
+            return null;
+        });
+
+        assertNoActionLogFor(userId, Duration.ofSeconds(3));
+    }
+
+    @Test
+    @DisplayName("updateTicket delta 양수 → CART_ADD 발행 (quantity=|delta|)")
+    void updateTicket_delta_양수_CART_ADD() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        Cart cart = cartRepository.save(Cart.create(userId));
+        CartItem item = cartItemRepository.save(CartItem.create(cart.getId(), eventId, 1));
+        stubEventPrice(eventId, 3_000);
+
+        cartItemUseCase.updateTicket(userId, item.getId(), new CartItemQuantityRequest(2));
+
+        ActionLogEvent event = awaitSingleActionLog(userId);
+        assertThat(event.actionType()).isEqualTo(ActionType.CART_ADD);
+        assertThat(event.eventId()).isEqualTo(eventId);
+        assertThat(event.quantity()).isEqualTo(2);
+        assertThat(event.totalAmount()).isEqualTo(6_000L); // 3,000 × 2
+    }
+
+    @Test
+    @DisplayName("updateTicket delta 음수 → CART_REMOVE 발행 (quantity=|delta|)")
+    void updateTicket_delta_음수_CART_REMOVE() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        Cart cart = cartRepository.save(Cart.create(userId));
+        CartItem item = cartItemRepository.save(CartItem.create(cart.getId(), eventId, 5));
+        stubEventPrice(eventId, 4_000);
+
+        cartItemUseCase.updateTicket(userId, item.getId(), new CartItemQuantityRequest(-2));
+
+        ActionLogEvent event = awaitSingleActionLog(userId);
+        assertThat(event.actionType()).isEqualTo(ActionType.CART_REMOVE);
+        assertThat(event.eventId()).isEqualTo(eventId);
+        assertThat(event.quantity()).isEqualTo(2);
+        assertThat(event.totalAmount()).isEqualTo(8_000L); // 4,000 × 2
+    }
+
+    @Test
+    @DisplayName("updateTicket delta 0 → 미발행")
+    void updateTicket_delta_0_미발행() {
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        Cart cart = cartRepository.save(Cart.create(userId));
+        CartItem item = cartItemRepository.save(CartItem.create(cart.getId(), eventId, 1));
+        stubEventPrice(eventId, 5_000);
+
+        cartItemUseCase.updateTicket(userId, item.getId(), new CartItemQuantityRequest(0));
+
+        assertNoActionLogFor(userId, Duration.ofSeconds(3));
+    }
+
+    @Test
+    @DisplayName("fallbackExecution=true — 트랜잭션 없이 publishEvent해도 발행 도달")
+    void fallbackExecution_트랜잭션_없이도_발행() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+
+        // 트랜잭션 경계 없이 직접 publishEvent — fallbackExecution=true 덕에 즉시 발행
+        eventPublisher.publishEvent(new ActionLogDomainEvent(
+                userId, eventId, ActionType.VIEW,
+                null, null, null, null, null, Instant.now()));
+
+        ActionLogEvent event = awaitSingleActionLog(userId);
+        assertThat(event.actionType()).isEqualTo(ActionType.VIEW);
+        assertThat(event.eventId()).isEqualTo(eventId);
+    }
+
+    @Test
+    @DisplayName("deleteTicket — eventClient 예외 시 totalAmount=null로 CART_REMOVE 발행 (fetchEventPriceSafely 복원력)")
+    void deleteTicket_eventClient_예외_시_totalAmount_null_CART_REMOVE() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        Cart cart = cartRepository.save(Cart.create(userId));
+        CartItem item = cartItemRepository.save(CartItem.create(cart.getId(), eventId, 2));
+
+        // eventClient 전 호출 실패 — price 조회 실패하지만 action.log는 발행되어야 함
+        given(eventClient.getValidateEventStatus(any(), any(), anyInt()))
+                .willThrow(new RuntimeException("event-service down"));
+
+        cartItemUseCase.deleteTicket(userId, item.getId());
+
+        ActionLogEvent event = awaitSingleActionLog(userId);
+        assertThat(event.actionType()).isEqualTo(ActionType.CART_REMOVE);
+        assertThat(event.eventId()).isEqualTo(eventId);
+        assertThat(event.quantity()).isEqualTo(2);
+        assertThat(event.totalAmount()).isNull(); // price 실패 → totalAmount=null
+    }
+
     // ── 헬퍼 ──────────────────────────────────────────────────────────
 
     private void stubEventPrice(UUID eventId, int price) {
@@ -222,6 +333,20 @@ class ActionLogProducerIntegrationTest {
 
         assertThat(collected).hasSize(expectedCount);
         return collected;
+    }
+
+    // 지정 userId 키의 메시지가 timeout 내에 도착하지 않음을 검증 (미발행 시나리오)
+    private void assertNoActionLogFor(UUID expectedUserId, Duration timeout) {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(300));
+            for (ConsumerRecord<String, String> record : records) {
+                if (expectedUserId.toString().equals(record.key())) {
+                    throw new AssertionError(
+                            "예상과 달리 action.log 수신 — key=" + record.key() + ", value=" + record.value());
+                }
+            }
+        }
     }
 
     private Consumer<String, String> createTestConsumer(String topic) {

--- a/commerce/src/test/java/com/devticket/commerce/integration/ConsumerDltIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/ConsumerDltIntegrationTest.java
@@ -125,6 +125,7 @@ class ConsumerDltIntegrationTest {
                 UUID.randomUUID(),
                 PaymentMethod.PG,
                 10_000,
+                List.of(),
                 Instant.now()
         );
 

--- a/commerce/src/test/java/com/devticket/commerce/integration/PaymentCompletedCartIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/PaymentCompletedCartIntegrationTest.java
@@ -245,7 +245,8 @@ class PaymentCompletedCartIntegrationTest {
 
     private String paymentCompletedPayload(UUID orderId, UUID userId, int totalAmount) throws Exception {
         PaymentCompletedEvent event = new PaymentCompletedEvent(
-                orderId, userId, UUID.randomUUID(), PaymentMethod.PG, totalAmount, Instant.now());
+                orderId, userId, UUID.randomUUID(), PaymentMethod.PG, totalAmount,
+                List.of(), Instant.now());
         return objectMapper.writeValueAsString(event);
     }
 }

--- a/commerce/src/test/resources/application-test.yml
+++ b/commerce/src/test/resources/application-test.yml
@@ -25,6 +25,17 @@ spring:
     listener:
       ack-mode: manual
 
+# EmbeddedKafka 첫 발행 메타데이터 워밍 수용 — 운영 기본(500/1000/1500/2000)보다 완화
+# 불변식 유지: max.block(3000) < request(5000) ≤ delivery(8000) < send-timeout-ms(10000)
+devticket:
+  outbox:
+    send-timeout-ms: 10000
+  kafka:
+    producer:
+      delivery-timeout-ms: 8000
+      request-timeout-ms: 5000
+      max-block-ms: 3000
+
 external:
   event-base-url: http://localhost:8082
   payment-base-url: http://localhost:8084


### PR DESCRIPTION
## 배경
Parent Issue #481 — Outbox 이중 발행 완화 (3모듈 공통 작업의 Commerce 축)

> ⚠️ **머지 순서 필수**
> 본 PR은 PR #469에 포함된 커밋 8건과 중첩됩니다.
> **PR #469 머지 후** 본 PR 리뷰·머지 진행 부탁드립니다.
> PR #469 머지 후 본 PR의 diff는 `5e2c3d5` + `e1d53c8` 2커밋으로 자동 축소됩니다.

## 변경 (본 PR 신규 커밋)
- `5e2c3d5` fix(commerce): Outbox 이중 발행 완화 — lockAtMostFor + producer timeout 정합
  1. `@SchedulerLock lockAtMostFor` `30s` → `5m`
  2. KafkaProducer 타임아웃 3종 추가
     - `delivery.timeout.ms=1500`
     - `request.timeout.ms=1000`
     - `max.block.ms=500`
- `e1d53c8` test(commerce): Outbox 이중 발행 완화 회귀 방지 테스트 추가 (본 커밋 상세는 아래 "## 추가 커밋 (테스트 보강)" 참조)

## 근거
- 기존 `30s` 잠금 + Producer 기본 타임아웃(`delivery 120s`) 조합 시 잠금 조기 해제로 동일 Outbox row 중복 스케줄 실행 → 이중 발행
- 앱 `.get(2s)` 이내 Producer 내부 재시도가 확정 종료되도록 정합 → 이중 발행 원인 제거
- `Outbox.markFailed()` 지수 백오프(1/2/4/8/16s, 6회 시도 후 FAILED)를 단일 재시도 메커니즘으로 유지

## 테스트
- `commerce/gradlew -p commerce test` BUILD SUCCESSFUL (1m 41s)

## 추가 커밋 (테스트 보강)
- `e1d53c8` test(commerce): Outbox 이중 발행 완화 회귀 방지 테스트 추가
  - **KafkaProducerConfigTest 신규 (2 tests)**
    - `delivery.timeout.ms` / `request.timeout.ms` / `max.block.ms` / `acks` / `enable.idempotence` 값 고정
    - `OutboxEventProducer.SEND_TIMEOUT_SECONDS` 와의 불변식 가드
      (`max.block < request.timeout ≤ delivery.timeout < SEND_TIMEOUT*1000`)
    - 목적: 향후 `.get(2s)`를 줄이거나 `delivery.timeout.ms`를 2s 이상으로 되돌리는 회귀를 CI에서 즉시 차단
  - **OutboxSchedulerIntegrationTest 복구 (1 test)**
    - 기존 전체 주석 처리 상태 → 활성화
    - EmbeddedKafka + `@MockitoBean LockProvider` 조합으로 Outbox row 저장 → 스케줄러 발행 → Kafka record 수신 + DB `SENT` 전이 E2E 검증

### 실행 결과
- `./gradlew test --tests KafkaProducerConfigTest` — **BUILD SUCCESSFUL** (2 tests)
- `./gradlew test --tests OutboxSchedulerIntegrationTest` — **BUILD SUCCESSFUL** (1 test)

## 후속
- Event / Payment 모듈 동일 작업 별도 PR 예정 (이슈 #481 참조)

관련 Issue: #481