### PR TITLE
[Event] fix: Outbox 이중 발행 완화 (lockAtMostFor + producer timeout 정합)

### DIFF
--- a/event/src/main/java/com/devticket/event/common/config/KafkaProducerConfig.java
+++ b/event/src/main/java/com/devticket/event/common/config/KafkaProducerConfig.java
@@ -29,6 +29,12 @@ public class KafkaProducerConfig {
         props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
         props.put(ProducerConfig.RETRIES_CONFIG, 3);
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
+        // Scheduler lockAtMostFor(5m) 내에서 발행 실패 판정이 끝나도록 타임아웃 경계 고정
+        //   delivery.timeout.ms  ≥ linger.ms + request.timeout.ms
+        //   max.block.ms         = send() 블로킹 상한 (metadata/buffer 대기)
+        props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 1500);
+        props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000);
+        props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 500);
         return new DefaultKafkaProducerFactory<>(props);
     }
 

--- a/event/src/main/java/com/devticket/event/common/outbox/OutboxEventProducer.java
+++ b/event/src/main/java/com/devticket/event/common/outbox/OutboxEventProducer.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeoutException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
@@ -43,12 +44,20 @@ public class OutboxEventProducer {
             kafkaTemplate.send(record).get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             log.debug("Outbox 발행 성공 — topic={}, messageId={}", message.topic(), message.messageId());
             return true;
-        } catch (ExecutionException | InterruptedException | TimeoutException e) {
-            log.error("Outbox 발행 실패 — topic={}, messageId={}, error={}",
+        } catch (ExecutionException | TimeoutException e) {
+            // future 결과 대기 중 실패 — broker ack 실패 / send 타임아웃
+            log.error("Outbox 발행 실패 (future) — topic={}, messageId={}, error={}",
                     message.topic(), message.messageId(), e.getMessage());
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
+            return false;
+        } catch (InterruptedException e) {
+            log.error("Outbox 발행 인터럽트 — topic={}, messageId={}", message.topic(), message.messageId());
+            Thread.currentThread().interrupt();
+            return false;
+        } catch (KafkaException e) {
+            // send() 호출 시점 런타임 예외 — max.block.ms 초과(TimeoutException),
+            // 직렬화 실패(SerializationException), 메타데이터 실패 등
+            log.error("Outbox 발행 실패 (send) — topic={}, messageId={}, error={}",
+                    message.topic(), message.messageId(), e.getMessage());
             return false;
         }
     }

--- a/event/src/main/java/com/devticket/event/common/outbox/OutboxEventProducer.java
+++ b/event/src/main/java/com/devticket/event/common/outbox/OutboxEventProducer.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 public class OutboxEventProducer {
 
     private static final String MESSAGE_ID_HEADER = "X-Message-Id";
-    private static final long SEND_TIMEOUT_SECONDS = 5L;
+    private static final long SEND_TIMEOUT_SECONDS = 2L;
 
     private final KafkaTemplate<String, String> kafkaTemplate;
 

--- a/event/src/main/java/com/devticket/event/common/outbox/OutboxScheduler.java
+++ b/event/src/main/java/com/devticket/event/common/outbox/OutboxScheduler.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Outbox 스케줄러 — 미발행 이벤트를 Kafka로 폴링 발행
@@ -21,6 +20,10 @@ import org.springframework.transaction.annotation.Transactional;
  *   <li>5회: 8초 후</li>
  *   <li>6회: 16초 후 → 실패 시 FAILED 처리</li>
  * </ul>
+ *
+ * <p>건별 발행 처리는 {@link OutboxService#processOne(Outbox)} 으로 위임한다.
+ * 자기 자신 호출(self-invocation)은 Spring AOP 프록시를 우회하여
+ * {@code @Transactional} 이 무효화되므로 별도 빈(OutboxService) 분리가 필수.
  *
  * <p>ShedLock으로 분산 환경 중복 실행 방지.
  * shedlock 테이블 DDL:
@@ -39,13 +42,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OutboxScheduler {
 
-    private static final int MAX_RETRIES = 6;
-
     private final OutboxRepository outboxRepository;
-    private final OutboxEventProducer outboxEventProducer;
+    private final OutboxService outboxService;
 
     @Scheduled(fixedDelay = 3_000)
-    @SchedulerLock(name = "outbox-scheduler", lockAtMostFor = "30s", lockAtLeastFor = "5s")
+    @SchedulerLock(name = "outbox-scheduler", lockAtMostFor = "5m", lockAtLeastFor = "5s")
     public void publishPendingEvents() {
         List<Outbox> pendingOutboxes =
                 outboxRepository.findPendingOutboxes(OutboxStatus.PENDING, Instant.now());
@@ -57,25 +58,7 @@ public class OutboxScheduler {
         log.debug("Outbox 발행 대상: {}건", pendingOutboxes.size());
 
         for (Outbox outbox : pendingOutboxes) {
-            processOutbox(outbox);
+            outboxService.processOne(outbox);
         }
-    }
-
-    @Transactional
-    public void processOutbox(Outbox outbox) {
-        OutboxEventMessage message = OutboxEventMessage.from(outbox);
-        boolean success = outboxEventProducer.publish(message);
-
-        if (success) {
-            outbox.markSent();
-        } else {
-            outbox.markFailed(MAX_RETRIES);
-            if (outbox.getStatus() == OutboxStatus.FAILED) {
-                log.error("Outbox 최대 재시도 초과 → FAILED — outboxId={}, topic={}, messageId={}",
-                        outbox.getId(), outbox.getTopic(), outbox.getMessageId());
-            }
-        }
-
-        outboxRepository.save(outbox);
     }
 }

--- a/event/src/main/java/com/devticket/event/common/outbox/OutboxService.java
+++ b/event/src/main/java/com/devticket/event/common/outbox/OutboxService.java
@@ -50,9 +50,20 @@ public class OutboxService {
     /**
      * Outbox 한 건을 Kafka에 발행하고 상태를 반영한다.
      * Kafka 발행은 트랜잭션 밖, 상태 저장은 {@code save()} 자체 트랜잭션에서 수행.
+     *
+     * <p>publish() 가 예상 외 RuntimeException 을 던져도 markFailed/save 를 보장해야
+     * Scheduler 루프가 중단되지 않고 동일 레코드의 무한 고착을 막을 수 있다.
      */
     public void processOne(Outbox outbox) {
-        boolean success = outboxEventProducer.publish(OutboxEventMessage.from(outbox));
+        boolean success;
+        try {
+            success = outboxEventProducer.publish(OutboxEventMessage.from(outbox));
+        } catch (RuntimeException e) {
+            log.error("Outbox 발행 중 예외 전파 — outboxId={}, topic={}, messageId={}, error={}",
+                    outbox.getId(), outbox.getTopic(), outbox.getMessageId(), e.getMessage(), e);
+            success = false;
+        }
+
         if (success) {
             outbox.markSent();
         } else {

--- a/event/src/main/java/com/devticket/event/common/outbox/OutboxService.java
+++ b/event/src/main/java/com/devticket/event/common/outbox/OutboxService.java
@@ -3,21 +3,30 @@ package com.devticket.event.common.outbox;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Outbox 저장 서비스 — 비즈니스 트랜잭션 내부에서 호출
+ * Outbox 저장·건별 발행 서비스
  *
- * <p>호출 원칙: 비즈니스 로직과 반드시 단일 @Transactional 경계 안에서 호출해야 한다.
+ * <p>저장 경로({@link #save}) — 비즈니스 트랜잭션 내부에서 호출.
  * 트랜잭션 커밋이 되어야 비로소 OutboxScheduler가 발행 대상으로 인식한다.
+ *
+ * <p>발행 경로({@link #processOne}) — OutboxScheduler가 건별로 호출.
+ * Scheduler와 동일 클래스에서 호출하면 self-invocation으로 @Transactional이 무효화되므로
+ * 별도 빈으로 분리한다.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OutboxService {
 
+    static final int MAX_RETRIES = 6;
+
     private final OutboxRepository outboxRepository;
+    private final OutboxEventProducer outboxEventProducer;
     private final ObjectMapper objectMapper;
 
     /**
@@ -35,6 +44,24 @@ public class OutboxService {
                      String eventType, String topic, Object event) {
         String payload = serialize(event);
         Outbox outbox = Outbox.create(aggregateId, partitionKey, eventType, topic, payload);
+        outboxRepository.save(outbox);
+    }
+
+    /**
+     * Outbox 한 건을 Kafka에 발행하고 상태를 반영한다.
+     * Kafka 발행은 트랜잭션 밖, 상태 저장은 {@code save()} 자체 트랜잭션에서 수행.
+     */
+    public void processOne(Outbox outbox) {
+        boolean success = outboxEventProducer.publish(OutboxEventMessage.from(outbox));
+        if (success) {
+            outbox.markSent();
+        } else {
+            outbox.markFailed(MAX_RETRIES);
+            if (outbox.getStatus() == OutboxStatus.FAILED) {
+                log.error("Outbox 최대 재시도 초과 → FAILED — outboxId={}, topic={}, messageId={}",
+                        outbox.getId(), outbox.getTopic(), outbox.getMessageId());
+            }
+        }
         outboxRepository.save(outbox);
     }
 

--- a/event/src/test/java/com/devticket/event/common/outbox/OutboxServiceTest.java
+++ b/event/src/test/java/com/devticket/event/common/outbox/OutboxServiceTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.UUID;
+import org.apache.kafka.common.KafkaException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -91,6 +92,23 @@ class OutboxServiceTest {
         assertThat(outbox.getRetryCount()).isEqualTo(1);
         assertThat(outbox.getNextRetryAt()).isNotNull();
         assertThat(outbox.getSentAt()).isNull();
+        then(outboxRepository).should().save(outbox);
+    }
+
+    @Test
+    void processOne_publish가_KafkaException을_던져도_markFailed후_저장한다() {
+        // given — publish() 가 send() 시점 KafkaException (max.block.ms 초과 등) 을 전파
+        Outbox outbox = pendingOutbox();
+        given(outboxEventProducer.publish(any(OutboxEventMessage.class)))
+                .willThrow(new KafkaException("max.block.ms expired while fetching metadata"));
+
+        // when — processOne 은 예외를 최후 방어선에서 흡수해야 함
+        outboxService.processOne(outbox);
+
+        // then — 루프 중단 방지 위해 markFailed + save 보장
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PENDING);
+        assertThat(outbox.getRetryCount()).isEqualTo(1);
+        assertThat(outbox.getNextRetryAt()).isNotNull();
         then(outboxRepository).should().save(outbox);
     }
 

--- a/event/src/test/java/com/devticket/event/common/outbox/OutboxServiceTest.java
+++ b/event/src/test/java/com/devticket/event/common/outbox/OutboxServiceTest.java
@@ -1,0 +1,125 @@
+package com.devticket.event.common.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxServiceTest {
+
+    @Mock
+    private OutboxRepository outboxRepository;
+
+    @Mock
+    private OutboxEventProducer outboxEventProducer;
+
+    @Spy
+    private ObjectMapper objectMapper = JsonMapper.builder()
+            .addModule(new JavaTimeModule())
+            .build();
+
+    @InjectMocks
+    private OutboxService outboxService;
+
+    @Test
+    void save_호출시_직렬화된_이벤트를_Outbox로_저장한다() {
+        // given
+        String aggregateId = UUID.randomUUID().toString();
+        String partitionKey = aggregateId;
+        String eventType = "STOCK_DEDUCTED";
+        String topic = "stock.deducted";
+        SamplePayload event = new SamplePayload("v1", 42);
+
+        // when
+        outboxService.save(aggregateId, partitionKey, eventType, topic, event);
+
+        // then
+        ArgumentCaptor<Outbox> captor = ArgumentCaptor.forClass(Outbox.class);
+        then(outboxRepository).should().save(captor.capture());
+        Outbox saved = captor.getValue();
+        assertThat(saved.getAggregateId()).isEqualTo(aggregateId);
+        assertThat(saved.getPartitionKey()).isEqualTo(partitionKey);
+        assertThat(saved.getEventType()).isEqualTo(eventType);
+        assertThat(saved.getTopic()).isEqualTo(topic);
+        assertThat(saved.getPayload()).contains("\"name\":\"v1\"").contains("\"value\":42");
+        assertThat(saved.getStatus()).isEqualTo(OutboxStatus.PENDING);
+        assertThat(saved.getRetryCount()).isZero();
+        assertThat(saved.getMessageId()).isNotBlank();
+    }
+
+    @Test
+    void processOne_성공시_SENT로_변경하고_저장한다() {
+        // given
+        Outbox outbox = pendingOutbox();
+        given(outboxEventProducer.publish(any(OutboxEventMessage.class))).willReturn(true);
+
+        // when
+        outboxService.processOne(outbox);
+
+        // then
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.SENT);
+        assertThat(outbox.getSentAt()).isNotNull();
+        assertThat(outbox.getRetryCount()).isZero();
+        then(outboxRepository).should().save(outbox);
+    }
+
+    @Test
+    void processOne_발행_실패시_markFailed후_저장한다() {
+        // given
+        Outbox outbox = pendingOutbox();
+        given(outboxEventProducer.publish(any(OutboxEventMessage.class))).willReturn(false);
+
+        // when
+        outboxService.processOne(outbox);
+
+        // then
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PENDING);
+        assertThat(outbox.getRetryCount()).isEqualTo(1);
+        assertThat(outbox.getNextRetryAt()).isNotNull();
+        assertThat(outbox.getSentAt()).isNull();
+        then(outboxRepository).should().save(outbox);
+    }
+
+    @Test
+    void processOne_여섯번째_실패시_FAILED로_저장한다() {
+        // given
+        Outbox outbox = pendingOutbox();
+        ReflectionTestUtils.setField(outbox, "retryCount", 5);
+        given(outboxEventProducer.publish(any(OutboxEventMessage.class))).willReturn(false);
+
+        // when
+        outboxService.processOne(outbox);
+
+        // then
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
+        assertThat(outbox.getRetryCount()).isEqualTo(6);
+        then(outboxRepository).should().save(outbox);
+    }
+
+    private Outbox pendingOutbox() {
+        return Outbox.create(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                "STOCK_DEDUCTED",
+                "stock.deducted",
+                "{\"dummy\":true}"
+        );
+    }
+
+    private record SamplePayload(String name, int value) {
+    }
+}


### PR DESCRIPTION
## Summary
- self-invocation 해소: `OutboxScheduler.processOutbox()` 제거 → `OutboxService.processOne()` 별도 빈 이관. Spring AOP 프록시 우회로 `@Transactional` 무효화되던 문제 제거. Scheduler는 락·조회·루프만, 건별 발행은 Service 담당
- Scheduler 락(`lockAtMostFor` 30s→5m)이 Producer 타임아웃 누적 대기보다 짧게 풀려 중복 실행 창이 열리던 것 차단
- Producer 타임아웃 경계 고정: `delivery.timeout.ms=1500` / `request.timeout.ms=1000` / `max.block.ms=500` 신설, `OutboxEventProducer.get()` 5s→2s — 앱/Kafka 타임아웃 이중 대기 제거
- `MAX_RETRIES` 상수 Scheduler → Service 이관 (처리 주체 기준 배치)
- `OutboxServiceTest` 신규 — save 1 + processOne 3케이스(성공/실패/6번째 FAILED) 추가 (Commerce 선례 정합)

## 본 PR 스코프 밖 (후속 PR)
- Producer `publish()` 시그니처 `boolean` → `void throws OutboxPublishException` 전환
- Repository 쿼리 메서드명 / 연산자 / `markFailed` 상수 내부화 (3모듈 공통 선택 항목)
- 패키지 경로 `common.outbox` → `infrastructure.messaging` 이관 (F2, 3모듈 공통)
- `docs/kafka-design.md` / `docs/kafka-impl-plan.md` 갱신 (3모듈 코드 정합 완료 후 일괄)

## Test plan
- [x] `:event:compileJava` / `:event:compileTestJava` 통과 (로컬)                                                                                                                                                                   
- [x] `:event:test --tests "*OutboxServiceTest"` 5케이스 전부 green (로컬)
- [x] 기존 Outbox/Kafka 스코프 테스트 회귀 없음 (로컬) 
- [ ] CI green
- [ ] 수동: Scheduler 락 5m 유지 확인, `DELIVERY_TIMEOUT_MS`/`REQUEST_TIMEOUT_MS`/`MAX_BLOCK_MS` 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)