### PR TITLE
[Payment] refactor: 3모듈 통합 결정값 정합 + 회귀 방지 테스트

### DIFF
--- a/payment/src/main/java/com/devticket/payment/common/config/KafkaProducerConfig.java
+++ b/payment/src/main/java/com/devticket/payment/common/config/KafkaProducerConfig.java
@@ -17,6 +17,15 @@ public class KafkaProducerConfig {
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
 
+    @Value("${kafka-producer.max-block-ms:500}")
+    private int maxBlockMs;
+
+    @Value("${kafka-producer.request-timeout-ms:1000}")
+    private int requestTimeoutMs;
+
+    @Value("${kafka-producer.delivery-timeout-ms:1500}")
+    private int deliveryTimeoutMs;
+
     @Bean
     public ProducerFactory<String, String> producerFactory() {
         Map<String, Object> props = new HashMap<>();
@@ -25,9 +34,9 @@ public class KafkaProducerConfig {
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.ACKS_CONFIG, "all");
         props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 1500);
-        props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000);
-        props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 500);
+        props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, maxBlockMs);
+        props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs);
+        props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, deliveryTimeoutMs);
         return new DefaultKafkaProducerFactory<>(props);
     }
 

--- a/payment/src/main/java/com/devticket/payment/common/outbox/Outbox.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/Outbox.java
@@ -19,10 +19,12 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "outbox", indexes = {
+@Table(name = "outbox", schema = "payment", indexes = {
     @Index(name = "idx_outbox_status_created", columnList = "status, created_at")
 })
 public class Outbox extends BaseEntity {
+
+    private static final int MAX_RETRY = 6;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,8 +49,8 @@ public class Outbox extends BaseEntity {
     @Column(nullable = false, length = 20)
     private OutboxStatus status;
 
-    @Column(name = "message_id", nullable = false, unique = true)
-    private UUID messageId;
+    @Column(name = "message_id", nullable = false, unique = true, length = 36)
+    private String messageId;
 
     @Column(name = "retry_count", nullable = false)
     private int retryCount;
@@ -59,18 +61,16 @@ public class Outbox extends BaseEntity {
     @Column(name = "sent_at")
     private Instant sentAt;
 
-    private static final int MAX_RETRY = 5;
-
-    public static Outbox create(String aggregateId, String eventType,
-                                String topic, String partitionKey, String payload) {
+    public static Outbox create(String aggregateId, String partitionKey,
+                                String eventType, String topic, String payload) {
         Outbox outbox = new Outbox();
         outbox.aggregateId = aggregateId;
+        outbox.partitionKey = partitionKey;
         outbox.eventType = eventType;
         outbox.topic = topic;
-        outbox.partitionKey = partitionKey;
         outbox.payload = payload;
         outbox.status = OutboxStatus.PENDING;
-        outbox.messageId = UUID.randomUUID();
+        outbox.messageId = UUID.randomUUID().toString();
         outbox.retryCount = 0;
         return outbox;
     }
@@ -80,12 +80,13 @@ public class Outbox extends BaseEntity {
         this.sentAt = Instant.now();
     }
 
-    public void increaseRetryCount() {
+    public void markFailed() {
         this.retryCount++;
         if (this.retryCount >= MAX_RETRY) {
             this.status = OutboxStatus.FAILED;
         } else {
-            this.nextRetryAt = Instant.now().plusSeconds(this.retryCount * 60L);
+            long backoffSeconds = 1L << (this.retryCount - 1);
+            this.nextRetryAt = Instant.now().plusSeconds(backoffSeconds);
         }
     }
 

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxEventMessage.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxEventMessage.java
@@ -1,19 +1,25 @@
 package com.devticket.payment.common.outbox;
 
 import java.time.Instant;
-import java.util.UUID;
 
 public record OutboxEventMessage(
-    UUID messageId,
+    String messageId,
     String eventType,
+    String topic,
+    String partitionKey,
     String payload,
     Instant timestamp
 ) {
 
     public static OutboxEventMessage from(Outbox outbox) {
+        String key = outbox.getPartitionKey() != null
+            ? outbox.getPartitionKey()
+            : outbox.getAggregateId();
         return new OutboxEventMessage(
             outbox.getMessageId(),
             outbox.getEventType(),
+            outbox.getTopic(),
+            key,
             outbox.getPayload(),
             Instant.now()
         );

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxEventProducer.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxEventProducer.java
@@ -5,11 +5,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
@@ -18,28 +18,37 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class OutboxEventProducer {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ObjectMapper objectMapper;
 
+    @Value("${kafka-producer.send-timeout-ms:2000}")
+    private long sendTimeoutMs = 2000L;
+
+    public OutboxEventProducer(KafkaTemplate<String, String> kafkaTemplate,
+                               ObjectMapper objectMapper) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.objectMapper = objectMapper;
+    }
+
     /**
      * Kafka 메시지를 동기적으로 발행한다.
      * 발행 실패 시 OutboxPublishException을 던진다.
      */
-    public void send(String topic, String key, OutboxEventMessage message) {
+    public void publish(OutboxEventMessage message) {
         try {
             String json = objectMapper.writeValueAsString(message);
 
-            ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, json);
+            ProducerRecord<String, String> record =
+                new ProducerRecord<>(message.topic(), message.partitionKey(), json);
             record.headers().add("X-Message-Id",
-                message.messageId().toString().getBytes(StandardCharsets.UTF_8));
+                message.messageId().getBytes(StandardCharsets.UTF_8));
 
-            var result = kafkaTemplate.send(record).get(2, TimeUnit.SECONDS);
+            var result = kafkaTemplate.send(record).get(sendTimeoutMs, TimeUnit.MILLISECONDS);
 
             log.info("[Outbox] Kafka 발행 성공 — topic={}, messageId={}, offset={}",
-                topic, message.messageId(),
+                message.topic(), message.messageId(),
                 result.getRecordMetadata().offset());
 
         } catch (JsonProcessingException e) {

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxRepository.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxRepository.java
@@ -9,8 +9,8 @@ import org.springframework.data.repository.query.Param;
 public interface OutboxRepository extends JpaRepository<Outbox, Long> {
 
     @Query("SELECT o FROM Outbox o WHERE o.status = :status " +
-           "AND (o.nextRetryAt IS NULL OR o.nextRetryAt <= :now) " +
+           "AND (o.nextRetryAt IS NULL OR o.nextRetryAt < :now) " +
            "ORDER BY o.createdAt ASC LIMIT 50")
-    List<Outbox> findPendingForRetry(@Param("status") OutboxStatus status,
-                                     @Param("now") Instant now);
+    List<Outbox> findPendingToPublish(@Param("status") OutboxStatus status,
+                                      @Param("now") Instant now);
 }

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxScheduler.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxScheduler.java
@@ -20,7 +20,7 @@ public class OutboxScheduler {
     @SchedulerLock(name = "outbox-scheduler", lockAtMostFor = "5m", lockAtLeastFor = "5s")
     public void publishPendingEvents() {
         List<Outbox> pendingList =
-            outboxRepository.findPendingForRetry(OutboxStatus.PENDING, Instant.now());
+            outboxRepository.findPendingToPublish(OutboxStatus.PENDING, Instant.now());
 
         if (pendingList.isEmpty()) {
             return;

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxService.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -20,17 +22,18 @@ public class OutboxService {
      * 반드시 비즈니스 로직과 같은 트랜잭션 안에서 호출해야 한다.
      *
      * @param aggregateId  관련 엔티티 식별자 (UUID 문자열)
+     * @param partitionKey Kafka 파티션 키 (예: orderId)
      * @param eventType    도메인 이벤트 타입 (예: "payment.completed")
      * @param topic        Kafka 토픽명 (예: "payment.completed")
-     * @param partitionKey Kafka 파티션 키 (예: orderId)
-     * @param payload      이벤트 페이로드 객체 (JSON 직렬화됨)
+     * @param event        이벤트 페이로드 객체 (JSON 직렬화됨)
      * @return 생성된 Outbox 엔티티
      */
-    public Outbox save(String aggregateId, String eventType,
-                       String topic, String partitionKey, Object payload) {
+    @Transactional(propagation = Propagation.MANDATORY)
+    public Outbox save(String aggregateId, String partitionKey,
+                       String eventType, String topic, Object event) {
         try {
-            String json = objectMapper.writeValueAsString(payload);
-            Outbox outbox = Outbox.create(aggregateId, eventType, topic, partitionKey, json);
+            String json = objectMapper.writeValueAsString(event);
+            Outbox outbox = Outbox.create(aggregateId, partitionKey, eventType, topic, json);
             return outboxRepository.save(outbox);
         } catch (JsonProcessingException e) {
             log.error("[Outbox] 페이로드 직렬화 실패 — aggregateId={}, eventType={}, topic={}",
@@ -43,15 +46,12 @@ public class OutboxService {
     public void processOne(Outbox outbox) {
         try {
             OutboxEventMessage message = OutboxEventMessage.from(outbox);
-            String key = outbox.getPartitionKey() != null
-                ? outbox.getPartitionKey()
-                : outbox.getAggregateId();
-            outboxEventProducer.send(outbox.getTopic(), key, message);
+            outboxEventProducer.publish(message);
             outbox.markSent();
         } catch (OutboxPublishException e) {
             log.warn("[Outbox] 이벤트 발행 실패 — outboxId={}, eventType={}, retry={}, error={}",
                 outbox.getId(), outbox.getEventType(), outbox.getRetryCount() + 1, e.getMessage());
-            outbox.increaseRetryCount();
+            outbox.markFailed();
         }
         outboxRepository.save(outbox);
     }

--- a/payment/src/main/java/com/devticket/payment/payment/application/scheduler/WalletPgTimeoutHandler.java
+++ b/payment/src/main/java/com/devticket/payment/payment/application/scheduler/WalletPgTimeoutHandler.java
@@ -57,9 +57,9 @@ public class WalletPgTimeoutHandler {
 
         outboxService.save(
             payment.getPaymentId().toString(),
-            KafkaTopics.PAYMENT_FAILED,
-            KafkaTopics.PAYMENT_FAILED,
             payment.getOrderId().toString(),
+            KafkaTopics.PAYMENT_FAILED,
+            KafkaTopics.PAYMENT_FAILED,
             event
         );
 

--- a/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
@@ -163,9 +163,9 @@ public class PaymentServiceImpl implements PaymentService {
             .build();
         outboxService.save(
             payment.getPaymentId().toString(),
-            KafkaTopics.PAYMENT_COMPLETED,
-            KafkaTopics.PAYMENT_COMPLETED,
             payment.getOrderId().toString(),
+            KafkaTopics.PAYMENT_COMPLETED,
+            KafkaTopics.PAYMENT_COMPLETED,
             event
         );
 
@@ -248,9 +248,9 @@ public class PaymentServiceImpl implements PaymentService {
             .build();
         outboxService.save(
             payment.getPaymentId().toString(),
-            KafkaTopics.PAYMENT_FAILED,
-            KafkaTopics.PAYMENT_FAILED,
             payment.getOrderId().toString(),
+            KafkaTopics.PAYMENT_FAILED,
+            KafkaTopics.PAYMENT_FAILED,
             event
         );
 

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -258,9 +258,9 @@ public class WalletServiceImpl implements WalletService {
             .build();
         outboxService.save(
             payment.getPaymentId().toString(),
-            KafkaTopics.PAYMENT_COMPLETED,
-            KafkaTopics.PAYMENT_COMPLETED,
             orderId.toString(),
+            KafkaTopics.PAYMENT_COMPLETED,
+            KafkaTopics.PAYMENT_COMPLETED,
             event
         );
 

--- a/payment/src/main/resources/application-test.yml
+++ b/payment/src/main/resources/application-test.yml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;INIT=CREATE SCHEMA IF NOT EXISTS payment\;CREATE SCHEMA IF NOT EXISTS refund\;CREATE TABLE IF NOT EXISTS payment.shedlock(name VARCHAR(64) NOT NULL PRIMARY KEY, lock_until TIMESTAMP NOT NULL, locked_at TIMESTAMP NOT NULL, locked_by VARCHAR(255) NOT NULL)
     driver-class-name: org.h2.Driver
@@ -25,6 +27,13 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+# EmbeddedKafka 환경용 완화 타임아웃 — 불변식 유지
+kafka-producer:
+  max-block-ms: 3000
+  request-timeout-ms: 5000
+  delivery-timeout-ms: 8000
+  send-timeout-ms: 10000
 
 server:
   port: 8085

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -7,6 +7,14 @@ spring:
 server:
   port: 8084
 
+# Kafka Producer 타임아웃 정합 (kafka-design.md §4 / outbox_fix.md §2)
+# 불변식: max.block.ms < request.timeout.ms ≤ delivery.timeout.ms < send-timeout-ms
+kafka-producer:
+  max-block-ms: 500
+  request-timeout-ms: 1000
+  delivery-timeout-ms: 1500
+  send-timeout-ms: 2000
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html

--- a/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
@@ -638,7 +638,7 @@ class WalletServiceTest {
 
             // then
             then(walletRepository).should(times(1)).useBalanceAtomic(USER_ID, 50_000);
-            then(outboxService).should(times(1)).save(anyString(), eq(KafkaTopics.PAYMENT_COMPLETED), eq(KafkaTopics.PAYMENT_COMPLETED), anyString(), any());
+            then(outboxService).should(times(1)).save(anyString(), anyString(), eq(KafkaTopics.PAYMENT_COMPLETED), eq(KafkaTopics.PAYMENT_COMPLETED), any());
         }
 
         @Test
@@ -711,8 +711,9 @@ class WalletServiceTest {
             // then: outboxService.save에 전달된 payload 검증
             ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
             then(outboxService).should(times(1)).save(
-                anyString(), eq(KafkaTopics.PAYMENT_COMPLETED),
-                eq(KafkaTopics.PAYMENT_COMPLETED), anyString(), payloadCaptor.capture()
+                anyString(), anyString(),
+                eq(KafkaTopics.PAYMENT_COMPLETED), eq(KafkaTopics.PAYMENT_COMPLETED),
+                payloadCaptor.capture()
             );
 
             Object captured = payloadCaptor.getValue();
@@ -745,8 +746,9 @@ class WalletServiceTest {
             // then
             ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
             then(outboxService).should(times(1)).save(
-                anyString(), eq(KafkaTopics.PAYMENT_COMPLETED),
-                eq(KafkaTopics.PAYMENT_COMPLETED), anyString(), payloadCaptor.capture()
+                anyString(), anyString(),
+                eq(KafkaTopics.PAYMENT_COMPLETED), eq(KafkaTopics.PAYMENT_COMPLETED),
+                payloadCaptor.capture()
             );
 
             PaymentCompletedEvent event = (PaymentCompletedEvent) payloadCaptor.getValue();

--- a/payment/src/test/java/com/devticket/payment/common/config/KafkaProducerConfigTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/config/KafkaProducerConfigTest.java
@@ -1,0 +1,93 @@
+package com.devticket.payment.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.devticket.payment.common.outbox.OutboxEventProducer;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Outbox 이중 발행 완화(Issue #481) — Producer 타임아웃과
+ * OutboxEventProducer.sendTimeoutMs 간 정합성 회귀 방지.
+ *
+ * 불변식:
+ *   max.block.ms < request.timeout.ms ≤ delivery.timeout.ms < sendTimeoutMs
+ * 하나라도 깨지면 앱 타임아웃 이전에 Producer 재시도가 종료되지 않아 이중 발행 위험 재발.
+ *
+ * 운영값(@Value default): 500/1000/1500 + sendTimeoutMs 2000.
+ * 테스트 프로파일(application-test.yml): 3000/5000/8000 + sendTimeoutMs 10000.
+ * 두 세트 모두 불변식을 만족해야 한다.
+ */
+class KafkaProducerConfigTest {
+
+    @Test
+    void OutboxEventProducer_sendTimeoutMs_기본값이_운영값_2000ms이다() {
+        OutboxEventProducer producer = new OutboxEventProducer(null, null);
+
+        long sendTimeoutMs = (long) ReflectionTestUtils.getField(producer, "sendTimeoutMs");
+
+        assertThat(sendTimeoutMs)
+                .as("Spring 주입 실패 시 폴백 초기값 — @Value default 와도 일치해야 함")
+                .isEqualTo(2000L);
+    }
+
+    @Test
+    void producerFactory_운영_기본값이_적용되고_ACKS_idempotence가_고정된다() {
+        Map<String, Object> props = buildProps(500, 1000, 1500);
+
+        assertThat(props)
+                .containsEntry(ProducerConfig.MAX_BLOCK_MS_CONFIG, 500)
+                .containsEntry(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000)
+                .containsEntry(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 1500)
+                .containsEntry(ProducerConfig.ACKS_CONFIG, "all")
+                .containsEntry(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+    }
+
+    @Test
+    void 운영_기본값은_불변식을_만족한다() {
+        Map<String, Object> props = buildProps(500, 1000, 1500);
+
+        assertInvariant(props, 2000L);
+    }
+
+    @Test
+    void 테스트_프로파일_완화값도_불변식을_만족한다() {
+        Map<String, Object> props = buildProps(3000, 5000, 8000);
+
+        assertInvariant(props, 10000L);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> buildProps(int maxBlockMs, int requestTimeoutMs, int deliveryTimeoutMs) {
+        KafkaProducerConfig config = new KafkaProducerConfig();
+        ReflectionTestUtils.setField(config, "bootstrapServers", "localhost:9092");
+        ReflectionTestUtils.setField(config, "maxBlockMs", maxBlockMs);
+        ReflectionTestUtils.setField(config, "requestTimeoutMs", requestTimeoutMs);
+        ReflectionTestUtils.setField(config, "deliveryTimeoutMs", deliveryTimeoutMs);
+
+        return ((DefaultKafkaProducerFactory<String, String>) config.producerFactory())
+                .getConfigurationProperties();
+    }
+
+    private void assertInvariant(Map<String, Object> props, long sendTimeoutMs) {
+        int maxBlock = (int) props.get(ProducerConfig.MAX_BLOCK_MS_CONFIG);
+        int request = (int) props.get(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG);
+        int delivery = (int) props.get(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG);
+
+        assertThat(maxBlock)
+                .as("max.block.ms(%d) < request.timeout.ms(%d) — 메타데이터 블로킹 조기 이탈",
+                        maxBlock, request)
+                .isLessThan(request);
+        assertThat(request)
+                .as("request.timeout.ms(%d) ≤ delivery.timeout.ms(%d) — Kafka 클라이언트 필수 제약",
+                        request, delivery)
+                .isLessThanOrEqualTo(delivery);
+        assertThat((long) delivery)
+                .as("delivery.timeout.ms(%d) < sendTimeoutMs(%d) — 앱 타임아웃 이전 Producer 재시도 확정 종료",
+                        delivery, sendTimeoutMs)
+                .isLessThan(sendTimeoutMs);
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxEventProducerTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxEventProducerTest.java
@@ -54,10 +54,12 @@ class OutboxEventProducerTest {
         producer = new OutboxEventProducer(kafkaTemplate, objectMapper);
     }
 
-    private OutboxEventMessage createMessage(UUID messageId) {
+    private OutboxEventMessage createMessage(String messageId) {
         return new OutboxEventMessage(
             messageId,
             "payment.completed",
+            "payment.completed",
+            "order-001",
             "{\"orderId\":\"order-001\"}",
             Instant.now()
         );
@@ -65,7 +67,7 @@ class OutboxEventProducerTest {
 
     private void stubSendSuccess() throws Exception {
         given(kafkaTemplate.send(any(ProducerRecord.class))).willReturn(future);
-        given(future.get(2L, TimeUnit.SECONDS)).willReturn(sendResult);
+        given(future.get(2000L, TimeUnit.MILLISECONDS)).willReturn(sendResult);
         given(sendResult.getRecordMetadata()).willReturn(recordMetadata);
         given(recordMetadata.offset()).willReturn(42L);
     }
@@ -76,21 +78,21 @@ class OutboxEventProducerTest {
 
         @Test
         void 발행_성공_시_예외_없음() throws Exception {
-            OutboxEventMessage message = createMessage(UUID.randomUUID());
+            OutboxEventMessage message = createMessage(UUID.randomUUID().toString());
             stubSendSuccess();
 
-            assertThatCode(() -> producer.send("payment.completed", "order-001", message))
+            assertThatCode(() -> producer.publish(message))
                 .doesNotThrowAnyException();
         }
 
         @Test
         @SuppressWarnings("unchecked")
         void X_Message_Id_헤더_세팅됨() throws Exception {
-            UUID messageId = UUID.randomUUID();
+            String messageId = UUID.randomUUID().toString();
             OutboxEventMessage message = createMessage(messageId);
             stubSendSuccess();
 
-            producer.send("payment.completed", "order-001", message);
+            producer.publish(message);
 
             ArgumentCaptor<ProducerRecord<String, String>> captor =
                 ArgumentCaptor.forClass(ProducerRecord.class);
@@ -98,7 +100,22 @@ class OutboxEventProducerTest {
             Header header = captor.getValue().headers().lastHeader("X-Message-Id");
             assertThat(header).isNotNull();
             assertThat(new String(header.value(), StandardCharsets.UTF_8))
-                .isEqualTo(messageId.toString());
+                .isEqualTo(messageId);
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void ProducerRecord의_topic과_key가_메시지와_일치() throws Exception {
+            OutboxEventMessage message = createMessage(UUID.randomUUID().toString());
+            stubSendSuccess();
+
+            producer.publish(message);
+
+            ArgumentCaptor<ProducerRecord<String, String>> captor =
+                ArgumentCaptor.forClass(ProducerRecord.class);
+            then(kafkaTemplate).should().send(captor.capture());
+            assertThat(captor.getValue().topic()).isEqualTo("payment.completed");
+            assertThat(captor.getValue().key()).isEqualTo("order-001");
         }
     }
 
@@ -108,35 +125,35 @@ class OutboxEventProducerTest {
 
         @Test
         void TimeoutException_래핑() throws Exception {
-            OutboxEventMessage message = createMessage(UUID.randomUUID());
+            OutboxEventMessage message = createMessage(UUID.randomUUID().toString());
             given(kafkaTemplate.send(any(ProducerRecord.class))).willReturn(future);
-            given(future.get(2L, TimeUnit.SECONDS))
+            given(future.get(2000L, TimeUnit.MILLISECONDS))
                 .willThrow(new TimeoutException("send timed out"));
 
-            assertThatThrownBy(() -> producer.send("payment.completed", "order-001", message))
+            assertThatThrownBy(() -> producer.publish(message))
                 .isInstanceOf(OutboxPublishException.class)
                 .hasMessageContaining("Kafka 발행 실패");
         }
 
         @Test
         void ExecutionException_래핑() throws Exception {
-            OutboxEventMessage message = createMessage(UUID.randomUUID());
+            OutboxEventMessage message = createMessage(UUID.randomUUID().toString());
             given(kafkaTemplate.send(any(ProducerRecord.class))).willReturn(future);
-            given(future.get(2L, TimeUnit.SECONDS))
+            given(future.get(2000L, TimeUnit.MILLISECONDS))
                 .willThrow(new ExecutionException("broker error", new RuntimeException()));
 
-            assertThatThrownBy(() -> producer.send("payment.completed", "order-001", message))
+            assertThatThrownBy(() -> producer.publish(message))
                 .isInstanceOf(OutboxPublishException.class)
                 .hasMessageContaining("Kafka 발행 실패");
         }
 
         @Test
         void KafkaException_래핑() {
-            OutboxEventMessage message = createMessage(UUID.randomUUID());
+            OutboxEventMessage message = createMessage(UUID.randomUUID().toString());
             given(kafkaTemplate.send(any(ProducerRecord.class)))
                 .willThrow(new KafkaException("producer closed"));
 
-            assertThatThrownBy(() -> producer.send("payment.completed", "order-001", message))
+            assertThatThrownBy(() -> producer.publish(message))
                 .isInstanceOf(OutboxPublishException.class)
                 .hasMessageContaining("Kafka 발행 실패");
         }

--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxRepositoryTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxRepositoryTest.java
@@ -1,0 +1,148 @@
+package com.devticket.payment.common.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * OutboxRepository.findPendingToPublish — 쿼리 경계 조건 회귀 방지.
+ *
+ * outbox_fix.md §2 결정값:
+ *  - 연산자: `o.nextRetryAt < :now` (경계 배제 — `== now`는 다음 틱에서 픽업)
+ *  - LIMIT: 50 (배치 상한)
+ *
+ * @SpringBootTest + @Transactional — 각 테스트 메서드 종료 시 자동 롤백.
+ * @DataJpaTest 는 본 프로젝트 Spring Boot 4.0 starter 구성상 사용 불가.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("OutboxRepository — 쿼리 경계 조건")
+class OutboxRepositoryTest {
+
+    @Autowired
+    private OutboxRepository outboxRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    /**
+     * Outbox 엔티티는 `nextRetryAt` 세터가 없으므로 native UPDATE 로 조정.
+     */
+    private Outbox saveWithNextRetryAt(Instant nextRetryAt) {
+        Outbox outbox = Outbox.create(
+            "agg-" + System.nanoTime(),
+            "pk-1",
+            "payment.completed",
+            "payment.completed",
+            "{}"
+        );
+        outboxRepository.saveAndFlush(outbox);
+        if (nextRetryAt != null) {
+            em.createQuery("UPDATE Outbox o SET o.nextRetryAt = :t WHERE o.id = :id")
+                .setParameter("t", nextRetryAt)
+                .setParameter("id", outbox.getId())
+                .executeUpdate();
+            em.flush();
+            em.clear();
+        }
+        return outbox;
+    }
+
+    @Nested
+    @DisplayName("< :now 경계 조건")
+    class BoundaryCondition {
+
+        @Test
+        void nextRetryAt_NULL은_항상_픽업된다() {
+            Outbox saved = saveWithNextRetryAt(null);
+
+            List<Outbox> result = outboxRepository.findPendingToPublish(
+                OutboxStatus.PENDING, Instant.now());
+
+            assertThat(result).extracting(Outbox::getId).contains(saved.getId());
+        }
+
+        @Test
+        void nextRetryAt이_현재보다_과거이면_픽업된다() {
+            Instant now = Instant.now();
+            Outbox saved = saveWithNextRetryAt(now.minusSeconds(1));
+
+            List<Outbox> result = outboxRepository.findPendingToPublish(
+                OutboxStatus.PENDING, now);
+
+            assertThat(result).extracting(Outbox::getId).contains(saved.getId());
+        }
+
+        @Test
+        void nextRetryAt이_현재와_동일하면_스킵된다() {
+            // `<` 연산자라서 경계값은 배제 — 다음 틱에서 픽업됨
+            Instant now = Instant.now();
+            Outbox saved = saveWithNextRetryAt(now);
+
+            List<Outbox> result = outboxRepository.findPendingToPublish(
+                OutboxStatus.PENDING, now);
+
+            assertThat(result).extracting(Outbox::getId).doesNotContain(saved.getId());
+        }
+
+        @Test
+        void nextRetryAt이_현재보다_미래이면_스킵된다() {
+            Instant now = Instant.now();
+            Outbox saved = saveWithNextRetryAt(now.plusSeconds(10));
+
+            List<Outbox> result = outboxRepository.findPendingToPublish(
+                OutboxStatus.PENDING, now);
+
+            assertThat(result).extracting(Outbox::getId).doesNotContain(saved.getId());
+        }
+
+        @Test
+        void SENT_상태는_픽업되지_않는다() {
+            Outbox outbox = Outbox.create("agg-sent-" + System.nanoTime(), "pk", "t", "t", "{}");
+            outbox.markSent();
+            outboxRepository.saveAndFlush(outbox);
+
+            List<Outbox> result = outboxRepository.findPendingToPublish(
+                OutboxStatus.PENDING, Instant.now());
+
+            assertThat(result).extracting(Outbox::getId).doesNotContain(outbox.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("LIMIT 50 배치 상한")
+    class BatchLimit {
+
+        @Test
+        @DisplayName("51건 저장 시 50건만 반환된다")
+        void returns_at_most_50() {
+            for (int i = 0; i < 51; i++) {
+                outboxRepository.save(Outbox.create(
+                    "agg-limit-" + System.nanoTime() + "-" + i,
+                    "pk-" + i,
+                    "payment.completed",
+                    "payment.completed",
+                    "{\"i\":" + i + "}"
+                ));
+            }
+            em.flush();
+
+            List<Outbox> result = outboxRepository.findPendingToPublish(
+                OutboxStatus.PENDING, Instant.now());
+
+            assertThat(result).hasSize(50);
+        }
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxSchedulerIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxSchedulerIntegrationTest.java
@@ -1,0 +1,127 @@
+package com.devticket.payment.common.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import net.javacrumbs.shedlock.core.LockProvider;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Outbox 스케줄러 E2E — EmbeddedKafka.
+ *
+ * 검증:
+ * 1. Outbox row PENDING → 스케줄러 → Kafka 발행 + DB SENT 전이
+ * 2. X-Message-Id 헤더 세팅 + partitionKey → Kafka record key 보존
+ *
+ * 선례: Commerce PR #482 `OutboxSchedulerIntegrationTest`
+ * (프로젝트 일관성을 위해 PaymentKafkaIntegrationTest 동일한 @KafkaListener 패턴 채택)
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DirtiesContext
+@EmbeddedKafka(
+        partitions = 1,
+        topics = {"payment.completed"},
+        bootstrapServersProperty = "spring.kafka.bootstrap-servers"
+)
+@DisplayName("Outbox Scheduler 통합 테스트 (EmbeddedKafka)")
+class OutboxSchedulerIntegrationTest {
+
+    // ShedLock JdbcTemplateLockProvider 는 H2(테스트 프로파일)에서 usingDbTime 등
+    // 호환성 이슈가 있고, @MockitoBean Mock stub 타이밍이 AOP 첫 tick 전에
+    // 반영되지 않아 "It's locked" 로 건너뛰는 케이스가 발생함.
+    // ShedLock 6.3.1의 BeanNameSelectingLockProviderSupplier 는 Bean 이름 기반 선택이므로
+    // 이름을 `lockProvider` 로 맞춰 main 빈을 오버라이드한다.
+    @TestConfiguration
+    static class NoOpLockProviderConfig {
+        @Bean(name = "lockProvider")
+        @Primary
+        LockProvider lockProvider() {
+            return lockConfiguration -> Optional.of(() -> {});
+        }
+    }
+
+    @Autowired
+    private OutboxRepository outboxRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final List<ConsumerRecord<String, String>> received =
+            Collections.synchronizedList(new ArrayList<>());
+
+    @KafkaListener(topics = "payment.completed", groupId = "outbox-scheduler-it")
+    void listen(ConsumerRecord<String, String> record) {
+        received.add(record);
+    }
+
+    @BeforeEach
+    void setUp() {
+        received.clear();
+    }
+
+    @Test
+    void publishPendingEvents_대기중인_레코드를_발행하고_SENT로_변경한다() throws Exception {
+        // given
+        Outbox saved = outboxRepository.save(
+                Outbox.create(
+                        "aggregate-1",
+                        "partition-1",
+                        "PaymentCompleted",
+                        "payment.completed",
+                        "{\"orderId\":1}"
+                )
+        );
+        String expectedMessageId = saved.getMessageId();
+
+        // when & then: Kafka 레코드 도착 검증
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> assertThat(received).isNotEmpty());
+
+        ConsumerRecord<String, String> record = received.get(0);
+
+        assertThat(record.key()).isEqualTo("partition-1");
+        assertThat(record.headers().lastHeader("X-Message-Id")).isNotNull();
+        assertThat(new String(record.headers().lastHeader("X-Message-Id").value()))
+                .isEqualTo(expectedMessageId);
+
+        // OutboxEventMessage JSON 래핑 구조 검증 — payload 필드 내 실제 도메인 이벤트 보존
+        JsonNode envelope = objectMapper.readTree(record.value());
+        assertThat(envelope.get("eventType").asText()).isEqualTo("PaymentCompleted");
+        assertThat(envelope.get("topic").asText()).isEqualTo("payment.completed");
+        assertThat(envelope.get("partitionKey").asText()).isEqualTo("partition-1");
+        JsonNode payloadNode = objectMapper.readTree(envelope.get("payload").asText());
+        assertThat(payloadNode.get("orderId").asInt()).isEqualTo(1);
+
+        // Outbox 상태 갱신은 발행 직후 별도 트랜잭션으로 커밋되므로 독립 대기
+        await()
+                .atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> {
+                    Outbox outbox = outboxRepository.findById(saved.getId()).orElseThrow();
+                    assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.SENT);
+                    assertThat(outbox.getSentAt()).isNotNull();
+                });
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxSchedulerTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxSchedulerTest.java
@@ -30,16 +30,16 @@ class OutboxSchedulerTest {
     private Outbox createOutbox(String topic, String partitionKey) {
         return Outbox.create(
             "agg-id-001",
+            partitionKey,
             "payment.completed",
             topic,
-            partitionKey,
             "{\"orderId\":\"order-uuid-001\"}"
         );
     }
 
     @Test
     void PENDING_없으면_processOne_미호출() {
-        given(outboxRepository.findPendingForRetry(any(), any())).willReturn(List.of());
+        given(outboxRepository.findPendingToPublish(any(), any())).willReturn(List.of());
 
         scheduler.publishPendingEvents();
 
@@ -49,7 +49,7 @@ class OutboxSchedulerTest {
     @Test
     void PENDING_단건이면_processOne_1회_호출() {
         Outbox outbox = createOutbox("payment.completed", "order-uuid-001");
-        given(outboxRepository.findPendingForRetry(any(), any())).willReturn(List.of(outbox));
+        given(outboxRepository.findPendingToPublish(any(), any())).willReturn(List.of(outbox));
 
         scheduler.publishPendingEvents();
 
@@ -61,7 +61,7 @@ class OutboxSchedulerTest {
         Outbox o1 = createOutbox("payment.completed", "order-001");
         Outbox o2 = createOutbox("payment.completed", "order-002");
         Outbox o3 = createOutbox("payment.completed", "order-003");
-        given(outboxRepository.findPendingForRetry(any(), any())).willReturn(List.of(o1, o2, o3));
+        given(outboxRepository.findPendingToPublish(any(), any())).willReturn(List.of(o1, o2, o3));
 
         scheduler.publishPendingEvents();
 

--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxServicePropagationTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxServicePropagationTest.java
@@ -1,0 +1,62 @@
+package com.devticket.payment.common.outbox;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.IllegalTransactionStateException;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * OutboxService.save() @Transactional(propagation=MANDATORY) 불변식 회귀 방지.
+ *
+ * outbox_fix.md §2:
+ *   외부 `@Transactional` 없이 호출되면 비즈니스 DB 커밋과 Outbox 커밋 분리 위험 →
+ *   MANDATORY 로 강제하여 컴파일 이후 첫 호출 시 예외 발생.
+ *
+ * 본 테스트가 통과해야 "실수로 @Transactional 빠뜨린 호출부"를 CI 에서 즉시 감지 가능.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("OutboxService.save() — @Transactional(MANDATORY) 불변식")
+class OutboxServicePropagationTest {
+
+    @Autowired
+    private OutboxService outboxService;
+
+    @Test
+    void 외부_트랜잭션_없이_호출하면_IllegalTransactionStateException() {
+        assertThatThrownBy(() ->
+            outboxService.save(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                "payment.completed",
+                "payment.completed",
+                new TestEvent("order-1")
+            )
+        ).isInstanceOf(IllegalTransactionStateException.class);
+    }
+
+    @Test
+    @Transactional
+    void 외부_트랜잭션_안에서_호출하면_정상_저장() {
+        assertThatCode(() ->
+            outboxService.save(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                "payment.completed",
+                "payment.completed",
+                new TestEvent("order-2")
+            )
+        ).doesNotThrowAnyException();
+    }
+
+    private record TestEvent(String orderId) {}
+}

--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxServiceTest.java
@@ -3,7 +3,6 @@ package com.devticket.payment.common.outbox;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.times;
@@ -13,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -36,9 +36,9 @@ class OutboxServiceTest {
     private Outbox createOutbox(String topic, String partitionKey) {
         return Outbox.create(
             "agg-id-001",
+            partitionKey,
             "payment.completed",
             topic,
-            partitionKey,
             "{\"orderId\":\"order-uuid-001\"}"
         );
     }
@@ -53,8 +53,10 @@ class OutboxServiceTest {
 
             outboxService.processOne(outbox);
 
-            then(outboxEventProducer).should(times(1))
-                .send(eq("payment.completed"), eq("order-uuid-001"), any());
+            ArgumentCaptor<OutboxEventMessage> captor = ArgumentCaptor.forClass(OutboxEventMessage.class);
+            then(outboxEventProducer).should(times(1)).publish(captor.capture());
+            assertThat(captor.getValue().topic()).isEqualTo("payment.completed");
+            assertThat(captor.getValue().partitionKey()).isEqualTo("order-uuid-001");
         }
 
         @Test
@@ -81,8 +83,9 @@ class OutboxServiceTest {
 
             outboxService.processOne(outbox);
 
-            then(outboxEventProducer).should(times(1))
-                .send(eq("payment.completed"), eq("agg-id-001"), any());
+            ArgumentCaptor<OutboxEventMessage> captor = ArgumentCaptor.forClass(OutboxEventMessage.class);
+            then(outboxEventProducer).should(times(1)).publish(captor.capture());
+            assertThat(captor.getValue().partitionKey()).isEqualTo("agg-id-001");
         }
 
         @Test
@@ -103,7 +106,7 @@ class OutboxServiceTest {
         void 발행_실패_시_retryCount_증가() {
             Outbox outbox = createOutbox("payment.completed", "order-uuid-001");
             willThrow(new OutboxPublishException("Kafka 연결 실패", new RuntimeException()))
-                .given(outboxEventProducer).send(any(), any(), any());
+                .given(outboxEventProducer).publish(any());
 
             outboxService.processOne(outbox);
 
@@ -114,7 +117,7 @@ class OutboxServiceTest {
         void 발행_실패_시_nextRetryAt_설정() {
             Outbox outbox = createOutbox("payment.completed", "order-uuid-001");
             willThrow(new OutboxPublishException("Kafka 연결 실패", new RuntimeException()))
-                .given(outboxEventProducer).send(any(), any(), any());
+                .given(outboxEventProducer).publish(any());
 
             outboxService.processOne(outbox);
 
@@ -125,7 +128,7 @@ class OutboxServiceTest {
         void 발행_실패_시_예외_미전파() {
             Outbox outbox = createOutbox("payment.completed", "order-uuid-001");
             willThrow(new OutboxPublishException("전체 오류", new RuntimeException()))
-                .given(outboxEventProducer).send(any(), any(), any());
+                .given(outboxEventProducer).publish(any());
 
             assertThatCode(() -> outboxService.processOne(outbox))
                 .doesNotThrowAnyException();
@@ -135,7 +138,7 @@ class OutboxServiceTest {
         void 발행_실패여도_save_호출() {
             Outbox outbox = createOutbox("payment.completed", "order-uuid-001");
             willThrow(new OutboxPublishException("Kafka 오류", new RuntimeException()))
-                .given(outboxEventProducer).send(any(), any(), any());
+                .given(outboxEventProducer).publish(any());
 
             outboxService.processOne(outbox);
 

--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @DisplayName("Outbox 엔티티")
 class OutboxTest {
@@ -17,16 +19,12 @@ class OutboxTest {
     void setUp() {
         outbox = Outbox.create(
             "payment-uuid-001",
-            "payment.completed",
-            "payment.completed",
             "order-uuid-001",
+            "payment.completed",
+            "payment.completed",
             "{\"orderId\":\"order-uuid-001\"}"
         );
     }
-
-    // =====================================================================
-    // 생성
-    // =====================================================================
 
     @Nested
     @DisplayName("생성")
@@ -58,11 +56,15 @@ class OutboxTest {
             assertThat(outbox.getTopic()).isEqualTo("payment.completed");
             assertThat(outbox.getPartitionKey()).isEqualTo("order-uuid-001");
         }
-    }
 
-    // =====================================================================
-    // 발행 성공 — markSent()
-    // =====================================================================
+        @Test
+        void messageId는_36자리_UUID_문자열() {
+            assertThat(outbox.getMessageId())
+                .isNotNull()
+                .hasSize(36)
+                .matches("^[0-9a-fA-F-]{36}$");
+        }
+    }
 
     @Nested
     @DisplayName("발행 성공 — markSent()")
@@ -70,22 +72,14 @@ class OutboxTest {
 
         @Test
         void markSent_호출_후_status가_SENT() {
-            // when
             outbox.markSent();
-
-            // then
             assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.SENT);
         }
 
         @Test
         void markSent_호출_후_sentAt_채워짐() {
-            // given
             Instant before = Instant.now();
-
-            // when
             outbox.markSent();
-
-            // then
             assertThat(outbox.getSentAt())
                 .isNotNull()
                 .isAfterOrEqualTo(before);
@@ -93,40 +87,25 @@ class OutboxTest {
 
         @Test
         void markSent_후_isPending_false() {
-            // when
             outbox.markSent();
-
-            // then
             assertThat(outbox.isPending()).isFalse();
         }
     }
 
-    // =====================================================================
-    // 재시도 — increaseRetryCount()
-    // =====================================================================
-
     @Nested
-    @DisplayName("재시도 — increaseRetryCount()")
-    class IncreaseRetryCount {
+    @DisplayName("재시도 — markFailed() 지수 백오프")
+    class MarkFailed {
 
         @Test
         void 재시도_호출_시_retryCount_1_증가() {
-            // when
-            outbox.increaseRetryCount();
-
-            // then
+            outbox.markFailed();
             assertThat(outbox.getRetryCount()).isEqualTo(1);
         }
 
         @Test
         void 재시도_시_nextRetryAt이_현재_이후로_설정() {
-            // given
             Instant before = Instant.now();
-
-            // when
-            outbox.increaseRetryCount();
-
-            // then
+            outbox.markFailed();
             assertThat(outbox.getNextRetryAt())
                 .isNotNull()
                 .isAfterOrEqualTo(before);
@@ -134,64 +113,61 @@ class OutboxTest {
 
         @Test
         void MAX_RETRY_미만이면_status_PENDING_유지() {
-            // when: 4회 재시도 (MAX_RETRY = 5)
-            for (int i = 0; i < 4; i++) {
-                outbox.increaseRetryCount();
-            }
-
-            // then
-            assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PENDING);
-            assertThat(outbox.getRetryCount()).isEqualTo(4);
-        }
-
-        @Test
-        void MAX_RETRY_도달_시_status가_FAILED() {
-            // when: 5회 재시도
+            // 5회 재시도 (MAX_RETRY = 6)
             for (int i = 0; i < 5; i++) {
-                outbox.increaseRetryCount();
+                outbox.markFailed();
             }
-
-            // then
-            assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
+            assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PENDING);
             assertThat(outbox.getRetryCount()).isEqualTo(5);
         }
 
         @Test
-        void 재시도_횟수에_따른_백오프_간격_증가() {
-            // 1차 재시도: 60초, 2차: 120초, 3차: 180초
-            Instant before1 = Instant.now();
-            outbox.increaseRetryCount(); // retryCount=1
-            Instant after1 = outbox.getNextRetryAt();
-
-            Instant before2 = Instant.now();
-            outbox.increaseRetryCount(); // retryCount=2
-            Instant after2 = outbox.getNextRetryAt();
-
-            // 2차 nextRetryAt이 1차보다 더 먼 미래
-            assertThat(after2).isAfter(after1);
+        void MAX_RETRY_도달_시_status가_FAILED() {
+            // 6회 재시도
+            for (int i = 0; i < 6; i++) {
+                outbox.markFailed();
+            }
+            assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
+            assertThat(outbox.getRetryCount()).isEqualTo(6);
         }
 
-        @Test
-        void markSent_후_sentAt이_Instant_타입() {
-            // when
-            outbox.markSent();
+        /**
+         * 회차별 지수 백오프 정확값 — 2^(retryCount-1) 초.
+         * 1→1s / 2→2s / 3→4s / 4→8s / 5→16s (6회차는 FAILED 전환으로 nextRetryAt 미세팅)
+         */
+        @ParameterizedTest(name = "retryCount={0} → {1}초")
+        @CsvSource({
+            "1, 1",
+            "2, 2",
+            "3, 4",
+            "4, 8",
+            "5, 16"
+        })
+        void 회차별_지수_백오프_정확값(int attempts, long expectedSeconds) {
+            Instant before = Instant.now();
+            for (int i = 0; i < attempts; i++) {
+                outbox.markFailed();
+            }
 
-            // then
-            assertThat(outbox.getSentAt()).isInstanceOf(Instant.class);
+            assertThat(outbox.getRetryCount()).isEqualTo(attempts);
+            // 허용 오차 ±1초 (markFailed() 내부 Instant.now() 호출 타이밍)
+            long actualDelta = outbox.getNextRetryAt().getEpochSecond() - before.getEpochSecond();
+            assertThat(actualDelta)
+                .as("retryCount=%d 에서 expectedSeconds=%d 근사 (±1초 허용)", attempts, expectedSeconds)
+                .isBetween(expectedSeconds - 1, expectedSeconds + 1);
         }
 
         @Test
         void MAX_RETRY_도달_시_nextRetryAt_갱신_안됨() {
-            // given: 4회까지 nextRetryAt 설정
-            for (int i = 0; i < 4; i++) {
-                outbox.increaseRetryCount();
+            // 5회까지 nextRetryAt 설정
+            for (int i = 0; i < 5; i++) {
+                outbox.markFailed();
             }
             Instant nextRetryAtBefore = outbox.getNextRetryAt();
 
-            // when: 5회째 → FAILED 전환, nextRetryAt 갱신 없음
-            outbox.increaseRetryCount();
+            // 6회째 → FAILED 전환, nextRetryAt 갱신 없음
+            outbox.markFailed();
 
-            // then
             assertThat(outbox.getNextRetryAt()).isEqualTo(nextRetryAtBefore);
         }
     }

--- a/payment/src/test/java/com/devticket/payment/integration/PaymentKafkaIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/integration/PaymentKafkaIntegrationTest.java
@@ -129,9 +129,9 @@ class PaymentKafkaIntegrationTest {
 
             Outbox outbox = Outbox.create(
                 payment.getPaymentId().toString(),
-                "payment.completed",
-                "payment.completed",
                 orderId.toString(),
+                "payment.completed",
+                "payment.completed",
                 payload
             );
             outboxRepository.save(outbox);
@@ -176,9 +176,9 @@ class PaymentKafkaIntegrationTest {
 
             Outbox outbox = Outbox.create(
                 payment.getPaymentId().toString(),
-                "payment.completed",
-                "payment.completed",
                 orderId.toString(),
+                "payment.completed",
+                "payment.completed",
                 payload
             );
             outboxRepository.save(outbox);
@@ -218,9 +218,9 @@ class PaymentKafkaIntegrationTest {
 
             Outbox outbox = Outbox.create(
                 payment.getPaymentId().toString(),
-                "payment.failed",
-                "payment.failed",
                 orderId.toString(),
+                "payment.failed",
+                "payment.failed",
                 payload
             );
             outboxRepository.save(outbox);
@@ -273,7 +273,7 @@ class PaymentKafkaIntegrationTest {
             assertThat(completedPayment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
 
             // Outbox INSERT 확인
-            List<Outbox> outboxes = outboxRepository.findPendingForRetry(
+            List<Outbox> outboxes = outboxRepository.findPendingToPublish(
                 OutboxStatus.PENDING, java.time.Instant.now().plusSeconds(60));
             assertThat(outboxes).anyMatch(o ->
                 "payment.completed".equals(o.getEventType())


### PR DESCRIPTION
## Summary
- `docs/outbox_fix.md` §2 통합 결정값으로 Payment Outbox 구현 수렴 (B1~B5, B7)
- Commerce 선례(PR #482) 패턴 반영 — Producer 타임아웃 `@Value` 외부화 + 불변식 가드
- 고가치 회귀 방지 테스트 4종 신규 (B6/B8 + T2/T3)

## Changes

### [B1] 재시도 6회 지수 백오프
- `MAX_RETRY` 5→6, `nextRetryAt = 2^(n-1)s` (1·2·4·8·16·32)
- `increaseRetryCount()` → `markFailed()` (상수 내부화)

### [B2] `OutboxService.save()` 시그니처 재정렬 + `@Transactional(MANDATORY)`
- `(aggregateId, partitionKey, eventType, topic, event)` — Commerce 기준
- `Outbox.create()` 동일 순서
- 호출부 4곳 반영 (`PaymentServiceImpl` 2, `WalletServiceImpl` 1, `WalletPgTimeoutHandler` 1)

### [B3] Producer `publish(OutboxEventMessage) void throws OutboxPublishException`
- `OutboxEventMessage`에 `topic`/`partitionKey` 필드 추가 → Producer가 엔티티 비의존

### [B4] `@Table(schema=\"payment\")` + `messageId` UUID→String(36)
> ⚠️ DB 마이그레이션 (UUID→VARCHAR(36))은 **별건 이슈로 분리** — PostgreSQL `USING message_id::text` 명시 필요

### [B5] Repository — `findPendingForRetry` → `findPendingToPublish` / `<= :now` → `< :now`

### [B7] Commerce 선례 — 타임아웃 `@Value` 외부화
- `KafkaProducerConfig`: `maxBlockMs`/`requestTimeoutMs`/`deliveryTimeoutMs`
- `OutboxEventProducer`: `sendTimeoutMs`
- `application.yml` 운영값 (500/1000/1500 + 2000)
- `application-test.yml` 완화값 (3000/5000/8000 + 10000)

### [B6/B8 + T2/T3] 회귀 방지 테스트 신규
- **`KafkaProducerConfigTest`** — 타임아웃 불변식 `max.block < request ≤ delivery < sendTimeout` (운영/테스트 두 세트)
- **`OutboxSchedulerIntegrationTest`** — EmbeddedKafka E2E + `@KafkaListener` + `NoOpLockProviderConfig`
- **`OutboxServicePropagationTest`** — `@Transactional(MANDATORY)` 불변식 (외부 TX 없이 호출 시 `IllegalTransactionStateException`)
- **`OutboxRepositoryTest`** — `< :now` 경계 4케이스(NULL/past/equal/future) + SENT 배제 + LIMIT 50

## Commits
- `4fc0a20` refactor — 기능 변경 + 기존 테스트 시그니처 갱신 (18 files, +195/-155)
- `c70ba7e` test — 회귀 방지 테스트 이식 (4 files, +430)

## Test plan
- [x] `./gradlew test` 전체 192건 통과 (flaky 1건 재실행 후 통과)
- [x] OutboxTest 지수 백오프 회차별 정확값 (1/2/4/8/16s) parametrized
- [x] EmbeddedKafka E2E — Kafka 발행 + DB SENT 전이 + X-Message-Id 헤더
- [x] Repository 경계 4케이스 + LIMIT 50
- [ ] 수동 검증 — local Kafka 환경에서 Outbox 발행 후 스케줄러 동작 확인 (reviewer)

## 미처리 (별건 이슈 권고)
- `outbox.message_id` 컬럼 UUID→VARCHAR(36) 운영 DB 마이그레이션 스크립트
- 기존 선형 5회 재시도 상태의 PENDING 레코드 `nextRetryAt` 재산정 정책 (운영팀 논의)

Refs: #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)