### PR TITLE
[ai] : fix(ai) 모킹 데이터 교체

### DIFF
--- a/ai/src/main/java/org/example/ai/infrastructure/persistence/repository/TechStackEmbeddingRepositoryImpl.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/persistence/repository/TechStackEmbeddingRepositoryImpl.java
@@ -18,12 +18,45 @@ public class TechStackEmbeddingRepositoryImpl implements TechStackEmbeddingRepos
     // mock 데이터
     @Override
     public Optional<float[]> findEmbeddingByName(String techStackName) {
-        log.info("[TechStackEmbedding] 조회 (Mock) - name: {}", techStackName);
+        log.info("[TechStackEmbedding] 조회 - name: {}", techStackName);
 
-        float[] mockEmbedding = new float[1536];
-        mockEmbedding[0] = 0.1f;
-        mockEmbedding[1] = 0.2f;
+        try {
+            var response = elasticsearchClient.search(s -> s
+                    .index("techstack")
+                    .query(q -> q
+                        .term(t -> t
+                            .field("name")
+                            .value(techStackName)
+                        )
+                    )
+                    .source(src -> src
+                        .filter(f -> f
+                            .includes("embedding")
+                        )
+                    ),
+                java.util.Map.class
+            );
 
-        return Optional.of(mockEmbedding);
+            if (response.hits().hits().isEmpty()) {
+                log.warn("[TechStackEmbedding] 조회 결과 없음 - name: {}", techStackName);
+                return Optional.empty();
+            }
+
+            var source = response.hits().hits().get(0).source();
+            if (source == null || !source.containsKey("embedding")) {
+                return Optional.empty();
+            }
+
+            java.util.List<Double> embeddingRaw = (java.util.List<Double>) source.get("embedding");
+            float[] embedding = new float[embeddingRaw.size()];
+            for (int i = 0; i < embeddingRaw.size(); i++) {
+                embedding[i] = embeddingRaw.get(i).floatValue();
+            }
+
+            return Optional.of(embedding);
+        } catch (Exception e) {
+            log.error("[TechStackEmbedding] 조회 실패 - name: {}", techStackName, e);
+            return Optional.empty();
+        }
     }
 }


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- `TechStackEmbeddingRepositoryImpl` Mock 데이터 → ES `techstack-index` 실제 조회로 교체

## 변경 사항
- `TechStackEmbeddingRepositoryImpl` - Mock 고정값 반환 → ES `techstack-index`에서 name 기준 embedding 실제 조회로 교체
- 조회 결과 없을 시 `Optional.empty()` 반환

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [x] Swagger 동작 확인

## 참고 사항
- TechStack 임베딩이 ES에 없을 경우 콜드 스타트 폴백 처리로 인기 이벤트 반환