### PR TITLE
[Event] fix: Admin 기술스택 응답 구조 불일치 수정 — TechStackItem[] 직접 역직렬화

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -129,7 +129,7 @@ public class EventService {
 
     private Map<Long, String> buildTechStackMap() {
         return adminClient.getTechStacks().stream()
-            .collect(Collectors.toMap(TechStackItem::techStackId, TechStackItem::name));
+            .collect(Collectors.toMap(TechStackItem::id, TechStackItem::name));
     }
 
     @Transactional(readOnly = true)

--- a/event/src/main/java/com/devticket/event/infrastructure/client/AdminClient.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/AdminClient.java
@@ -1,7 +1,6 @@
 package com.devticket.event.infrastructure.client;
 
 import com.devticket.event.infrastructure.client.dto.TechStackItem;
-import com.devticket.event.infrastructure.client.dto.TechStackListResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,11 +21,11 @@ public class AdminClient {
     public List<TechStackItem> getTechStacks() {
         try {
             String url = adminServiceUrl + "/internal/admin/tech-stacks";
-            TechStackListResponse response = restTemplate.getForObject(url, TechStackListResponse.class);
-            if (response == null) {
+            TechStackItem[] items = restTemplate.getForObject(url, TechStackItem[].class);
+            if (items == null) {
                 return List.of();
             }
-            return response.techStacks() != null ? response.techStacks() : List.of();
+            return items != null ? List.of(items) : List.of();
         } catch (Exception e) {
             log.warn("[기술스택 조회 실패] Admin 서비스 호출 오류", e);
             return List.of();

--- a/event/src/main/java/com/devticket/event/infrastructure/client/dto/TechStackItem.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/dto/TechStackItem.java
@@ -1,3 +1,3 @@
 package com.devticket.event.infrastructure.client.dto;
 
-public record TechStackItem(Long techStackId, String name) {}
+public record TechStackItem(Long id, String name) {}

--- a/event/src/main/resources/application.yml
+++ b/event/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
   application:
     name: devticket-event
   profiles:


### PR DESCRIPTION
## 관련 이슈
- close #510 

## 작업 내용
Admin 서비스 기술스택 응답 구조 불일치로 이벤트 기술스택이 "Unknown"으로 저장되는 버그 수정

Event Service가 Admin Service의 `/internal/admin/tech-stacks` 응답을 잘못된 구조로 역직렬화하여
기술스택 이름이 항상 "Unknown"으로 저장되는 문제를 수정합니다.

### 원인
- Admin 서비스 응답: `[{"id": Long, "name": String}, ...]` (raw 배열)
- Event 서비스 기대: `{"techStacks": [{"techStackId": Long, "name": String}, ...]}` (래핑 객체)
- 역직렬화 실패 → catch 블록에서 빈 리스트 반환 → `getOrDefault(id, "Unknown")` → DB에 "Unknown" 저장

### 수정 플로우
1. 이벤트 생성/수정 요청
2. `AdminClient.getTechStacks()` → `TechStackItem[]`로 직접 역직렬화
3. `buildTechStackMap()` → `{id: name}` Map 생성
4. `EventTechStack` 저장 시 정상 기술스택 이름 반영

## 변경 사항
- **AdminClient.java** (수정): `TechStackListResponse` 객체 → `TechStackItem[]` 배열로 직접 역직렬화
- **TechStackItem.java** (수정): 필드명 `techStackId` → `id` (Admin 응답 필드명 일치)
- **EventService.java** (수정): `buildTechStackMap()`에서 `TechStackItem::id` 참조로 변경