### PR TITLE
[Settlement] Fix : 월 정산 배치 중복 생성 오류 

### DIFF
--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalServiceImpl.java
@@ -19,8 +19,8 @@ import com.devticket.settlement.infrastructure.external.dto.InternalSettlementRe
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
-import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -43,6 +43,10 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
     private final FeePolicyRepository feePolicyRepository;
     private final SettlementRepository settlementRepository;
     private final SettlementItemRepository settlementItemRepository;
+
+    // ────────────────────────────────────────────────
+    // Public API
+    // ────────────────────────────────────────────────
 
     @Transactional(readOnly = true)
     public InternalSettlementPageResponse getSettlements(
@@ -134,82 +138,99 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
     public void createSettlementFromItems() {
         LocalDate periodFrom = YearMonth.now().minusMonths(2).atDay(26);
         LocalDate periodTo = YearMonth.now().minusMonths(1).atDay(25);
-        LocalDateTime settlementPeriodStart = periodFrom.atStartOfDay();
-        LocalDateTime settlementPeriodEnd = periodTo.atTime(23, 59, 59);
+        LocalDateTime periodStart = periodFrom.atStartOfDay();
+        LocalDateTime periodEnd = periodTo.atTime(23, 59, 59);
 
-        List<SettlementItem> targetItems = settlementItemRepository
-            .findByStatusAndEventDateTimeBetween(SettlementItemStatus.READY, periodFrom, periodTo);
+        Map<UUID, List<SettlementItem>> itemsBySeller = collectItemsBySeller(periodFrom, periodTo);
+        includeCarryOverSellers(itemsBySeller);
 
-        log.info("[정산 생성] 대상 기간: {} ~ {}, 항목: {}건", periodFrom, periodTo, targetItems.size());
+        log.info("[정산 생성] 대상 기간: {} ~ {}, 판매자: {}명", periodFrom, periodTo, itemsBySeller.size());
 
-        Map<UUID, List<SettlementItem>> itemsBySeller = targetItems.stream()
-            .collect(Collectors.groupingBy(SettlementItem::getSellerId));
+        for (Map.Entry<UUID, List<SettlementItem>> entry : itemsBySeller.entrySet()) {
+            processSellerSettlement(entry.getKey(), entry.getValue(), periodStart, periodEnd);
+        }
+    }
 
-        // 이번 달 신규 아이템이 없어도 이월 건이 있는 판매자도 처리해야 하므로
-        // PENDING_MIN_AMOUNT 판매자 목록도 포함
-        List<Settlement> allPendingSettlements = settlementRepository
-            .findByStatus(SettlementStatus.PENDING_MIN_AMOUNT);
-        allPendingSettlements.stream()
+    // ────────────────────────────────────────────────
+    // Private helpers
+    // ────────────────────────────────────────────────
+
+    private Map<UUID, List<SettlementItem>> collectItemsBySeller(LocalDate from, LocalDate to) {
+        List<SettlementItem> items = settlementItemRepository
+            .findByStatusAndEventDateTimeBetween(SettlementItemStatus.READY, from, to);
+        log.info("[정산 생성] READY 항목: {}건", items.size());
+        return new HashMap<>(items.stream()
+            .collect(Collectors.groupingBy(SettlementItem::getSellerId)));
+    }
+
+    private void includeCarryOverSellers(Map<UUID, List<SettlementItem>> itemsBySeller) {
+        settlementRepository.findByStatus(SettlementStatus.PENDING_MIN_AMOUNT).stream()
             .map(Settlement::getSellerId)
             .distinct()
             .filter(sellerId -> !itemsBySeller.containsKey(sellerId))
             .forEach(sellerId -> itemsBySeller.put(sellerId, List.of()));
-
-        for (Map.Entry<UUID, List<SettlementItem>> entry : itemsBySeller.entrySet()) {
-            UUID sellerId = entry.getKey();
-            List<SettlementItem> sellerItems = entry.getValue();
-
-            // 이번 달 신규 집계 금액
-            long totalSales = sellerItems.stream().mapToLong(SettlementItem::getSalesAmount).sum();
-            long totalRefund = sellerItems.stream().mapToLong(SettlementItem::getRefundAmount).sum();
-            long totalFee = sellerItems.stream().mapToLong(SettlementItem::getFeeAmount).sum();
-            long newSettlementAmount = sellerItems.stream().mapToLong(SettlementItem::getSettlementAmount).sum();
-
-            // 직전 이월 건 조회 (체인의 최신 노드)
-            List<Settlement> pendingSettlements = settlementRepository
-                .findBySellerIdAndStatus(sellerId, SettlementStatus.PENDING_MIN_AMOUNT);
-            Settlement latestPending = pendingSettlements.stream()
-                .max(Comparator.comparing(Settlement::getCreatedAt))
-                .orElse(null);
-
-            int carriedInAmount = (latestPending != null) ? latestPending.getFinalSettlementAmount() : 0;
-            UUID carriedInSettlementId = (latestPending != null) ? latestPending.getSettlementId() : null;
-            long totalFinalAmount = newSettlementAmount + carriedInAmount;
-
-            SettlementStatus newStatus = (totalFinalAmount >= MIN_SETTLEMENT_AMOUNT)
-                ? SettlementStatus.COMPLETED
-                : SettlementStatus.PENDING_MIN_AMOUNT;
-
-            Settlement settlement = Settlement.builder()
-                .sellerId(sellerId)
-                .periodStartAt(settlementPeriodStart)
-                .periodEndAt(settlementPeriodEnd)
-                .totalSalesAmount((int) totalSales)
-                .totalRefundAmount((int) totalRefund)
-                .totalFeeAmount((int) totalFee)
-                .finalSettlementAmount((int) totalFinalAmount)
-                .carriedInAmount(carriedInAmount)
-                .carriedInSettlementId(carriedInSettlementId)
-                .status(newStatus)
-                .settledAt(LocalDateTime.now())
-                .build();
-
-            settlementRepository.save(settlement);
-
-            // 이월 건 해소 시 체인 전체를 COMPLETED로 변경
-            if (newStatus == SettlementStatus.COMPLETED && latestPending != null) {
-                markChainAsPaidByCarryForward(latestPending);
-            }
-
-            if (!sellerItems.isEmpty()) {
-                sellerItems.forEach(item -> item.finalize(settlement.getSettlementId()));
-                settlementItemRepository.saveAll(sellerItems);
-            }
-
-            log.info("[정산 생성] sellerId={}, items={}건, carriedIn={}, finalAmount={}, status={}",
-                sellerId, sellerItems.size(), carriedInAmount, totalFinalAmount, newStatus);
-        }
     }
+
+    private void processSellerSettlement(UUID sellerId, List<SettlementItem> items,
+        LocalDateTime periodStart, LocalDateTime periodEnd) {
+
+        SellerAmounts amounts = aggregateAmounts(items);
+        Settlement latestPending = resolveLatestPending(sellerId);
+
+        int carriedInAmount = latestPending != null ? latestPending.getFinalSettlementAmount() : 0;
+        UUID carriedInSettlementId = latestPending != null ? latestPending.getSettlementId() : null;
+        long totalFinalAmount = amounts.settlementAmount() + carriedInAmount;
+        SettlementStatus status = totalFinalAmount >= MIN_SETTLEMENT_AMOUNT
+            ? SettlementStatus.COMPLETED
+            : SettlementStatus.PENDING_MIN_AMOUNT;
+
+        Settlement settlement = Settlement.builder()
+            .sellerId(sellerId)
+            .periodStartAt(periodStart)
+            .periodEndAt(periodEnd)
+            .totalSalesAmount((int) amounts.totalSales())
+            .totalRefundAmount((int) amounts.totalRefund())
+            .totalFeeAmount((int) amounts.totalFee())
+            .finalSettlementAmount((int) totalFinalAmount)
+            .carriedInAmount(carriedInAmount)
+            .carriedInSettlementId(carriedInSettlementId)
+            .status(status)
+            .settledAt(LocalDateTime.now())
+            .build();
+
+        settlementRepository.save(settlement);
+
+        if (status == SettlementStatus.COMPLETED && latestPending != null) {
+            markChainAsPaidByCarryForward(latestPending);
+        }
+
+        if (!items.isEmpty()) {
+            items.forEach(item -> item.finalize(settlement.getSettlementId()));
+            settlementItemRepository.saveAll(items);
+        }
+
+        log.info("[정산 생성] sellerId={}, items={}건, carriedIn={}, finalAmount={}, status={}",
+            sellerId, items.size(), carriedInAmount, totalFinalAmount, status);
+    }
+
+    private SellerAmounts aggregateAmounts(List<SettlementItem> items) {
+        return new SellerAmounts(
+            items.stream().mapToLong(SettlementItem::getSalesAmount).sum(),
+            items.stream().mapToLong(SettlementItem::getRefundAmount).sum(),
+            items.stream().mapToLong(SettlementItem::getFeeAmount).sum(),
+            items.stream().mapToLong(SettlementItem::getSettlementAmount).sum()
+        );
+    }
+
+    private Settlement resolveLatestPending(UUID sellerId) {
+        return settlementRepository
+            .findBySellerIdAndStatus(sellerId, SettlementStatus.PENDING_MIN_AMOUNT)
+            .stream()
+            .max(Comparator.comparing(Settlement::getCreatedAt))
+            .orElse(null);
+    }
+
+    private record SellerAmounts(long totalSales, long totalRefund, long totalFee, long settlementAmount) {}
 
     private void markChainAsPaidByCarryForward(Settlement settlement) {
         Settlement cursor = settlement;

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalServiceImpl.java
@@ -223,11 +223,12 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
     }
 
     private boolean alreadySettledForPeriod(UUID sellerId, LocalDateTime periodStart) {
-        return settlementRepository.findBySellerIdAndPeriodStartAtBetween(
+        return settlementRepository.existsBySellerIdAndPeriodStartAtBetweenAndStatusNot(
             sellerId,
             periodStart,
-            periodStart.toLocalDate().atTime(23, 59, 59)
-        ).filter(s -> s.getStatus() != SettlementStatus.CANCELLED).isPresent();
+            periodStart.toLocalDate().atTime(23, 59, 59),
+            SettlementStatus.CANCELLED
+        );
     }
 
     private SellerAmounts aggregateAmounts(List<SettlementItem> items) {

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalServiceImpl.java
@@ -136,16 +136,19 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
 
     @Transactional
     public void createSettlementFromItems() {
+        //매월1일 정산시작시 정산대상기간 설정 : 전전월 26일 ~ 전월 25일
         LocalDate periodFrom = YearMonth.now().minusMonths(2).atDay(26);
         LocalDate periodTo = YearMonth.now().minusMonths(1).atDay(25);
         LocalDateTime periodStart = periodFrom.atStartOfDay();
         LocalDateTime periodEnd = periodTo.atTime(23, 59, 59);
 
+        //판매자별 settlementItem데이터 조회
         Map<UUID, List<SettlementItem>> itemsBySeller = collectItemsBySeller(periodFrom, periodTo);
         includeCarryOverSellers(itemsBySeller);
 
         log.info("[정산 생성] 대상 기간: {} ~ {}, 판매자: {}명", periodFrom, periodTo, itemsBySeller.size());
 
+        //Settlement생성
         for (Map.Entry<UUID, List<SettlementItem>> entry : itemsBySeller.entrySet()) {
             processSellerSettlement(entry.getKey(), entry.getValue(), periodStart, periodEnd);
         }
@@ -173,6 +176,12 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
 
     private void processSellerSettlement(UUID sellerId, List<SettlementItem> items,
         LocalDateTime periodStart, LocalDateTime periodEnd) {
+
+        // Settlement가 이미 생
+        if (alreadySettledForPeriod(sellerId, periodStart)) {
+            log.info("[정산 생성 스킵] 이미 처리된 기간 - sellerId={}, periodStart={}", sellerId, periodStart);
+            return;
+        }
 
         SellerAmounts amounts = aggregateAmounts(items);
         Settlement latestPending = resolveLatestPending(sellerId);
@@ -211,6 +220,14 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
 
         log.info("[정산 생성] sellerId={}, items={}건, carriedIn={}, finalAmount={}, status={}",
             sellerId, items.size(), carriedInAmount, totalFinalAmount, status);
+    }
+
+    private boolean alreadySettledForPeriod(UUID sellerId, LocalDateTime periodStart) {
+        return settlementRepository.findBySellerIdAndPeriodStartAtBetween(
+            sellerId,
+            periodStart,
+            periodStart.toLocalDate().atTime(23, 59, 59)
+        ).filter(s -> s.getStatus() != SettlementStatus.CANCELLED).isPresent();
     }
 
     private SellerAmounts aggregateAmounts(List<SettlementItem> items) {

--- a/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementRepository.java
@@ -21,6 +21,8 @@ public interface SettlementRepository {
 
     Optional<Settlement> findBySellerIdAndPeriodStartAtBetween(UUID sellerId, LocalDateTime from, LocalDateTime to);
 
+    boolean existsBySellerIdAndPeriodStartAtBetweenAndStatusNot(UUID sellerId, LocalDateTime from, LocalDateTime to, SettlementStatus status);
+
     List<Settlement> saveAll(List<? extends Settlement> settlements);
 
     Settlement save(Settlement settlement);

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementJpaRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementJpaRepository.java
@@ -24,6 +24,8 @@ public interface SettlementJpaRepository extends JpaRepository<Settlement, Long>
 
     Optional<Settlement> findBySellerIdAndPeriodStartAtBetween(UUID sellerId, LocalDateTime from, LocalDateTime to);
 
+    boolean existsBySellerIdAndPeriodStartAtBetweenAndStatusNot(UUID sellerId, LocalDateTime from, LocalDateTime to, SettlementStatus status);
+
     @Query("""
     SELECT s FROM Settlement s
     WHERE (CAST(:status AS string) IS NULL OR s.status = :status)

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementRepositoryImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementRepositoryImpl.java
@@ -60,6 +60,11 @@ public class SettlementRepositoryImpl implements SettlementRepository {
     }
 
     @Override
+    public boolean existsBySellerIdAndPeriodStartAtBetweenAndStatusNot(UUID sellerId, LocalDateTime from, LocalDateTime to, SettlementStatus status) {
+        return settlementJpaRepository.existsBySellerIdAndPeriodStartAtBetweenAndStatusNot(sellerId, from, to, status);
+    }
+
+    @Override
     public Page<Settlement> search(SettlementStatus status, UUID sellerId,
         LocalDateTime startDate, LocalDateTime endDate, Pageable pageable) {
         return settlementJpaRepository.search(status, sellerId, startDate, endDate, pageable);

--- a/settlement/src/test/java/com/devticket/settlement/application/service/SettlementInternalServiceImplTest.java
+++ b/settlement/src/test/java/com/devticket/settlement/application/service/SettlementInternalServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -167,7 +168,8 @@ class SettlementInternalServiceImplTest {
     void createSettlementFromItems_동일기간_이미정산존재_스킵() {
         SettlementItem item = buildItem(sellerId, 48500L);
         givenReadyItems(List.of(item));
-        givenNoPendingSettlements();
+        given(settlementRepository.findByStatus(SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of());
         given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
             eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
             .willReturn(Optional.of(buildPendingSettlement(sellerId, 48500)));
@@ -270,7 +272,7 @@ class SettlementInternalServiceImplTest {
 
     private Settlement captureNewSettlement() {
         ArgumentCaptor<Settlement> captor = ArgumentCaptor.forClass(Settlement.class);
-        verify(settlementRepository).save(captor.capture());
-        return captor.getValue();
+        verify(settlementRepository, atLeastOnce()).save(captor.capture());
+        return captor.getAllValues().get(0);
     }
 }

--- a/settlement/src/test/java/com/devticket/settlement/application/service/SettlementInternalServiceImplTest.java
+++ b/settlement/src/test/java/com/devticket/settlement/application/service/SettlementInternalServiceImplTest.java
@@ -1,0 +1,276 @@
+package com.devticket.settlement.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.devticket.settlement.domain.model.Settlement;
+import com.devticket.settlement.domain.model.SettlementItem;
+import com.devticket.settlement.domain.model.SettlementItemStatus;
+import com.devticket.settlement.domain.model.SettlementStatus;
+import com.devticket.settlement.domain.repository.FeePolicyRepository;
+import com.devticket.settlement.domain.repository.SettlementItemRepository;
+import com.devticket.settlement.domain.repository.SettlementRepository;
+import com.devticket.settlement.infrastructure.client.SettlementToCommerceClient;
+import com.devticket.settlement.infrastructure.client.SettlementToMemberClient;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementInternalServiceImplTest {
+
+    @Mock private SettlementToCommerceClient settlementToCommerceClient;
+    @Mock private SettlementToMemberClient settlementToMemberClient;
+    @Mock private FeePolicyRepository feePolicyRepository;
+    @Mock private SettlementRepository settlementRepository;
+    @Mock private SettlementItemRepository settlementItemRepository;
+
+    @InjectMocks
+    private SettlementInternalServiceImpl service;
+
+    private final UUID sellerId = UUID.randomUUID();
+
+    // ────────────────────────────────────────────────
+    // createSettlementFromItems
+    // ────────────────────────────────────────────────
+
+    @Test
+    void createSettlementFromItems_최소금액충족_COMPLETED생성() {
+        SettlementItem item = buildItem(sellerId, 48500L);
+        givenReadyItems(List.of(item));
+        givenNoPendingSettlements();
+        givenSaveReturnsArgument();
+
+        service.createSettlementFromItems();
+
+        Settlement saved = captureNewSettlement();
+        assertThat(saved.getStatus()).isEqualTo(SettlementStatus.COMPLETED);
+        assertThat(saved.getFinalSettlementAmount()).isEqualTo(48500);
+        assertThat(saved.getCarriedInAmount()).isEqualTo(0);
+    }
+
+    @Test
+    void createSettlementFromItems_최소금액미달_PENDING_MIN_AMOUNT생성() {
+        SettlementItem item = buildItem(sellerId, 4850L);
+        givenReadyItems(List.of(item));
+        givenNoPendingSettlements();
+        givenSaveReturnsArgument();
+
+        service.createSettlementFromItems();
+
+        Settlement saved = captureNewSettlement();
+        assertThat(saved.getStatus()).isEqualTo(SettlementStatus.PENDING_MIN_AMOUNT);
+        assertThat(saved.getFinalSettlementAmount()).isEqualTo(4850);
+        assertThat(saved.getCarriedInAmount()).isEqualTo(0);
+    }
+
+    @Test
+    void createSettlementFromItems_이월합산으로_최소금액충족_COMPLETED_체인해소() {
+        SettlementItem item = buildItem(sellerId, 4850L);
+        Settlement pending = buildPendingSettlement(sellerId, 5820);
+
+        givenReadyItems(List.of(item));
+        given(settlementRepository.findByStatus(SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of());
+        given(settlementRepository.findBySellerIdAndStatus(sellerId, SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of(pending));
+        given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
+            eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
+            .willReturn(Optional.empty());
+        givenSaveReturnsArgument();
+
+        service.createSettlementFromItems();
+
+        // 신규 정산 → COMPLETED, carriedInAmount 반영
+        Settlement saved = captureNewSettlement();
+        assertThat(saved.getStatus()).isEqualTo(SettlementStatus.COMPLETED);
+        assertThat(saved.getFinalSettlementAmount()).isEqualTo(10670); // 4850 + 5820
+        assertThat(saved.getCarriedInAmount()).isEqualTo(5820);
+        assertThat(saved.getCarriedInSettlementId()).isEqualTo(pending.getSettlementId());
+
+        // 이월 체인 해소 → pending COMPLETED로 변경
+        assertThat(pending.getStatus()).isEqualTo(SettlementStatus.COMPLETED);
+    }
+
+    @Test
+    void createSettlementFromItems_이월포함해도_최소금액미달_PENDING_MIN_AMOUNT() {
+        SettlementItem item = buildItem(sellerId, 3000L);
+        Settlement pending = buildPendingSettlement(sellerId, 4000);
+
+        givenReadyItems(List.of(item));
+        given(settlementRepository.findByStatus(SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of());
+        given(settlementRepository.findBySellerIdAndStatus(sellerId, SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of(pending));
+        given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
+            eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
+            .willReturn(Optional.empty());
+        givenSaveReturnsArgument();
+
+        service.createSettlementFromItems();
+
+        Settlement saved = captureNewSettlement();
+        assertThat(saved.getStatus()).isEqualTo(SettlementStatus.PENDING_MIN_AMOUNT);
+        assertThat(saved.getFinalSettlementAmount()).isEqualTo(7000); // 3000 + 4000
+    }
+
+    @Test
+    void createSettlementFromItems_신규아이템없고_이월판매자만있으면_처리됨() {
+        UUID carryOverSellerId = UUID.randomUUID();
+        Settlement pending = buildPendingSettlement(carryOverSellerId, 3000);
+
+        given(settlementItemRepository.findByStatusAndEventDateTimeBetween(
+            eq(SettlementItemStatus.READY), any(LocalDate.class), any(LocalDate.class)))
+            .willReturn(List.of());
+        given(settlementRepository.findByStatus(SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of(pending));
+        given(settlementRepository.findBySellerIdAndStatus(carryOverSellerId, SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of(pending));
+        given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
+            eq(carryOverSellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
+            .willReturn(Optional.empty());
+        givenSaveReturnsArgument();
+
+        service.createSettlementFromItems();
+
+        verify(settlementRepository).save(any(Settlement.class));
+    }
+
+    @Test
+    void createSettlementFromItems_아이템없고_이월없음_아무처리없음() {
+        given(settlementItemRepository.findByStatusAndEventDateTimeBetween(
+            eq(SettlementItemStatus.READY), any(LocalDate.class), any(LocalDate.class)))
+            .willReturn(List.of());
+        given(settlementRepository.findByStatus(SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of());
+
+        service.createSettlementFromItems();
+
+        verify(settlementRepository, never()).save(any(Settlement.class));
+        verify(settlementItemRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void createSettlementFromItems_동일기간_이미정산존재_스킵() {
+        SettlementItem item = buildItem(sellerId, 48500L);
+        givenReadyItems(List.of(item));
+        givenNoPendingSettlements();
+        given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
+            eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
+            .willReturn(Optional.of(buildPendingSettlement(sellerId, 48500)));
+
+        service.createSettlementFromItems();
+
+        verify(settlementRepository, never()).save(any(Settlement.class));
+        verify(settlementItemRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void createSettlementFromItems_정산완료시_아이템_FINALIZED처리() {
+        SettlementItem item = buildItem(sellerId, 48500L);
+        givenReadyItems(List.of(item));
+        givenNoPendingSettlements();
+        givenSaveReturnsArgument();
+
+        service.createSettlementFromItems();
+
+        assertThat(item.getStatus()).isEqualTo(SettlementItemStatus.FINALIZED);
+        assertThat(item.getSettlementId()).isNotNull();
+        verify(settlementItemRepository).saveAll(List.of(item));
+    }
+
+    @Test
+    void createSettlementFromItems_신규아이템없는_이월판매자_아이템finalize미호출() {
+        UUID carryOverSellerId = UUID.randomUUID();
+        Settlement pending = buildPendingSettlement(carryOverSellerId, 3000);
+
+        given(settlementItemRepository.findByStatusAndEventDateTimeBetween(
+            eq(SettlementItemStatus.READY), any(LocalDate.class), any(LocalDate.class)))
+            .willReturn(List.of());
+        given(settlementRepository.findByStatus(SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of(pending));
+        given(settlementRepository.findBySellerIdAndStatus(carryOverSellerId, SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of(pending));
+        given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
+            eq(carryOverSellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
+            .willReturn(Optional.empty());
+        givenSaveReturnsArgument();
+
+        service.createSettlementFromItems();
+
+        verify(settlementItemRepository, never()).saveAll(anyList());
+    }
+
+    // ────────────────────────────────────────────────
+    // 헬퍼
+    // ────────────────────────────────────────────────
+
+    private SettlementItem buildItem(UUID sellerId, long settlementAmount) {
+        return SettlementItem.builder()
+            .orderItemId(UUID.randomUUID())
+            .eventId(1L)
+            .eventUUID(UUID.randomUUID())
+            .sellerId(sellerId)
+            .salesAmount(settlementAmount + 1500L)
+            .refundAmount(0L)
+            .feeAmount(1500L)
+            .settlementAmount(settlementAmount)
+            .status(SettlementItemStatus.READY)
+            .eventDateTime(LocalDate.now().minusDays(10))
+            .build();
+    }
+
+    private Settlement buildPendingSettlement(UUID sellerId, int finalSettlementAmount) {
+        return Settlement.builder()
+            .sellerId(sellerId)
+            .periodStartAt(LocalDateTime.now().minusMonths(2))
+            .periodEndAt(LocalDateTime.now().minusMonths(1))
+            .totalSalesAmount(finalSettlementAmount + 150)
+            .totalRefundAmount(0)
+            .totalFeeAmount(150)
+            .finalSettlementAmount(finalSettlementAmount)
+            .carriedInAmount(0)
+            .status(SettlementStatus.PENDING_MIN_AMOUNT)
+            .settledAt(LocalDateTime.now().minusMonths(1))
+            .build();
+    }
+
+    private void givenReadyItems(List<SettlementItem> items) {
+        given(settlementItemRepository.findByStatusAndEventDateTimeBetween(
+            eq(SettlementItemStatus.READY), any(LocalDate.class), any(LocalDate.class)))
+            .willReturn(items);
+    }
+
+    private void givenNoPendingSettlements() {
+        given(settlementRepository.findByStatus(SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of());
+        given(settlementRepository.findBySellerIdAndStatus(sellerId, SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of());
+        given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
+            eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
+            .willReturn(Optional.empty());
+    }
+
+    private void givenSaveReturnsArgument() {
+        given(settlementRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    }
+
+    private Settlement captureNewSettlement() {
+        ArgumentCaptor<Settlement> captor = ArgumentCaptor.forClass(Settlement.class);
+        verify(settlementRepository).save(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/settlement/src/test/java/com/devticket/settlement/application/service/SettlementInternalServiceImplTest.java
+++ b/settlement/src/test/java/com/devticket/settlement/application/service/SettlementInternalServiceImplTest.java
@@ -21,7 +21,6 @@ import com.devticket.settlement.infrastructure.client.SettlementToMemberClient;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -88,21 +87,17 @@ class SettlementInternalServiceImplTest {
             .willReturn(List.of());
         given(settlementRepository.findBySellerIdAndStatus(sellerId, SettlementStatus.PENDING_MIN_AMOUNT))
             .willReturn(List.of(pending));
-        given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
-            eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
-            .willReturn(Optional.empty());
+        givenNotAlreadySettled(sellerId);
         givenSaveReturnsArgument();
 
         service.createSettlementFromItems();
 
-        // 신규 정산 → COMPLETED, carriedInAmount 반영
         Settlement saved = captureNewSettlement();
         assertThat(saved.getStatus()).isEqualTo(SettlementStatus.COMPLETED);
         assertThat(saved.getFinalSettlementAmount()).isEqualTo(10670); // 4850 + 5820
         assertThat(saved.getCarriedInAmount()).isEqualTo(5820);
         assertThat(saved.getCarriedInSettlementId()).isEqualTo(pending.getSettlementId());
 
-        // 이월 체인 해소 → pending COMPLETED로 변경
         assertThat(pending.getStatus()).isEqualTo(SettlementStatus.COMPLETED);
     }
 
@@ -116,9 +111,7 @@ class SettlementInternalServiceImplTest {
             .willReturn(List.of());
         given(settlementRepository.findBySellerIdAndStatus(sellerId, SettlementStatus.PENDING_MIN_AMOUNT))
             .willReturn(List.of(pending));
-        given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
-            eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
-            .willReturn(Optional.empty());
+        givenNotAlreadySettled(sellerId);
         givenSaveReturnsArgument();
 
         service.createSettlementFromItems();
@@ -140,9 +133,7 @@ class SettlementInternalServiceImplTest {
             .willReturn(List.of(pending));
         given(settlementRepository.findBySellerIdAndStatus(carryOverSellerId, SettlementStatus.PENDING_MIN_AMOUNT))
             .willReturn(List.of(pending));
-        given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
-            eq(carryOverSellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
-            .willReturn(Optional.empty());
+        givenNotAlreadySettled(carryOverSellerId);
         givenSaveReturnsArgument();
 
         service.createSettlementFromItems();
@@ -170,9 +161,9 @@ class SettlementInternalServiceImplTest {
         givenReadyItems(List.of(item));
         given(settlementRepository.findByStatus(SettlementStatus.PENDING_MIN_AMOUNT))
             .willReturn(List.of());
-        given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
-            eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
-            .willReturn(Optional.of(buildPendingSettlement(sellerId, 48500)));
+        given(settlementRepository.existsBySellerIdAndPeriodStartAtBetweenAndStatusNot(
+            eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class), eq(SettlementStatus.CANCELLED)))
+            .willReturn(true);
 
         service.createSettlementFromItems();
 
@@ -206,9 +197,7 @@ class SettlementInternalServiceImplTest {
             .willReturn(List.of(pending));
         given(settlementRepository.findBySellerIdAndStatus(carryOverSellerId, SettlementStatus.PENDING_MIN_AMOUNT))
             .willReturn(List.of(pending));
-        given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
-            eq(carryOverSellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
-            .willReturn(Optional.empty());
+        givenNotAlreadySettled(carryOverSellerId);
         givenSaveReturnsArgument();
 
         service.createSettlementFromItems();
@@ -261,9 +250,13 @@ class SettlementInternalServiceImplTest {
             .willReturn(List.of());
         given(settlementRepository.findBySellerIdAndStatus(sellerId, SettlementStatus.PENDING_MIN_AMOUNT))
             .willReturn(List.of());
-        given(settlementRepository.findBySellerIdAndPeriodStartAtBetween(
-            eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
-            .willReturn(Optional.empty());
+        givenNotAlreadySettled(sellerId);
+    }
+
+    private void givenNotAlreadySettled(UUID sellerId) {
+        given(settlementRepository.existsBySellerIdAndPeriodStartAtBetweenAndStatusNot(
+            eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class), eq(SettlementStatus.CANCELLED)))
+            .willReturn(false);
     }
 
     private void givenSaveReturnsArgument() {


### PR DESCRIPTION
## 관련 이슈
- close #488 

## 작업 내용
- Settlement 생성시 "판매자 + 기간"조건으로 기존 Settlement 유무 확인 로직 추가
- SettlementInternalSeriveImpl.createSettlementFromItems내부 로직 private메서드로 코드 분리

## 변경 사항
- SettlementInternalSeriveImpl.createSettlementFromItems 
   - private메서드 : collectItemsBySeller : 판매자별 정산대상 데이터 조회
   - private메서드 : includeCarryOverSellers : 정산최소금액으로 이월된 정산건 조회
   - private메서드 : processSellerSettlement : alreadySettledForPeriod추가해서 중복Settlement검증

## 테스트
- [x] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항