### PR TITLE
[Settlement] Feat : 월정산 batch, 월정산내역 조회API, 익월예상정산내역 조회 API

### DIFF
--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalService.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalService.java
@@ -17,4 +17,6 @@ public interface SettlementInternalService {
     );
 
     void runSettlement();
+
+    void createSettlementFromItems();
 }

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalServiceImpl.java
@@ -4,8 +4,11 @@ import com.devticket.settlement.common.exception.BusinessException;
 import com.devticket.settlement.domain.exception.SettlementErrorCode;
 import com.devticket.settlement.domain.model.FeePolicy;
 import com.devticket.settlement.domain.model.Settlement;
+import com.devticket.settlement.domain.model.SettlementItem;
+import com.devticket.settlement.domain.model.SettlementItemStatus;
 import com.devticket.settlement.domain.model.SettlementStatus;
 import com.devticket.settlement.domain.repository.FeePolicyRepository;
+import com.devticket.settlement.domain.repository.SettlementItemRepository;
 import com.devticket.settlement.domain.repository.SettlementRepository;
 import com.devticket.settlement.infrastructure.client.SettlementToCommerceClient;
 import com.devticket.settlement.infrastructure.client.SettlementToMemberClient;
@@ -15,9 +18,13 @@ import com.devticket.settlement.infrastructure.external.dto.InternalSettlementPa
 import com.devticket.settlement.infrastructure.external.dto.InternalSettlementResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -35,6 +42,7 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
     private final SettlementToMemberClient settlementToMemberClient;
     private final FeePolicyRepository feePolicyRepository;
     private final SettlementRepository settlementRepository;
+    private final SettlementItemRepository settlementItemRepository;
 
     @Transactional(readOnly = true)
     public InternalSettlementPageResponse getSettlements(
@@ -117,6 +125,101 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
             } catch (Exception e) {
                 log.warn("[정산 실패] sellerId: {}", sellerId, e);
             }
+        }
+    }
+
+    private static final int MIN_SETTLEMENT_AMOUNT = 10_000;
+
+    @Transactional
+    public void createSettlementFromItems() {
+        LocalDate periodFrom = YearMonth.now().minusMonths(2).atDay(26);
+        LocalDate periodTo = YearMonth.now().minusMonths(1).atDay(25);
+        LocalDateTime settlementPeriodStart = periodFrom.atStartOfDay();
+        LocalDateTime settlementPeriodEnd = periodTo.atTime(23, 59, 59);
+
+        List<SettlementItem> targetItems = settlementItemRepository
+            .findByStatusAndEventDateTimeBetween(SettlementItemStatus.READY, periodFrom, periodTo);
+
+        log.info("[정산 생성] 대상 기간: {} ~ {}, 항목: {}건", periodFrom, periodTo, targetItems.size());
+
+        Map<UUID, List<SettlementItem>> itemsBySeller = targetItems.stream()
+            .collect(Collectors.groupingBy(SettlementItem::getSellerId));
+
+        // 이번 달 신규 아이템이 없어도 이월 건이 있는 판매자도 처리해야 하므로
+        // PENDING_MIN_AMOUNT 판매자 목록도 포함
+        List<Settlement> allPendingSettlements = settlementRepository
+            .findByStatus(SettlementStatus.PENDING_MIN_AMOUNT);
+        allPendingSettlements.stream()
+            .map(Settlement::getSellerId)
+            .distinct()
+            .filter(sellerId -> !itemsBySeller.containsKey(sellerId))
+            .forEach(sellerId -> itemsBySeller.put(sellerId, List.of()));
+
+        for (Map.Entry<UUID, List<SettlementItem>> entry : itemsBySeller.entrySet()) {
+            UUID sellerId = entry.getKey();
+            List<SettlementItem> sellerItems = entry.getValue();
+
+            // 이번 달 신규 집계 금액
+            long totalSales = sellerItems.stream().mapToLong(SettlementItem::getSalesAmount).sum();
+            long totalRefund = sellerItems.stream().mapToLong(SettlementItem::getRefundAmount).sum();
+            long totalFee = sellerItems.stream().mapToLong(SettlementItem::getFeeAmount).sum();
+            long newSettlementAmount = sellerItems.stream().mapToLong(SettlementItem::getSettlementAmount).sum();
+
+            // 직전 이월 건 조회 (체인의 최신 노드)
+            List<Settlement> pendingSettlements = settlementRepository
+                .findBySellerIdAndStatus(sellerId, SettlementStatus.PENDING_MIN_AMOUNT);
+            Settlement latestPending = pendingSettlements.stream()
+                .max(Comparator.comparing(Settlement::getCreatedAt))
+                .orElse(null);
+
+            int carriedInAmount = (latestPending != null) ? latestPending.getFinalSettlementAmount() : 0;
+            UUID carriedInSettlementId = (latestPending != null) ? latestPending.getSettlementId() : null;
+            long totalFinalAmount = newSettlementAmount + carriedInAmount;
+
+            SettlementStatus newStatus = (totalFinalAmount >= MIN_SETTLEMENT_AMOUNT)
+                ? SettlementStatus.COMPLETED
+                : SettlementStatus.PENDING_MIN_AMOUNT;
+
+            Settlement settlement = Settlement.builder()
+                .sellerId(sellerId)
+                .periodStartAt(settlementPeriodStart)
+                .periodEndAt(settlementPeriodEnd)
+                .totalSalesAmount((int) totalSales)
+                .totalRefundAmount((int) totalRefund)
+                .totalFeeAmount((int) totalFee)
+                .finalSettlementAmount((int) totalFinalAmount)
+                .carriedInAmount(carriedInAmount)
+                .carriedInSettlementId(carriedInSettlementId)
+                .status(newStatus)
+                .settledAt(LocalDateTime.now())
+                .build();
+
+            settlementRepository.save(settlement);
+
+            // 이월 건 해소 시 체인 전체를 COMPLETED로 변경
+            if (newStatus == SettlementStatus.COMPLETED && latestPending != null) {
+                markChainAsPaidByCarryForward(latestPending);
+            }
+
+            if (!sellerItems.isEmpty()) {
+                sellerItems.forEach(item -> item.finalize(settlement.getSettlementId()));
+                settlementItemRepository.saveAll(sellerItems);
+            }
+
+            log.info("[정산 생성] sellerId={}, items={}건, carriedIn={}, finalAmount={}, status={}",
+                sellerId, sellerItems.size(), carriedInAmount, totalFinalAmount, newStatus);
+        }
+    }
+
+    private void markChainAsPaidByCarryForward(Settlement settlement) {
+        Settlement cursor = settlement;
+        while (cursor != null) {
+            cursor.updateStatus(SettlementStatus.COMPLETED);
+            settlementRepository.save(cursor);
+            UUID nextId = cursor.getCarriedInSettlementId();
+            cursor = (nextId != null)
+                ? settlementRepository.findBySettlementId(nextId).orElse(null)
+                : null;
         }
     }
 

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementService.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementService.java
@@ -22,4 +22,6 @@ public interface SettlementService {
     SettlementTargetPreviewResponse collectSettlementTargets(LocalDate targetDate);
 
     SettlementPeriodResponse getSettlementByPeriod(UUID sellerId, String yearMonth);
+
+    SettlementPeriodResponse getSettlementPreview(UUID sellerId);
 }

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementService.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementService.java
@@ -2,6 +2,7 @@ package com.devticket.settlement.application.service;
 
 import com.devticket.settlement.infrastructure.client.dto.res.InternalSettlementDataResponse;
 import com.devticket.settlement.presentation.dto.SellerSettlementDetailResponse;
+import com.devticket.settlement.presentation.dto.SettlementPeriodResponse;
 import com.devticket.settlement.presentation.dto.SettlementResponse;
 import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse;
 import java.time.LocalDate;
@@ -19,4 +20,6 @@ public interface SettlementService {
     SettlementTargetPreviewResponse previewSettlementTarget(LocalDate targetDate);
 
     SettlementTargetPreviewResponse collectSettlementTargets(LocalDate targetDate);
+
+    SettlementPeriodResponse getSettlementByPeriod(UUID sellerId, String yearMonth);
 }

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
@@ -18,10 +18,13 @@ import com.devticket.settlement.infrastructure.client.dto.res.EventTicketSettlem
 import com.devticket.settlement.infrastructure.client.dto.res.InternalSettlementDataResponse;
 import com.devticket.settlement.presentation.dto.EventItemResponse;
 import com.devticket.settlement.presentation.dto.SellerSettlementDetailResponse;
+import com.devticket.settlement.presentation.dto.SettlementPeriodResponse;
 import com.devticket.settlement.presentation.dto.SettlementResponse;
 import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse;
 import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse.EventSettlementPreview;
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -181,6 +184,31 @@ public class SettlementServiceImpl implements SettlementService {
         );
     }
 
+
+    @Override
+    public SettlementPeriodResponse getSettlementByPeriod(UUID sellerId, String yearMonth) {
+        int year = Integer.parseInt(yearMonth.substring(0, 4));
+        int month = Integer.parseInt(yearMonth.substring(4, 6));
+        LocalDateTime periodStartAt = YearMonth.of(year, month).minusMonths(1).atDay(26).atStartOfDay();
+
+        Settlement settlement = settlementRepository.findBySellerIdAndPeriodStartAt(sellerId, periodStartAt)
+            .orElseThrow(() -> new BusinessException(SettlementErrorCode.SETTLEMENT_NOT_FOUND));
+
+        validateSellerAccess(sellerId, settlement);
+
+        List<EventItemResponse> items = settlementItemRepository.findBySettlementId(settlement.getSettlementId())
+            .stream()
+            .map(this::toResponse)
+            .toList();
+
+        return new SettlementPeriodResponse(
+            settlement.getFinalSettlementAmount(),
+            settlement.getTotalFeeAmount(),
+            settlement.getTotalSalesAmount(),
+            settlement.getCarriedInAmount(),
+            items
+        );
+    }
 
     private void validateSellerAccess(UUID sellerId, Settlement settlement) {
         if (!sellerId.equals(settlement.getSellerId())) {

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
@@ -191,25 +191,27 @@ public class SettlementServiceImpl implements SettlementService {
     public SettlementPeriodResponse getSettlementByPeriod(UUID sellerId, String yearMonth) {
         int year = Integer.parseInt(yearMonth.substring(0, 4));
         int month = Integer.parseInt(yearMonth.substring(4, 6));
-        LocalDateTime periodStartAt = YearMonth.of(year, month).minusMonths(1).atDay(26).atStartOfDay();
+        // 202604 → periodStartAt = 3/26, periodEndAt = 4/25
+        // periodStartAt이 전월 26일 하루(00:00~23:59) 범위로 조회
+        LocalDate periodStartDate = YearMonth.of(year, month).minusMonths(1).atDay(26);
+        LocalDateTime periodStartFrom = periodStartDate.atStartOfDay();
+        LocalDateTime periodStartTo = periodStartDate.atTime(23, 59, 59);
 
-        Settlement settlement = settlementRepository.findBySellerIdAndPeriodStartAt(sellerId, periodStartAt)
-            .orElseThrow(() -> new BusinessException(SettlementErrorCode.SETTLEMENT_NOT_FOUND));
-
-        validateSellerAccess(sellerId, settlement);
-
-        List<EventItemResponse> items = settlementItemRepository.findBySettlementId(settlement.getSettlementId())
-            .stream()
-            .map(this::toResponse)
-            .toList();
-
-        return new SettlementPeriodResponse(
-            settlement.getFinalSettlementAmount(),
-            settlement.getTotalFeeAmount(),
-            settlement.getTotalSalesAmount(),
-            settlement.getCarriedInAmount(),
-            items
-        );
+        return settlementRepository.findBySellerIdAndPeriodStartAtBetween(sellerId, periodStartFrom, periodStartTo)
+            .map(settlement -> {
+                List<EventItemResponse> items = settlementItemRepository.findBySettlementId(settlement.getSettlementId())
+                    .stream()
+                    .map(this::toResponse)
+                    .toList();
+                return new SettlementPeriodResponse(
+                    settlement.getFinalSettlementAmount(),
+                    settlement.getTotalFeeAmount(),
+                    settlement.getTotalSalesAmount(),
+                    settlement.getCarriedInAmount(),
+                    items
+                );
+            })
+            .orElse(new SettlementPeriodResponse(0, 0, 0, 0, List.of()));
     }
 
     @Override

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
@@ -7,6 +7,7 @@ import com.devticket.settlement.domain.model.FeePolicy;
 import com.devticket.settlement.domain.model.Settlement;
 import com.devticket.settlement.domain.model.SettlementItem;
 import com.devticket.settlement.domain.model.SettlementItemStatus;
+import com.devticket.settlement.domain.model.SettlementStatus;
 import com.devticket.settlement.domain.repository.FeePolicyRepository;
 import com.devticket.settlement.domain.repository.SettlementItemRepository;
 import com.devticket.settlement.domain.repository.SettlementRepository;
@@ -23,9 +24,10 @@ import com.devticket.settlement.presentation.dto.SettlementResponse;
 import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse;
 import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse.EventSettlementPreview;
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -206,6 +208,40 @@ public class SettlementServiceImpl implements SettlementService {
             settlement.getTotalFeeAmount(),
             settlement.getTotalSalesAmount(),
             settlement.getCarriedInAmount(),
+            items
+        );
+    }
+
+    @Override
+    public SettlementPeriodResponse getSettlementPreview(UUID sellerId) {
+        LocalDate periodFrom = YearMonth.now().minusMonths(1).atDay(26);
+        LocalDate periodTo = YearMonth.now().atDay(25);
+
+        List<SettlementItem> readyItems = settlementItemRepository
+            .findBySellerIdAndStatusAndEventDateTimeBetween(sellerId, SettlementItemStatus.READY, periodFrom, periodTo);
+
+        long totalSales = readyItems.stream().mapToLong(SettlementItem::getSalesAmount).sum();
+        long totalFee = readyItems.stream().mapToLong(SettlementItem::getFeeAmount).sum();
+        long newSettlementAmount = readyItems.stream().mapToLong(SettlementItem::getSettlementAmount).sum();
+
+        int carriedInAmount = settlementRepository
+            .findBySellerIdAndStatus(sellerId, SettlementStatus.PENDING_MIN_AMOUNT)
+            .stream()
+            .max(Comparator.comparing(Settlement::getCreatedAt))
+            .map(Settlement::getFinalSettlementAmount)
+            .orElse(0);
+
+        long finalSettlementAmount = newSettlementAmount + carriedInAmount;
+
+        List<EventItemResponse> items = readyItems.stream()
+            .map(this::toResponse)
+            .toList();
+
+        return new SettlementPeriodResponse(
+            (int) finalSettlementAmount,
+            (int) totalFee,
+            (int) totalSales,
+            carriedInAmount,
             items
         );
     }

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
@@ -140,6 +140,8 @@ public class SettlementServiceImpl implements SettlementService {
                 continue;
             }
 
+            log.info(event.toString());
+
             SettlementItem item = SettlementItem.builder()
                 .orderItemId(ticketItem.orderItemId())
                 .eventId(event.id())
@@ -150,6 +152,7 @@ public class SettlementServiceImpl implements SettlementService {
                 .feeAmount(feeAmount)
                 .settlementAmount(settlementAmount)
                 .status(SettlementItemStatus.READY)
+                .eventDateTime(event.eventDateTime())
                 .build();
 
             settlementItemRepository.save(item);

--- a/settlement/src/main/java/com/devticket/settlement/domain/model/Settlement.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/model/Settlement.java
@@ -60,12 +60,17 @@ public class Settlement extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @Column(name = "carried_in_amount", nullable = false)
+    private Integer carriedInAmount;
 
-    //    빌더
+    @Column(name = "carried_in_settlement_id")
+    private UUID carriedInSettlementId;
+
+
     @Builder
     public Settlement(Long id, UUID settlementId, UUID sellerId, LocalDateTime periodStartAt, LocalDateTime periodEndAt,
         Integer totalSalesAmount, Integer totalRefundAmount, Integer totalFeeAmount, Integer finalSettlementAmount,
-        SettlementStatus status, LocalDateTime settledAt) {
+        SettlementStatus status, LocalDateTime settledAt, Integer carriedInAmount, UUID carriedInSettlementId) {
         this.id = id;
         this.settlementId = (settlementId != null) ? settlementId : UUID.randomUUID();
         this.sellerId = sellerId;
@@ -75,10 +80,15 @@ public class Settlement extends BaseEntity {
         this.totalRefundAmount = totalRefundAmount;
         this.totalFeeAmount = totalFeeAmount;
         this.finalSettlementAmount = finalSettlementAmount;
-        this.status = (status != null) ? status : SettlementStatus.PENDING;
+        this.status = (status != null) ? status : SettlementStatus.COMPLETED;
         this.settledAt = settledAt;
+        this.carriedInAmount = (carriedInAmount != null) ? carriedInAmount : 0;
+        this.carriedInSettlementId = carriedInSettlementId;
     }
 
+    public void updateStatus(SettlementStatus status) {
+        this.status = status;
+    }
 
 }
 

--- a/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementItem.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementItem.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -57,11 +58,15 @@ public class SettlementItem extends BaseEntity {
     @Column(name = "settlement_amount", nullable = false)
     private Long settlementAmount;
 
+    @Column(name = "event_date_time", nullable = false)
+    private LocalDate eventDateTime;
+
 
     @Builder
     public SettlementItem(UUID settlementId, UUID orderItemId, Long eventId, UUID eventUUID,
         UUID sellerId, SettlementItemStatus status,
-        Long salesAmount, Long refundAmount, Long feeAmount, Long settlementAmount) {
+        Long salesAmount, Long refundAmount, Long feeAmount, Long settlementAmount,
+        LocalDate eventDateTime) {
         this.settlementId = settlementId;
         this.orderItemId = orderItemId;
         this.eventId = eventId;
@@ -72,6 +77,12 @@ public class SettlementItem extends BaseEntity {
         this.refundAmount = refundAmount;
         this.feeAmount = feeAmount;
         this.settlementAmount = settlementAmount;
+        this.eventDateTime = eventDateTime;
+    }
+
+    public void finalize(UUID settlementId) {
+        this.settlementId = settlementId;
+        this.status = SettlementItemStatus.FINALIZED;
     }
 
 }

--- a/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementStatus.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementStatus.java
@@ -1,7 +1,7 @@
 package com.devticket.settlement.domain.model;
 
 public enum SettlementStatus {
-    PENDING,
-    COMPLETED,
-    FAILED
+    COMPLETED,          // 정산 완료 (최소 정산금액 충족)
+    PENDING_MIN_AMOUNT, // 정산 보류 (최소 정산금액 미달, 다음 달 이월)
+    CANCELLED           // 정산 취소
 }

--- a/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementItemRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementItemRepository.java
@@ -16,6 +16,9 @@ public interface SettlementItemRepository {
     List<SettlementItem> findByStatusAndEventDateTimeBetween(
         SettlementItemStatus status, LocalDate from, LocalDate to);
 
+    List<SettlementItem> findBySellerIdAndStatusAndEventDateTimeBetween(
+        UUID sellerId, SettlementItemStatus status, LocalDate from, LocalDate to);
+
     List<SettlementItem> saveAll(List<SettlementItem> items);
 
 }

--- a/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementItemRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementItemRepository.java
@@ -1,10 +1,9 @@
 package com.devticket.settlement.domain.repository;
-
-import com.devticket.settlement.domain.model.Settlement;
 import com.devticket.settlement.domain.model.SettlementItem;
+import com.devticket.settlement.domain.model.SettlementItemStatus;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SettlementItemRepository {
 
@@ -13,5 +12,10 @@ public interface SettlementItemRepository {
     boolean existsByOrderItemId(UUID orderItemId);
 
     SettlementItem save(SettlementItem settlementItem);
+
+    List<SettlementItem> findByStatusAndEventDateTimeBetween(
+        SettlementItemStatus status, LocalDate from, LocalDate to);
+
+    List<SettlementItem> saveAll(List<SettlementItem> items);
 
 }

--- a/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementRepository.java
@@ -19,6 +19,8 @@ public interface SettlementRepository {
 
     List<Settlement> findByStatus(SettlementStatus status);
 
+    Optional<Settlement> findBySellerIdAndPeriodStartAt(UUID sellerId, LocalDateTime periodStartAt);
+
     List<Settlement> saveAll(List<? extends Settlement> settlements);
 
     Settlement save(Settlement settlement);

--- a/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementRepository.java
@@ -19,7 +19,7 @@ public interface SettlementRepository {
 
     List<Settlement> findByStatus(SettlementStatus status);
 
-    Optional<Settlement> findBySellerIdAndPeriodStartAt(UUID sellerId, LocalDateTime periodStartAt);
+    Optional<Settlement> findBySellerIdAndPeriodStartAtBetween(UUID sellerId, LocalDateTime from, LocalDateTime to);
 
     List<Settlement> saveAll(List<? extends Settlement> settlements);
 

--- a/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementRepository.java
@@ -8,15 +8,16 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface SettlementRepository {
 
     List<Settlement> findBySellerId(UUID sellerId);
 
     Optional<Settlement> findBySettlementId(UUID settlementId);
+
+    List<Settlement> findBySellerIdAndStatus(UUID sellerId, SettlementStatus status);
+
+    List<Settlement> findByStatus(SettlementStatus status);
 
     List<Settlement> saveAll(List<? extends Settlement> settlements);
 

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EndedEventResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EndedEventResponse.java
@@ -1,10 +1,12 @@
 package com.devticket.settlement.infrastructure.client.dto.res;
 
+import java.time.LocalDate;
 import java.util.UUID;
 public record EndedEventResponse(
     Long id,          // Event 서비스의 숫자형 PK
     UUID eventId,     // Event 서비스의 UUID 식별자
-    UUID sellerId     // 판매자 UUID
+    UUID sellerId,     // 판매자 UUID
+    LocalDate eventDateTime // 이벤트개최일자
 ) {
 
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementItemJpaRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementItemJpaRepository.java
@@ -16,4 +16,7 @@ public interface SettlementItemJpaRepository extends JpaRepository<SettlementIte
     List<SettlementItem> findByStatusAndEventDateTimeBetween(
         SettlementItemStatus status, LocalDate from, LocalDate to);
 
+    List<SettlementItem> findBySellerIdAndStatusAndEventDateTimeBetween(
+        UUID sellerId, SettlementItemStatus status, LocalDate from, LocalDate to);
+
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementItemJpaRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementItemJpaRepository.java
@@ -1,6 +1,8 @@
 package com.devticket.settlement.infrastructure.persistence.repository;
 
 import com.devticket.settlement.domain.model.SettlementItem;
+import com.devticket.settlement.domain.model.SettlementItemStatus;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,5 +12,8 @@ public interface SettlementItemJpaRepository extends JpaRepository<SettlementIte
     List<SettlementItem> findBySettlementId(UUID settlementId);
 
     boolean existsByOrderItemId(UUID orderItemId);
+
+    List<SettlementItem> findByStatusAndEventDateTimeBetween(
+        SettlementItemStatus status, LocalDate from, LocalDate to);
 
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementItemRepositoryImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementItemRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.devticket.settlement.infrastructure.persistence.repository;
 
 import com.devticket.settlement.domain.model.SettlementItem;
+import com.devticket.settlement.domain.model.SettlementItemStatus;
 import com.devticket.settlement.domain.repository.SettlementItemRepository;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -26,5 +28,16 @@ public class SettlementItemRepositoryImpl implements SettlementItemRepository {
     @Override
     public SettlementItem save(SettlementItem settlementItem) {
         return settlementItemJpaRepository.save(settlementItem);
+    }
+
+    @Override
+    public List<SettlementItem> findByStatusAndEventDateTimeBetween(
+        SettlementItemStatus status, LocalDate from, LocalDate to) {
+        return settlementItemJpaRepository.findByStatusAndEventDateTimeBetween(status, from, to);
+    }
+
+    @Override
+    public List<SettlementItem> saveAll(List<SettlementItem> items) {
+        return settlementItemJpaRepository.saveAll(items);
     }
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementItemRepositoryImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementItemRepositoryImpl.java
@@ -37,6 +37,12 @@ public class SettlementItemRepositoryImpl implements SettlementItemRepository {
     }
 
     @Override
+    public List<SettlementItem> findBySellerIdAndStatusAndEventDateTimeBetween(
+        UUID sellerId, SettlementItemStatus status, LocalDate from, LocalDate to) {
+        return settlementItemJpaRepository.findBySellerIdAndStatusAndEventDateTimeBetween(sellerId, status, from, to);
+    }
+
+    @Override
     public List<SettlementItem> saveAll(List<SettlementItem> items) {
         return settlementItemJpaRepository.saveAll(items);
     }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementJpaRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementJpaRepository.java
@@ -18,6 +18,12 @@ public interface SettlementJpaRepository extends JpaRepository<Settlement, Long>
 
     Optional<Settlement> findBySettlementId(UUID settlementId);
 
+    List<Settlement> findBySellerIdAndStatus(UUID sellerId, SettlementStatus status);
+
+    List<Settlement> findByStatus(SettlementStatus status);
+
+    List<Settlement> findBySellerIdAndPeriodStartAt(UUID sellerId, LocalDateTime periodStartAt);
+
     @Query("""
     SELECT s FROM Settlement s
     WHERE (CAST(:status AS string) IS NULL OR s.status = :status)

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementJpaRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementJpaRepository.java
@@ -22,7 +22,7 @@ public interface SettlementJpaRepository extends JpaRepository<Settlement, Long>
 
     List<Settlement> findByStatus(SettlementStatus status);
 
-    Optional<Settlement> findBySellerIdAndPeriodStartAt(UUID sellerId, LocalDateTime periodStartAt);
+    Optional<Settlement> findBySellerIdAndPeriodStartAtBetween(UUID sellerId, LocalDateTime from, LocalDateTime to);
 
     @Query("""
     SELECT s FROM Settlement s

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementJpaRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementJpaRepository.java
@@ -22,7 +22,7 @@ public interface SettlementJpaRepository extends JpaRepository<Settlement, Long>
 
     List<Settlement> findByStatus(SettlementStatus status);
 
-    List<Settlement> findBySellerIdAndPeriodStartAt(UUID sellerId, LocalDateTime periodStartAt);
+    Optional<Settlement> findBySellerIdAndPeriodStartAt(UUID sellerId, LocalDateTime periodStartAt);
 
     @Query("""
     SELECT s FROM Settlement s

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementRepositoryImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementRepositoryImpl.java
@@ -44,6 +44,16 @@ public class SettlementRepositoryImpl implements SettlementRepository {
     }
 
     @Override
+    public List<Settlement> findBySellerIdAndStatus(UUID sellerId, SettlementStatus status) {
+        return settlementJpaRepository.findBySellerIdAndStatus(sellerId, status);
+    }
+
+    @Override
+    public List<Settlement> findByStatus(SettlementStatus status) {
+        return settlementJpaRepository.findByStatus(status);
+    }
+
+    @Override
     public Page<Settlement> search(SettlementStatus status, UUID sellerId,
         LocalDateTime startDate, LocalDateTime endDate, Pageable pageable) {
         return settlementJpaRepository.search(status, sellerId, startDate, endDate, pageable);

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementRepositoryImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementRepositoryImpl.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -51,6 +52,11 @@ public class SettlementRepositoryImpl implements SettlementRepository {
     @Override
     public List<Settlement> findByStatus(SettlementStatus status) {
         return settlementJpaRepository.findByStatus(status);
+    }
+
+    @Override
+    public Optional<Settlement> findBySellerIdAndPeriodStartAt(UUID sellerId, LocalDateTime periodStartAt) {
+        return settlementJpaRepository.findBySellerIdAndPeriodStartAt(sellerId, periodStartAt);
     }
 
     @Override

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementRepositoryImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementRepositoryImpl.java
@@ -55,8 +55,8 @@ public class SettlementRepositoryImpl implements SettlementRepository {
     }
 
     @Override
-    public Optional<Settlement> findBySellerIdAndPeriodStartAt(UUID sellerId, LocalDateTime periodStartAt) {
-        return settlementJpaRepository.findBySellerIdAndPeriodStartAt(sellerId, periodStartAt);
+    public Optional<Settlement> findBySellerIdAndPeriodStartAtBetween(UUID sellerId, LocalDateTime from, LocalDateTime to) {
+        return settlementJpaRepository.findBySellerIdAndPeriodStartAtBetween(sellerId, from, to);
     }
 
     @Override

--- a/settlement/src/main/java/com/devticket/settlement/presentation/controller/InternalSettlementController.java
+++ b/settlement/src/main/java/com/devticket/settlement/presentation/controller/InternalSettlementController.java
@@ -1,4 +1,4 @@
-package com.devticket.settlement.presentation.controller;
+ package com.devticket.settlement.presentation.controller;
 
 import com.devticket.settlement.application.service.SettlementInternalService;
 import com.devticket.settlement.infrastructure.external.dto.InternalSettlementPageResponse;
@@ -36,6 +36,13 @@ public class InternalSettlementController {
     @PostMapping("/run")
     public ResponseEntity<Void> runSettlement() {
         settlementInternalService.runSettlement();
+        return ResponseEntity.ok().build();
+    }
+
+    // 정산기능 수동테스트용 API : SettlementItem데이터를 기반으로 Settelemnt생성
+    @PostMapping("/create-from-items")
+    public ResponseEntity<Void> createSettlementFromItems() {
+        settlementInternalService.createSettlementFromItems();
         return ResponseEntity.ok().build();
     }
 }

--- a/settlement/src/main/java/com/devticket/settlement/presentation/controller/SettlementController.java
+++ b/settlement/src/main/java/com/devticket/settlement/presentation/controller/SettlementController.java
@@ -44,28 +44,28 @@ public class SettlementController {
         return ResponseEntity.ok(settlementServiceImpl.previewSettlementTarget(targetDate));
     }
 
-    @Operation(
-        summary = "판매자 정산 내용 조회",
-        description = "판매자 정산 내용을 조회합니다."
-    )
-    @ApiResponse(responseCode = "200", description = "정산 내역 조회 성공")
-    @GetMapping("/seller/settlements")
-    public ResponseEntity<List<SettlementResponse>> getSellerSettlements(
-        @RequestHeader("X-User-Id") UUID sellerId) {
-        return ResponseEntity.ok(settlementServiceImpl.getSellerSettlements(sellerId));
-    }
-
-    @Operation(
-        summary = "판매자 정산 내용 상세 조회",
-        description = "판매자 정산 내용을 상세 조회합니다."
-    )
-    @ApiResponse(responseCode = "200", description = "정산 내역 조회 성공")
-    @GetMapping("/seller/settlements/{settlementId:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}")
-    public ResponseEntity<SellerSettlementDetailResponse> getSellerSettlement(
-        @RequestHeader("X-User-Id") UUID sellerId,
-        @PathVariable UUID settlementId) {
-        return ResponseEntity.ok(settlementServiceImpl.getSellerSettlementDetail(sellerId, settlementId));
-    }
+//    @Operation(
+//        summary = "판매자 정산 내용 조회",
+//        description = "판매자 정산 내용을 조회합니다."
+//    )
+//    @ApiResponse(responseCode = "200", description = "정산 내역 조회 성공")
+//    @GetMapping("/seller/settlements")
+//    public ResponseEntity<List<SettlementResponse>> getSellerSettlements(
+//        @RequestHeader("X-User-Id") UUID sellerId) {
+//        return ResponseEntity.ok(settlementServiceImpl.getSellerSettlements(sellerId));
+//    }
+//
+//    @Operation(
+//        summary = "판매자 정산 내용 상세 조회",
+//        description = "판매자 정산 내용을 상세 조회합니다."
+//    )
+//    @ApiResponse(responseCode = "200", description = "정산 내역 조회 성공")
+//    @GetMapping("/seller/settlements/{settlementId:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}")
+//    public ResponseEntity<SellerSettlementDetailResponse> getSellerSettlement(
+//        @RequestHeader("X-User-Id") UUID sellerId,
+//        @PathVariable UUID settlementId) {
+//        return ResponseEntity.ok(settlementServiceImpl.getSellerSettlementDetail(sellerId, settlementId));
+//    }
 
     @Operation(
         summary = "판매자 월별 정산 조회",
@@ -77,6 +77,18 @@ public class SettlementController {
         @RequestHeader("X-User-Id") UUID sellerId,
         @PathVariable String yearMonth) {
         return ResponseEntity.ok(settlementServiceImpl.getSettlementByPeriod(sellerId, yearMonth));
+    }
+
+    @Operation(
+        summary = "판매자 당월 예상 정산 미리보기",
+        description = "아직 정산일이 경과하지 않은 당월의 예상 정산 데이터를 조회합니다. " +
+            "집계 대상 기간: 전월 26일 ~ 당월 25일"
+    )
+    @ApiResponse(responseCode = "200", description = "예상 정산 조회 성공")
+    @GetMapping("/seller/settlements/preview")
+    public ResponseEntity<SettlementPeriodResponse> getSettlementPreview(
+        @RequestHeader("X-User-Id") UUID sellerId) {
+        return ResponseEntity.ok(settlementServiceImpl.getSettlementPreview(sellerId));
     }
 
 }

--- a/settlement/src/main/java/com/devticket/settlement/presentation/controller/SettlementController.java
+++ b/settlement/src/main/java/com/devticket/settlement/presentation/controller/SettlementController.java
@@ -2,6 +2,7 @@ package com.devticket.settlement.presentation.controller;
 
 import com.devticket.settlement.application.service.SettlementServiceImpl;
 import com.devticket.settlement.presentation.dto.SellerSettlementDetailResponse;
+import com.devticket.settlement.presentation.dto.SettlementPeriodResponse;
 import com.devticket.settlement.presentation.dto.SettlementResponse;
 import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -59,11 +60,23 @@ public class SettlementController {
         description = "판매자 정산 내용을 상세 조회합니다."
     )
     @ApiResponse(responseCode = "200", description = "정산 내역 조회 성공")
-    @GetMapping("/seller/settlements/{settlementId}")
+    @GetMapping("/seller/settlements/{settlementId:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}")
     public ResponseEntity<SellerSettlementDetailResponse> getSellerSettlement(
         @RequestHeader("X-User-Id") UUID sellerId,
         @PathVariable UUID settlementId) {
         return ResponseEntity.ok(settlementServiceImpl.getSellerSettlementDetail(sellerId, settlementId));
+    }
+
+    @Operation(
+        summary = "판매자 월별 정산 조회",
+        description = "YYYYMM 형식으로 해당 월의 정산 데이터를 조회합니다. 예: 202603"
+    )
+    @ApiResponse(responseCode = "200", description = "월별 정산 조회 성공")
+    @GetMapping("/seller/settlements/{yearMonth:[0-9]{6}}")
+    public ResponseEntity<SettlementPeriodResponse> getSettlementByPeriod(
+        @RequestHeader("X-User-Id") UUID sellerId,
+        @PathVariable String yearMonth) {
+        return ResponseEntity.ok(settlementServiceImpl.getSettlementByPeriod(sellerId, yearMonth));
     }
 
 }

--- a/settlement/src/main/java/com/devticket/settlement/presentation/dto/SettlementPeriodResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/presentation/dto/SettlementPeriodResponse.java
@@ -1,0 +1,33 @@
+package com.devticket.settlement.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record SettlementPeriodResponse(
+
+    @NotNull
+    @Schema(description = "최종 정산 금액", example = "855000", minimum = "0")
+    Integer finalSettlementAmount,
+
+    @NotNull
+    @Schema(description = "총 수수료 금액", example = "95000", minimum = "0")
+    Integer totalFeeAmount,
+
+    @NotNull
+    @Schema(description = "총 판매 금액", example = "1000000", minimum = "0")
+    Integer totalSalesAmount,
+
+    @NotNull
+    @Schema(description = "이월 금액 (전월 미달 이월분)", example = "0", minimum = "0")
+    Integer carriedInAmount,
+
+    @NotNull
+    @ArraySchema(
+        arraySchema = @Schema(description = "정산 항목 목록"),
+        schema = @Schema(implementation = EventItemResponse.class)
+    )
+    List<EventItemResponse> settlementItems
+) {
+}

--- a/settlement/src/main/java/com/devticket/settlement/presentation/scheduler/SettlementScheduler.java
+++ b/settlement/src/main/java/com/devticket/settlement/presentation/scheduler/SettlementScheduler.java
@@ -1,15 +1,11 @@
 package com.devticket.settlement.presentation.scheduler;
 
+import com.devticket.settlement.application.service.SettlementInternalService;
 import com.devticket.settlement.application.service.SettlementService;
-import com.devticket.settlement.infrastructure.batch.SettlementItemProcessor;
-import com.devticket.settlement.infrastructure.batch.SettlementItemReader;
 import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.job.Job;
-import org.springframework.batch.core.job.parameters.JobParameters;
-import org.springframework.batch.core.job.parameters.JobParametersBuilder;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class SettlementScheduler {
 
     private final SettlementService settlementService;
+    private final SettlementInternalService settlementInternalService;
 
     @Scheduled(cron = "1 0 0 * * *")
     public void collectDailySettlementTargets() {
@@ -29,8 +26,18 @@ public class SettlementScheduler {
             log.info("[SettlementScheduler] 정산대상 데이터 수집 완료 - 이벤트: {}건, 저장: {}건, 스킵: {}건",
                 result.totalEventCount(), result.savedCount(), result.skippedCount());
         } catch (Exception e) {
-            //실패 시 에러 로그만 남겨 배치 스케줄러 자체는 계속 동작하도록 처리
             log.error("[SettlementScheduler] 정산대상 데이터 수집 실패 - targetDate: {}", yesterday, e);
+        }
+    }
+
+    @Scheduled(cron = "0 10 0 1 * *")
+    public void createMonthlySettlement() {
+        log.info("[SettlementScheduler] 월 정산 생성 시작");
+        try {
+            settlementInternalService.createSettlementFromItems();
+            log.info("[SettlementScheduler] 월 정산 생성 완료");
+        } catch (Exception e) {
+            log.error("[SettlementScheduler] 월 정산 생성 실패", e);
         }
     }
 

--- a/settlement/src/test/java/com/devticket/settlement/presentation/controller/SettlementControllerTest.java
+++ b/settlement/src/test/java/com/devticket/settlement/presentation/controller/SettlementControllerTest.java
@@ -1,16 +1,11 @@
 package com.devticket.settlement.presentation.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import com.devticket.settlement.application.service.SettlementServiceImpl;
-import com.devticket.settlement.common.exception.BusinessException;
-import com.devticket.settlement.common.exception.CommonErrorCode;
-import com.devticket.settlement.domain.exception.SettlementErrorCode;
-import com.devticket.settlement.domain.model.SettlementStatus;
-import com.devticket.settlement.presentation.dto.SellerSettlementDetailResponse;
-import com.devticket.settlement.presentation.dto.SettlementResponse;
+import com.devticket.settlement.presentation.dto.EventItemResponse;
+import com.devticket.settlement.presentation.dto.SettlementPeriodResponse;
 import com.devticket.settlement.presentation.dto.SettlementTargetPreviewResponse;
 import java.time.LocalDate;
 import java.util.List;
@@ -33,7 +28,6 @@ class SettlementControllerTest {
     private SettlementController settlementController;
 
     private final UUID sellerId = UUID.randomUUID();
-    private final UUID settlementId = UUID.randomUUID();
 
     // ────────────────────────────────────────────────
     // previewSettlementTarget
@@ -82,82 +76,97 @@ class SettlementControllerTest {
     }
 
     // ────────────────────────────────────────────────
-    // getSellerSettlements
+    // getSettlementByPeriod
     // ────────────────────────────────────────────────
 
     @Test
-    void getSellerSettlements_성공() {
-        List<SettlementResponse> settlements = List.of(
-            new SettlementResponse(settlementId, "2024-01-01", "2024-01-31",
-                100000, 0, 3000, 97000, SettlementStatus.COMPLETED, "2024-02-01T10:00:00"),
-            new SettlementResponse(UUID.randomUUID(), "2024-02-01", "2024-02-28",
-                50000, 5000, 1500, 43500, SettlementStatus.PENDING, null)
-        );
-        given(settlementServiceImpl.getSellerSettlements(sellerId)).willReturn(settlements);
+    void getSettlementByPeriod_정상조회_성공() {
+        String yearMonth = "202603";
+        EventItemResponse item = new EventItemResponse("eventId", "이벤트", 100000L, 0L, 3000L, 97000L);
+        SettlementPeriodResponse response = new SettlementPeriodResponse(97000, 3000, 100000, 0, List.of(item));
+        given(settlementServiceImpl.getSettlementByPeriod(sellerId, yearMonth)).willReturn(response);
 
-        ResponseEntity<List<SettlementResponse>> result =
-            settlementController.getSellerSettlements(sellerId);
+        ResponseEntity<SettlementPeriodResponse> result =
+            settlementController.getSettlementByPeriod(sellerId, yearMonth);
 
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(result.getBody()).hasSize(2);
-        assertThat(result.getBody().get(0).totalSalesAmount()).isEqualTo(100000);
-        assertThat(result.getBody().get(0).status()).isEqualTo(SettlementStatus.COMPLETED);
-        assertThat(result.getBody().get(1).status()).isEqualTo(SettlementStatus.PENDING);
-    }
-
-    @Test
-    void getSellerSettlements_빈목록_빈배열반환() {
-        given(settlementServiceImpl.getSellerSettlements(sellerId)).willReturn(List.of());
-
-        ResponseEntity<List<SettlementResponse>> result =
-            settlementController.getSellerSettlements(sellerId);
-
-        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(result.getBody()).isEmpty();
-    }
-
-    // ────────────────────────────────────────────────
-    // getSellerSettlement (detail)
-    // ────────────────────────────────────────────────
-
-    @Test
-    void getSellerSettlement_상세조회_성공() {
-        SellerSettlementDetailResponse detail = new SellerSettlementDetailResponse(
-            settlementId.toString(), "2024-01-01T00:00:00", "2024-01-31T23:59:59",
-            100000, 0, 3000, 97000, "COMPLETED", "2024-02-01T10:00:00", List.of()
-        );
-        given(settlementServiceImpl.getSellerSettlementDetail(sellerId, settlementId)).willReturn(detail);
-
-        ResponseEntity<SellerSettlementDetailResponse> result =
-            settlementController.getSellerSettlement(sellerId, settlementId);
-
-        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(result.getBody().settlementId()).isEqualTo(settlementId.toString());
+        assertThat(result.getBody().finalSettlementAmount()).isEqualTo(97000);
         assertThat(result.getBody().totalSalesAmount()).isEqualTo(100000);
-        assertThat(result.getBody().status()).isEqualTo("COMPLETED");
+        assertThat(result.getBody().totalFeeAmount()).isEqualTo(3000);
+        assertThat(result.getBody().carriedInAmount()).isEqualTo(0);
+        assertThat(result.getBody().settlementItems()).hasSize(1);
     }
 
     @Test
-    void getSellerSettlement_정산없음_BusinessException발생() {
-        given(settlementServiceImpl.getSellerSettlementDetail(sellerId, settlementId))
-            .willThrow(new BusinessException(SettlementErrorCode.SETTLEMENT_BAD_REQUEST));
+    void getSettlementByPeriod_이월금액포함_성공() {
+        String yearMonth = "202603";
+        SettlementPeriodResponse response = new SettlementPeriodResponse(25000, 1500, 50000, 20000, List.of());
+        given(settlementServiceImpl.getSettlementByPeriod(sellerId, yearMonth)).willReturn(response);
 
-        assertThatThrownBy(() -> settlementController.getSellerSettlement(sellerId, settlementId))
-            .isInstanceOf(BusinessException.class)
-            .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
-                .isEqualTo(SettlementErrorCode.SETTLEMENT_BAD_REQUEST));
+        ResponseEntity<SettlementPeriodResponse> result =
+            settlementController.getSettlementByPeriod(sellerId, yearMonth);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().carriedInAmount()).isEqualTo(20000);
+        assertThat(result.getBody().finalSettlementAmount()).isEqualTo(25000);
     }
 
     @Test
-    void getSellerSettlement_다른판매자접근_BusinessException발생() {
-        UUID anotherSellerId = UUID.randomUUID();
-        given(settlementServiceImpl.getSellerSettlementDetail(anotherSellerId, settlementId))
-            .willThrow(new BusinessException(CommonErrorCode.ACCESS_DENIED));
+    void getSettlementByPeriod_정산내역없음_빈응답반환() {
+        String yearMonth = "202601";
+        SettlementPeriodResponse emptyResponse = new SettlementPeriodResponse(0, 0, 0, 0, List.of());
+        given(settlementServiceImpl.getSettlementByPeriod(sellerId, yearMonth)).willReturn(emptyResponse);
 
-        assertThatThrownBy(() -> settlementController.getSellerSettlement(anotherSellerId, settlementId))
-            .isInstanceOf(BusinessException.class)
-            .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
-                .isEqualTo(CommonErrorCode.ACCESS_DENIED));
+        ResponseEntity<SettlementPeriodResponse> result =
+            settlementController.getSettlementByPeriod(sellerId, yearMonth);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().finalSettlementAmount()).isEqualTo(0);
+        assertThat(result.getBody().settlementItems()).isEmpty();
+    }
+
+    // ────────────────────────────────────────────────
+    // getSettlementPreview
+    // ────────────────────────────────────────────────
+
+    @Test
+    void getSettlementPreview_READY항목있음_집계응답() {
+        EventItemResponse item = new EventItemResponse("eventId", "이벤트", 50000L, 0L, 1500L, 48500L);
+        SettlementPeriodResponse response = new SettlementPeriodResponse(48500, 1500, 50000, 0, List.of(item));
+        given(settlementServiceImpl.getSettlementPreview(sellerId)).willReturn(response);
+
+        ResponseEntity<SettlementPeriodResponse> result =
+            settlementController.getSettlementPreview(sellerId);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().finalSettlementAmount()).isEqualTo(48500);
+        assertThat(result.getBody().settlementItems()).hasSize(1);
+    }
+
+    @Test
+    void getSettlementPreview_이월금액포함_합산응답() {
+        SettlementPeriodResponse response = new SettlementPeriodResponse(18000, 600, 20000, 10000, List.of());
+        given(settlementServiceImpl.getSettlementPreview(sellerId)).willReturn(response);
+
+        ResponseEntity<SettlementPeriodResponse> result =
+            settlementController.getSettlementPreview(sellerId);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().carriedInAmount()).isEqualTo(10000);
+        assertThat(result.getBody().finalSettlementAmount()).isEqualTo(18000);
+    }
+
+    @Test
+    void getSettlementPreview_데이터없음_빈응답() {
+        SettlementPeriodResponse emptyResponse = new SettlementPeriodResponse(0, 0, 0, 0, List.of());
+        given(settlementServiceImpl.getSettlementPreview(sellerId)).willReturn(emptyResponse);
+
+        ResponseEntity<SettlementPeriodResponse> result =
+            settlementController.getSettlementPreview(sellerId);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().finalSettlementAmount()).isEqualTo(0);
+        assertThat(result.getBody().settlementItems()).isEmpty();
     }
 
     // ────────────────────────────────────────────────

--- a/settlement/src/test/java/com/devticket/settlement/presentation/scheduler/SettlementSchedulerTest.java
+++ b/settlement/src/test/java/com/devticket/settlement/presentation/scheduler/SettlementSchedulerTest.java
@@ -3,9 +3,11 @@ package com.devticket.settlement.presentation.scheduler;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
+import com.devticket.settlement.application.service.SettlementInternalService;
 import com.devticket.settlement.application.service.SettlementService;
 import com.devticket.settlement.common.exception.BusinessException;
 import com.devticket.settlement.common.exception.CommonErrorCode;
@@ -24,8 +26,15 @@ class SettlementSchedulerTest {
     @Mock
     private SettlementService settlementService;
 
+    @Mock
+    private SettlementInternalService settlementInternalService;
+
     @InjectMocks
     private SettlementScheduler settlementScheduler;
+
+    // ────────────────────────────────────────────────
+    // collectDailySettlementTargets
+    // ────────────────────────────────────────────────
 
     @Test
     void collectDailySettlementTargets_성공_어제날짜로_서비스호출() {
@@ -58,7 +67,6 @@ class SettlementSchedulerTest {
         given(settlementService.collectSettlementTargets(any(LocalDate.class)))
             .willThrow(new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR));
 
-        // 예외가 스케줄러 밖으로 전파되지 않아야 함
         assertThatNoException().isThrownBy(
             () -> settlementScheduler.collectDailySettlementTargets()
         );
@@ -75,5 +83,38 @@ class SettlementSchedulerTest {
         settlementScheduler.collectDailySettlementTargets();
 
         verify(settlementService).collectSettlementTargets(yesterday);
+    }
+
+    // ────────────────────────────────────────────────
+    // createMonthlySettlement
+    // ────────────────────────────────────────────────
+
+    @Test
+    void createMonthlySettlement_성공_서비스호출() {
+        willDoNothing().given(settlementInternalService).createSettlementFromItems();
+
+        settlementScheduler.createMonthlySettlement();
+
+        verify(settlementInternalService).createSettlementFromItems();
+    }
+
+    @Test
+    void createMonthlySettlement_예외발생_밖으로_전파하지않음() {
+        willThrow(new RuntimeException("정산 생성 실패"))
+            .given(settlementInternalService).createSettlementFromItems();
+
+        assertThatNoException().isThrownBy(
+            () -> settlementScheduler.createMonthlySettlement()
+        );
+    }
+
+    @Test
+    void createMonthlySettlement_비즈니스예외발생_밖으로_전파하지않음() {
+        willThrow(new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR))
+            .given(settlementInternalService).createSettlementFromItems();
+
+        assertThatNoException().isThrownBy(
+            () -> settlementScheduler.createMonthlySettlement()
+        );
     }
 }


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
  ##### 월별 정산 자동 생성 기능 구현
  - 매월 1일 00:10, 전전월 26일~전월 25일 기간의 READY 상태 SettlementItem을 판매자별로 집계하여 Settlement를 자동 생성하는 배치 로직 구현
  - 최소 정산 금액(10,000원) 미달 시 PENDING_MIN_AMOUNT 상태로 보류, 다음 달 집계 시 이월 합산 처리

 ##### 판매자 정산 조회 API 추가
  - GET /api/seller/settlements/{yearMonth} : YYYYMM 형식으로 특정 월 정산 조회 (예: 202603 → 전월 26일~당월 25일 기간 정산)
  - GET /api/seller/settlements/preview : 아직 정산일이 경과하지 않은 당월 예상 정산 미리보기 (READY 항목 실시간 집계)

## 변경 사항
  ##### 도메인 모델
  - Settlement — carriedInAmount(이월 금액), carriedInSettlementId(이월정산id) 필드 추가, updateStatus() 메서드 추가
  - SettlementItem — eventDateTime(이벤트 종료 날짜) 필드 추가, finalize() 메서드 추가
  - SettlementStatus — COMPLETED / PENDING_MIN_AMOUNT / CANCELLED
  - EndedEventResponse — eventDateTime 필드 추가

  ##### Repository
  - SettlementItemRepository — findByStatusAndEventDateTimeBetween,  findBySellerIdAndStatusAndEventDateTimeBetween, saveAll 추가
  - SettlementRepository — findByStatus,  findBySellerIdAndPeriodStartAtBetween 추가

  ##### Service / Scheduler
  - SettlementInternalServiceImpl — createSettlementFromItems() 구현
  - SettlementScheduler — createMonthlySettlement() 추가 

  ##### Presentation
  - SettlementController — getSettlementByPeriod, getSettlementPreview 엔드포인트 추가
  - SettlementPeriodResponse DTO 추가 (finalSettlementAmount, totalFeeAmount, totalSalesAmount, carriedInAmount, settlementItems)

  테스트
  - SettlementControllerTest — 신규 엔드포인트 테스트 추가
  - SettlementSchedulerTest — createMonthlySettlement 

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인

## 스크린샷
<img width="1100" height="553" alt="image" src="https://github.com/user-attachments/assets/a895e1d4-159d-47f1-81f7-67bef1b07675" />

## 참고 사항
- 정산데이터 적재시 Event제목도 추가필요(수정예정)