### PR TITLE
[Event] refactor: .env import 설정을 application.yml에서 application-local.yml로 이동

### DIFF
--- a/event/src/main/resources/application-local.yml
+++ b/event/src/main/resources/application-local.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
   datasource:
     url: jdbc:postgresql://localhost:5433/devticket?currentSchema=event
     username: devticket

--- a/event/src/main/resources/application.yml
+++ b/event/src/main/resources/application.yml
@@ -1,6 +1,4 @@
 spring:
-  config:
-    import: optional:file:.env[.properties]
   application:
     name: devticket-event
   profiles:


### PR DESCRIPTION
## 작업 내용
`.env` 파일 import 설정을 `application.yml`에서 `application-local.yml`로 이동

`spring.config.import: optional:file:.env[.properties]` 설정이 공통 `application.yml`에 있어
로컬 환경이 아닌 배포 환경에서도 불필요하게 `.env` 파일을 탐색하는 문제를 수정합니다.

### 원인
- `application.yml`은 모든 프로필에서 공통으로 로드되는 설정 파일
- `.env` import는 로컬 개발 환경에서만 필요한 설정

### 수정 내용
- `application.yml`에서 `spring.config.import` 제거
- `application-local.yml`에 `spring.config.import: optional:file:.env[.properties]` 추가
