### PR TITLE
[Member] feat(member) : AI 추천용 유저 기술 스택 조회 internal API 추가

### DIFF
--- a/member/src/main/java/com/devticket/member/application/InternalMemberService.java
+++ b/member/src/main/java/com/devticket/member/application/InternalMemberService.java
@@ -1,6 +1,7 @@
 package com.devticket.member.application;
 
 import com.devticket.member.common.exception.BusinessException;
+import com.devticket.member.infrastructure.external.client.AdminInternalClient;
 import com.devticket.member.presentation.domain.MemberErrorCode;
 import com.devticket.member.presentation.domain.SellerApplicationDecision;
 import com.devticket.member.presentation.domain.UserRole;
@@ -8,12 +9,15 @@ import com.devticket.member.presentation.domain.UserStatus;
 import com.devticket.member.presentation.domain.model.SellerApplication;
 import com.devticket.member.presentation.domain.model.User;
 import com.devticket.member.presentation.domain.model.UserProfile;
+import com.devticket.member.presentation.domain.model.UserTechStack;
 import com.devticket.member.presentation.domain.repository.SellerApplicationRepository;
 import com.devticket.member.presentation.domain.repository.UserProfileRepository;
 import com.devticket.member.presentation.domain.repository.UserRepository;
+import com.devticket.member.presentation.domain.repository.UserTechStackRepository;
 import com.devticket.member.presentation.dto.internal.request.InternalDecideSellerApplicationRequest;
 import com.devticket.member.presentation.dto.internal.request.InternalUpdateUserRoleRequest;
 import com.devticket.member.presentation.dto.internal.request.InternalUpdateUserStatusRequest;
+import com.devticket.member.presentation.dto.internal.response.InternalAdminTechStackResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalDecideSellerApplicationResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberInfoResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalMemberRoleResponse;
@@ -23,6 +27,9 @@ import com.devticket.member.presentation.dto.internal.response.InternalSellerApp
 import com.devticket.member.presentation.dto.internal.response.InternalSellerInfoResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalUpdateRoleResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalUpdateStatusResponse;
+import com.devticket.member.presentation.dto.internal.response.InternalUserTechStackResponse;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.List;
 import java.util.Objects;
 import org.springframework.data.domain.Pageable;
@@ -40,6 +47,8 @@ public class InternalMemberService {
     private final UserRepository userRepository;
     private final UserProfileRepository userProfileRepository;
     private final SellerApplicationRepository sellerApplicationRepository;
+    private final UserTechStackRepository userTechStackRepository;
+    private final AdminInternalClient adminInternalClient;
 
 
     public InternalMemberInfoResponse getMemberInfo(UUID userId) {
@@ -154,6 +163,36 @@ public class InternalMemberService {
         return userRepository.findByRole(UserRole.SELLER).stream()
             .map(User::getUserId)
             .toList();
+    }
+
+    // 유저 기술 스택 조회 (AI 추천용)
+    public InternalUserTechStackResponse getUserTechStacks(UUID userId) {
+        User user = findUserByUuidOrThrow(userId);
+
+        List<Long> techStackIds = userTechStackRepository.findByUserId(user.getId()).stream()
+            .map(UserTechStack::getTechStackId)
+            .toList();
+
+        if (techStackIds.isEmpty()) {
+            return new InternalUserTechStackResponse(user.getUserId().toString(), List.of());
+        }
+
+        InternalAdminTechStackResponse adminResponse = adminInternalClient.getTechStacks();
+        Map<Long, String> nameById = adminResponse.techStacks().stream()
+            .collect(Collectors.toMap(
+                InternalAdminTechStackResponse.TechStackInfo::id,
+                InternalAdminTechStackResponse.TechStackInfo::name
+            ));
+
+        List<InternalUserTechStackResponse.TechStackInfo> techStacks = techStackIds.stream()
+            .filter(nameById::containsKey)
+            .map(id -> new InternalUserTechStackResponse.TechStackInfo(
+                id.toString(),
+                nameById.get(id)
+            ))
+            .toList();
+
+        return new InternalUserTechStackResponse(user.getUserId().toString(), techStacks);
     }
 
 }

--- a/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
+++ b/member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java
@@ -15,6 +15,7 @@ import com.devticket.member.presentation.dto.internal.response.InternalSellerApp
 import com.devticket.member.presentation.dto.internal.response.InternalSellerInfoResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalUpdateRoleResponse;
 import com.devticket.member.presentation.dto.internal.response.InternalUpdateStatusResponse;
+import com.devticket.member.presentation.dto.internal.response.InternalUserTechStackResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -175,5 +176,17 @@ public class InternalMemberController {
         @RequestParam List<UUID> userIds
     ) {
         return ResponseEntity.ok(internalMemberService.getMemberInfoBatch(userIds));
+    }
+
+    @Operation(summary = "유저 기술 스택 조회", description = "내부 서비스용 — AI 추천을 위한 유저 기술 스택 조회")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "회원 없음")
+    })
+    @GetMapping("/{userId}/tech-stacks")
+    public ResponseEntity<InternalUserTechStackResponse> getUserTechStacks(
+        @PathVariable UUID userId
+    ) {
+        return ResponseEntity.ok(internalMemberService.getUserTechStacks(userId));
     }
 }

--- a/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalUserTechStackResponse.java
+++ b/member/src/main/java/com/devticket/member/presentation/dto/internal/response/InternalUserTechStackResponse.java
@@ -1,0 +1,13 @@
+package com.devticket.member.presentation.dto.internal.response;
+
+import java.util.List;
+
+public record InternalUserTechStackResponse(
+    String userId,
+    List<TechStackInfo> techStacks
+) {
+    public record TechStackInfo(
+        String techStackId,
+        String name
+    ) {}
+}


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- AI 서비스에서 유저별 추천을 위해 필요로 하는 기술 스택 정보를 조회할 수 있도록 Member 모듈에 internal API 신규 추가
- `UserTechStackRepository`로 유저가 보유한 `techStackId` 목록 조회 후, `AdminInternalClient`를 통해 기술 스택 이름 매핑
- 유저 기술 스택이 없는 경우 Admin 호출을 스킵하고 빈 배열을 반환하도록 처리

## 변경 사항
- `InternalMemberController` - `GET /internal/members/{userId}/tech-stacks` 엔드포인트 추가
- `InternalMemberService` - `getUserTechStacks(UUID userId)` 메서드 추가
  - `UserTechStackRepository`, `AdminInternalClient` 의존성 주입
  - id → name Map 구성 후 유저 보유 스택만 필터링하여 응답 구성
- `InternalUserTechStackResponse` - AI 모듈 스펙에 맞춘 응답 DTO 신규 추가
  - `String userId`, `List<TechStackInfo>` (각 `String techStackId`, `String name`)

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷


## 참고 사항
- 응답 DTO 필드 타입은 AI 모듈 요청 스펙(`UserTechStackResponse`)에 맞춰 `String`으로 통일
- 존재하지 않는 유저 조회 시 `MEMBER_009 (MEMBER_NOT_FOUND, 404)` 반환