### PR TITLE
[AI] feat: cold-start mock 데이터 교체

### DIFF
--- a/ai/src/main/java/org/example/ai/infrastructure/external/client/EventServiceClient.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/external/client/EventServiceClient.java
@@ -21,14 +21,19 @@ public class EventServiceClient {
     private String eventServiceUrl;
 
     public PopularEventListResponse getPopularEvents(PopularEventListRequest request) {
-        log.info("[EventClient] 인기 이벤트 조회 (Mock) - neededCount: {}", request.neededCount());
+        log.info("[EventClient] 인기 이벤트 조회 - neededCount: {}", request.neededCount());
 
-        List<PopularEventListResponse.EventInfo> mockEvents = new ArrayList<>();
-        for (int i = 1; i <= request.neededCount(); i++) {
-            mockEvents.add(new PopularEventListResponse.EventInfo("popular-event-" + i));
+        try {
+            return webClient.post()
+                .uri(eventServiceUrl + "/internal/events/popular")
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(PopularEventListResponse.class)
+                .block();
+        } catch (Exception e) {
+            log.error("[EventClient] 인기 이벤트 조회 실패", e);
+            return new PopularEventListResponse(List.of());
         }
-
-        return new PopularEventListResponse(mockEvents);
     }
 
 }

--- a/ai/src/main/java/org/example/ai/infrastructure/external/client/EventServiceClient.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/external/client/EventServiceClient.java
@@ -24,12 +24,14 @@ public class EventServiceClient {
         log.info("[EventClient] 인기 이벤트 조회 - neededCount: {}", request.neededCount());
 
         try {
-            return webClient.post()
+            PopularEventListResponse response = webClient.post()
                 .uri(eventServiceUrl + "/internal/events/popular")
                 .bodyValue(request)
                 .retrieve()
                 .bodyToMono(PopularEventListResponse.class)
                 .block();
+
+            return response != null ? response : new PopularEventListResponse(List.of());
         } catch (Exception e) {
             log.error("[EventClient] 인기 이벤트 조회 실패", e);
             return new PopularEventListResponse(List.of());

--- a/ai/src/main/java/org/example/ai/infrastructure/external/client/MemberServiceClient.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/external/client/MemberServiceClient.java
@@ -20,17 +20,18 @@ public class MemberServiceClient {
     private String memberServiceUrl;
 
     public UserTechStackResponse getUserTechStack(String userId){
-        UserTechStackRequest request = new UserTechStackRequest(userId);
+        log.info("[MemberClient] TechStack 조회 - userId: {}", userId);
 
-        log.info("[MemberClient] TechStack 조회 (Mock) - userId: {}", userId);
-
-        // UserTeckStack Mock 데이터
-        List<UserTechStackResponse.TechStackInfo> mockStacks = List.of(
-            new UserTechStackResponse.TechStackInfo("1", "Java"),
-            new UserTechStackResponse.TechStackInfo("2", "Spring")
-        );
-
-        return new UserTechStackResponse(userId, mockStacks);
+        try {
+            return webClient.get()
+                .uri(memberServiceUrl + "/internal/members/" + userId + "/tech-stacks")
+                .retrieve()
+                .bodyToMono(UserTechStackResponse.class)
+                .block();
+        } catch (Exception e) {
+            log.error("[MemberClient] TechStack 조회 실패 - userId: {}", userId, e);
+            return new UserTechStackResponse(userId, List.of());
+        }
     }
 
 }

--- a/ai/src/main/java/org/example/ai/infrastructure/external/client/MemberServiceClient.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/external/client/MemberServiceClient.java
@@ -23,15 +23,18 @@ public class MemberServiceClient {
         log.info("[MemberClient] TechStack 조회 - userId: {}", userId);
 
         try {
-            return webClient.get()
+            UserTechStackResponse response = webClient.get()
                 .uri(memberServiceUrl + "/internal/members/" + userId + "/tech-stacks")
                 .retrieve()
                 .bodyToMono(UserTechStackResponse.class)
                 .block();
+
+            return response != null ? response : new UserTechStackResponse(userId, List.of());
         } catch (Exception e) {
             log.error("[MemberClient] TechStack 조회 실패 - userId: {}", userId, e);
             return new UserTechStackResponse(userId, List.of());
         }
+
     }
 
 }

--- a/ai/src/main/java/org/example/ai/presentation/dto/req/ActionLogMessage.java
+++ b/ai/src/main/java/org/example/ai/presentation/dto/req/ActionLogMessage.java
@@ -16,6 +16,12 @@ public record ActionLogMessage(
     @JsonProperty("actionType")
     String actionType,
 
+    @JsonProperty("searchKeyword")
+    String searchKeyword,
+
+    @JsonProperty("stackFilter")
+    String stackFilter,
+
     @JsonProperty("dwellTimeSeconds")
     Integer dwellTimeSeconds,
 


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- `MemberServiceClient` Mock 데이터 → Member Service Internal API 실제 호출로 교체
- `EventServiceClient` Mock 데이터 → Event Service Internal API 실제 호출로 교체
- 콜드 스타트 시 유저 TechStack 기반 kNN 추천 실제 동작 확인

## 변경 사항
- `MemberServiceClient` - `GET /internal/members/{userId}/tech-stacks` 실제 호출로 교체
- `EventServiceClient` - `POST /internal/events/popular` 실제 호출로 교체

## 테스트
- [x] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인

## 스크린샷
<!-- 추천 API 응답 캡처 첨부 -->

## 참고 사항
- 콜드 스타트 유저는 TechStack 임베딩 기반 kNN 검색 후 부족분은 인기 이벤트로 채움
