### PR TITLE
feat : 관리자 정산목록조회, 정산세부내역조회, 정산취소 기능

### DIFF
--- a/settlement-process.md
+++ b/settlement-process.md
@@ -1,0 +1,55 @@
+# 정산프로세스 
+
+## 정산 상태 변화 
+- SettlementItem 
+  - READY : SettlementItem이 생성되었을때 기본상태값.
+  - FINALIZED : 집계되어 Settlement 생성이 완료된경우.
+  
+- Settlement
+  - CONFIRMED : 정산서 생성 완료. 지급 대기 상태.
+  - PENDING_MIN_AMOUNT : 정산서 생성완료. 지급 보류(최소 정산금액 1만원 미달, 다음 달 이월)
+  - CANCELLED : 생성된 정산서 취소처리
+  - PAID : 지급완료
+  - PAID_FAILED : 지급실패 (관리자 재시도 대상)
+
+## Settlement 주요 필드
+- settlementAmount : 당월 순수 정산금 (당월 SettlementItem 기반)
+- carriedInAmount : 이월받은 금액 합산 (정산서 생성 batch 시 계산 후 저장, 이후 변경 없음)
+- finalSettlementAmount : 실제 지급금 (= settlementAmount + carriedInAmount)
+- carriedToSettlementId : 이 정산서의 금액이 이월된 대상 정산서 ID (PENDING_MIN_AMOUNT인 경우 채워짐)
+
+## 정산대상 데이터 수집 (SettlementItem)
+- 매일 00:01시간에 SettlementItem 생성 Batch작업
+- 전날에 종료된 이벤트를 조회하고 해당 이벤트들의 Ticket데이터를 기반으로 SettlementItem생성
+
+## 정산서 생성 (Settlement)
+- 매월 1일 00:10시간에 정산서 생성 Batch작업
+- 정산대상 :
+   - SettlementItem의 status=READY이고 event_date_time(이벤트개최일)이 전전월 26일 ~ 전월 25일에 해당하는 것.
+- 이월 처리 :
+   - 동일 판매자의 Settlement.status=PENDING_MIN_AMOUNT 건을 조회
+   - SUM(settlementAmount)를 당월 정산서의 carriedInAmount로 저장
+   - 이월된 각 Settlement.carriedToSettlementId = 당월 정산서 ID로 설정
+- finalSettlementAmount(= settlementAmount + carriedInAmount) < 1만원이면 PENDING_MIN_AMOUNT, 이상이면 CONFIRMED
+
+## 정산서 취소 처리
+- 관리자페이지에서 월별 정산서목록보기, 정산서 세부내용 보기 지원
+- 정산서 단위로 개별 취소처리
+- 취소처리 진행시 상태값 변경
+  - Settlement.status = CANCELLED
+  - SettlementItem.status = READY
+  - 이월 금액이 포함된 경우 : carried_to_settlement_id = 취소된 Settlement.id 인 Settlement들 → PENDING_MIN_AMOUNT로 복구
+
+## 재정산
+- 정산서 단위로 재정산 진행 : 해당 월 + 판매자의 정산 재진행
+
+## 지급처리
+- Settlement.status = CONFIRMED 인 건을 대상으로 Wallet 서비스에 예치금 전환 요청
+- 지급 성공 시
+  - Settlement.status = PAID
+  - carried_to_settlement_id = 해당 Settlement.id 인 Settlement들(이월된 정산서) → PAID로 변경
+- 지급 실패 시
+  - Settlement.status = PAID_FAILED
+  - 이월된 정산서(carried_to_settlement_id = 해당 Settlement.id)는 상태 유지 (재시도 대기)
+- PAID_FAILED 재시도 : 관리자가 Settlement 단위로 재시도. 성공 시 위 지급 성공 흐름 동일하게 처리.
+- 이월 정산서 목록 조회 : carried_to_settlement_id 역조회로 확인 (carriedInAmount는 저장된 값 사용)

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalService.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalService.java
@@ -1,6 +1,7 @@
 package com.devticket.settlement.application.service;
 
 import com.devticket.settlement.infrastructure.client.dto.res.InternalSettlementDataResponse;
+import com.devticket.settlement.infrastructure.external.dto.AdminSettlementDetailResponse;
 import com.devticket.settlement.infrastructure.external.dto.InternalSettlementPageResponse;
 import java.util.UUID;
 import org.springframework.data.domain.PageImpl;
@@ -11,12 +12,17 @@ public interface SettlementInternalService {
     InternalSettlementPageResponse getSettlements(
         String status,
         UUID sellerId,
-        String startDate,
-        String endDate,
+        String yearMonth,
         Pageable pageable
     );
 
     void runSettlement();
 
     void createSettlementFromItems();
+
+    AdminSettlementDetailResponse getSettlementDetail(UUID settlementId);
+
+    void cancelSettlement(UUID settlementId);
+
+    void processPayment(UUID settlementId);
 }

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementInternalServiceImpl.java
@@ -10,12 +10,15 @@ import com.devticket.settlement.domain.model.SettlementStatus;
 import com.devticket.settlement.domain.repository.FeePolicyRepository;
 import com.devticket.settlement.domain.repository.SettlementItemRepository;
 import com.devticket.settlement.domain.repository.SettlementRepository;
+import com.devticket.settlement.infrastructure.external.dto.AdminSettlementDetailResponse;
+import com.devticket.settlement.infrastructure.external.dto.AdminSettlementDetailResponse.CarriedInSettlement;
 import com.devticket.settlement.infrastructure.client.SettlementToCommerceClient;
 import com.devticket.settlement.infrastructure.client.SettlementToMemberClient;
 import com.devticket.settlement.infrastructure.client.dto.req.InternalSettlementDataRequest;
 import com.devticket.settlement.infrastructure.client.dto.res.InternalSettlementDataResponse;
 import com.devticket.settlement.infrastructure.external.dto.InternalSettlementPageResponse;
 import com.devticket.settlement.infrastructure.external.dto.InternalSettlementResponse;
+import com.devticket.settlement.presentation.dto.EventItemResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
@@ -28,7 +31,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,6 +40,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SettlementInternalServiceImpl implements SettlementInternalService {
 
+    private static final int MIN_SETTLEMENT_AMOUNT = 10_000;
+
     private final SettlementToCommerceClient settlementToCommerceClient;
     private final SettlementToMemberClient settlementToMemberClient;
     private final FeePolicyRepository feePolicyRepository;
@@ -45,49 +49,50 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
     private final SettlementItemRepository settlementItemRepository;
 
     // ────────────────────────────────────────────────
-    // Public API
+    // 정산서 목록 조회 (관리자)
     // ────────────────────────────────────────────────
 
     @Transactional(readOnly = true)
     public InternalSettlementPageResponse getSettlements(
-        String status,
-        UUID sellerId,
-        String startDate,
-        String endDate,
-        Pageable pageable
+        String status, UUID sellerId, String yearMonth, Pageable pageable
     ) {
         SettlementStatus filterStatus = parseStatus(status);
-        LocalDateTime start = startDate != null && !startDate.isBlank()
-            ? LocalDate.parse(startDate).atStartOfDay() : null;
-        LocalDateTime end = endDate != null && !endDate.isBlank()
-            ? LocalDate.parse(endDate).plusDays(1).atStartOfDay() : null;
+        LocalDateTime monthStart = null;
+        LocalDateTime monthEnd = null;
+        if (yearMonth != null && !yearMonth.isBlank()) {
+            YearMonth ym = YearMonth.parse(yearMonth, java.time.format.DateTimeFormatter.ofPattern("yyyyMM"));
+            monthStart = ym.atDay(1).atStartOfDay();
+            monthEnd = ym.plusMonths(1).atDay(1).atStartOfDay();
+        }
 
-        Page<Settlement> page = settlementRepository.search(
-            filterStatus, sellerId, start, end, pageable
-        );
+        Page<Settlement> page = settlementRepository.search(filterStatus, sellerId, monthStart, monthEnd, pageable);
 
         List<InternalSettlementResponse> content = page.getContent().stream()
             .map(s -> new InternalSettlementResponse(
-                null,
+                s.getSettlementId(),
                 s.getPeriodStartAt().toLocalDate().toString(),
                 s.getPeriodEndAt().toLocalDate().toString(),
                 (long) s.getTotalSalesAmount(),
                 (long) s.getTotalRefundAmount(),
                 (long) s.getTotalFeeAmount(),
+                (long) s.getCarriedInAmount(),
                 (long) s.getFinalSettlementAmount(),
                 s.getStatus().name(),
-                s.getSettledAt().toString()
+                s.getSettledAt() != null ? s.getSettledAt().toString() : null,
+                s.getCarriedToSettlementId(),
+                s.getSellerId()
             ))
             .toList();
 
         return new InternalSettlementPageResponse(
-            content,
-            page.getNumber(),
-            page.getSize(),
-            (int) page.getTotalElements(),
-            page.getTotalPages()
+            content, page.getNumber(), page.getSize(),
+            (int) page.getTotalElements(), page.getTotalPages()
         );
     }
+
+    // ────────────────────────────────────────────────
+    // 정산서 생성 (Commerce 직접 호출 방식 - Legacy)
+    // ────────────────────────────────────────────────
 
     @Transactional
     public void runSettlement() {
@@ -103,7 +108,6 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
                 InternalSettlementDataRequest request = new InternalSettlementDataRequest(
                     sellerId, periodStart, periodEnd
                 );
-
                 InternalSettlementDataResponse data = settlementToCommerceClient.getSettlementData(request);
                 if (data == null || data.eventSettlements() == null) continue;
 
@@ -120,7 +124,7 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
                         .totalRefundAmount(eventSettlement.totalRefundAmount())
                         .totalFeeAmount((int) fee)
                         .finalSettlementAmount((int) finalAmount)
-                        .status(SettlementStatus.COMPLETED)
+                        .status(SettlementStatus.CONFIRMED)
                         .settledAt(LocalDateTime.now())
                         .build();
 
@@ -132,31 +136,153 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
         }
     }
 
-    private static final int MIN_SETTLEMENT_AMOUNT = 10_000;
+    // ────────────────────────────────────────────────
+    // 정산서 생성 (SettlementItem 기반 Batch)
+    // ────────────────────────────────────────────────
 
     @Transactional
     public void createSettlementFromItems() {
-        //매월1일 정산시작시 정산대상기간 설정 : 전전월 26일 ~ 전월 25일
         LocalDate periodFrom = YearMonth.now().minusMonths(2).atDay(26);
         LocalDate periodTo = YearMonth.now().minusMonths(1).atDay(25);
         LocalDateTime periodStart = periodFrom.atStartOfDay();
         LocalDateTime periodEnd = periodTo.atTime(23, 59, 59);
 
-        //판매자별 settlementItem데이터 조회
         Map<UUID, List<SettlementItem>> itemsBySeller = collectItemsBySeller(periodFrom, periodTo);
         includeCarryOverSellers(itemsBySeller);
 
         log.info("[정산 생성] 대상 기간: {} ~ {}, 판매자: {}명", periodFrom, periodTo, itemsBySeller.size());
 
-        //Settlement생성
         for (Map.Entry<UUID, List<SettlementItem>> entry : itemsBySeller.entrySet()) {
             processSellerSettlement(entry.getKey(), entry.getValue(), periodStart, periodEnd);
         }
     }
 
     // ────────────────────────────────────────────────
+    // 정산서 상세 조회 (관리자)
+    // ────────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public AdminSettlementDetailResponse getSettlementDetail(UUID settlementId) {
+        Settlement settlement = settlementRepository.findBySettlementId(settlementId)
+            .orElseThrow(() -> new BusinessException(SettlementErrorCode.SETTLEMENT_BAD_REQUEST));
+
+        List<EventItemResponse> settlementItems = settlementItemRepository
+            .findBySettlementId(settlementId)
+            .stream()
+            .map(item -> new EventItemResponse(
+                item.getEventId().toString(),
+                "Unknown",
+                item.getSalesAmount(),
+                item.getRefundAmount(),
+                item.getFeeAmount(),
+                item.getSettlementAmount()
+            ))
+            .toList();
+
+        // 이 정산서에 이월된 출처 정산서 목록 (역조회)
+        List<CarriedInSettlement> carriedInSettlements = settlementRepository
+            .findByCarriedToSettlementId(settlementId)
+            .stream()
+            .map(s -> new CarriedInSettlement(
+                s.getSettlementId(),
+                s.getPeriodStartAt().toLocalDate().toString(),
+                s.getPeriodEndAt().toLocalDate().toString(),
+                (long) s.getFinalSettlementAmount(),
+                s.getStatus().name()
+            ))
+            .toList();
+
+        long settlementAmount = settlement.getFinalSettlementAmount() - settlement.getCarriedInAmount();
+
+        return new AdminSettlementDetailResponse(
+            settlement.getSettlementId(),
+            settlement.getSellerId(),
+            settlement.getPeriodStartAt().toLocalDate().toString(),
+            settlement.getPeriodEndAt().toLocalDate().toString(),
+            (long) settlement.getTotalSalesAmount(),
+            (long) settlement.getTotalRefundAmount(),
+            (long) settlement.getTotalFeeAmount(),
+            settlementAmount,
+            (long) settlement.getCarriedInAmount(),
+            (long) settlement.getFinalSettlementAmount(),
+            settlement.getStatus().name(),
+            settlement.getSettledAt() != null ? settlement.getSettledAt().toString() : null,
+            settlement.getCarriedToSettlementId(),
+            carriedInSettlements,
+            settlementItems
+        );
+    }
+
+    // ────────────────────────────────────────────────
+    // 정산서 취소
+    // ────────────────────────────────────────────────
+
+    @Transactional
+    public void cancelSettlement(UUID settlementId) {
+        Settlement settlement = settlementRepository.findBySettlementId(settlementId)
+            .orElseThrow(() -> new BusinessException(SettlementErrorCode.SETTLEMENT_BAD_REQUEST));
+
+        settlement.updateStatus(SettlementStatus.CANCELLED);
+        settlementRepository.save(settlement);
+
+        List<SettlementItem> items = settlementItemRepository.findBySettlementId(settlementId);
+        items.forEach(SettlementItem::resetToReady);
+        settlementItemRepository.saveAll(items);
+
+        // 이 정산서에 이월됐던 PENDING 정산서들을 복구
+        List<Settlement> carriedSettlements = settlementRepository.findByCarriedToSettlementId(settlementId);
+        carriedSettlements.forEach(s -> {
+            s.updateStatus(SettlementStatus.PENDING_MIN_AMOUNT);
+            s.updateCarriedToSettlementId(null);
+        });
+        settlementRepository.saveAll(carriedSettlements);
+
+        log.info("[정산 취소] settlementId={}, 이월복구={}건", settlementId, carriedSettlements.size());
+    }
+
+    // ────────────────────────────────────────────────
+    // 지급처리
+    // ────────────────────────────────────────────────
+
+    @Transactional
+    public void processPayment(UUID settlementId) {
+        Settlement settlement = settlementRepository.findBySettlementId(settlementId)
+            .orElseThrow(() -> new BusinessException(SettlementErrorCode.SETTLEMENT_BAD_REQUEST));
+
+        if (settlement.getStatus() != SettlementStatus.CONFIRMED
+            && settlement.getStatus() != SettlementStatus.PAID_FAILED) {
+            throw new BusinessException(SettlementErrorCode.SETTLEMENT_BAD_REQUEST);
+        }
+
+        try {
+            settlementToCommerceClient.transferToDeposit(
+                settlement.getSellerId(), settlement.getFinalSettlementAmount()
+            );
+
+            settlement.updateStatus(SettlementStatus.PAID);
+            settlementRepository.save(settlement);
+
+            // 이 정산서에 이월된 PENDING 정산서들도 PAID로 변경
+            markCarriedSettlementsAsPaid(settlementId);
+
+            log.info("[지급 완료] settlementId={}, amount={}", settlementId, settlement.getFinalSettlementAmount());
+
+        } catch (Exception e) {
+            settlement.updateStatus(SettlementStatus.PAID_FAILED);
+            settlementRepository.save(settlement);
+            log.error("[지급 실패] settlementId={}", settlementId, e);
+        }
+    }
+
+    // ────────────────────────────────────────────────
     // Private helpers
     // ────────────────────────────────────────────────
+
+    private void markCarriedSettlementsAsPaid(UUID settlementId) {
+        List<Settlement> carried = settlementRepository.findByCarriedToSettlementId(settlementId);
+        carried.forEach(s -> s.updateStatus(SettlementStatus.PAID));
+        settlementRepository.saveAll(carried);
+    }
 
     private Map<UUID, List<SettlementItem>> collectItemsBySeller(LocalDate from, LocalDate to) {
         List<SettlementItem> items = settlementItemRepository
@@ -167,7 +293,9 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
     }
 
     private void includeCarryOverSellers(Map<UUID, List<SettlementItem>> itemsBySeller) {
+        // 아직 이월되지 않은 PENDING 판매자도 포함
         settlementRepository.findByStatus(SettlementStatus.PENDING_MIN_AMOUNT).stream()
+            .filter(s -> s.getCarriedToSettlementId() == null)
             .map(Settlement::getSellerId)
             .distinct()
             .filter(sellerId -> !itemsBySeller.containsKey(sellerId))
@@ -177,20 +305,18 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
     private void processSellerSettlement(UUID sellerId, List<SettlementItem> items,
         LocalDateTime periodStart, LocalDateTime periodEnd) {
 
-        // Settlement가 이미 생
         if (alreadySettledForPeriod(sellerId, periodStart)) {
             log.info("[정산 생성 스킵] 이미 처리된 기간 - sellerId={}, periodStart={}", sellerId, periodStart);
             return;
         }
 
         SellerAmounts amounts = aggregateAmounts(items);
-        Settlement latestPending = resolveLatestPending(sellerId);
+        Settlement pendingSettlement = resolveLatestPending(sellerId);
 
-        int carriedInAmount = latestPending != null ? latestPending.getFinalSettlementAmount() : 0;
-        UUID carriedInSettlementId = latestPending != null ? latestPending.getSettlementId() : null;
-        long totalFinalAmount = amounts.settlementAmount() + carriedInAmount;
-        SettlementStatus status = totalFinalAmount >= MIN_SETTLEMENT_AMOUNT
-            ? SettlementStatus.COMPLETED
+        int carriedInAmount = pendingSettlement != null ? pendingSettlement.getFinalSettlementAmount() : 0;
+        long finalAmount = amounts.settlementAmount() + carriedInAmount;
+        SettlementStatus status = finalAmount >= MIN_SETTLEMENT_AMOUNT
+            ? SettlementStatus.CONFIRMED
             : SettlementStatus.PENDING_MIN_AMOUNT;
 
         Settlement settlement = Settlement.builder()
@@ -200,17 +326,18 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
             .totalSalesAmount((int) amounts.totalSales())
             .totalRefundAmount((int) amounts.totalRefund())
             .totalFeeAmount((int) amounts.totalFee())
-            .finalSettlementAmount((int) totalFinalAmount)
+            .finalSettlementAmount((int) finalAmount)
             .carriedInAmount(carriedInAmount)
-            .carriedInSettlementId(carriedInSettlementId)
             .status(status)
             .settledAt(LocalDateTime.now())
             .build();
 
         settlementRepository.save(settlement);
 
-        if (status == SettlementStatus.COMPLETED && latestPending != null) {
-            markChainAsPaidByCarryForward(latestPending);
+        // 이월된 PENDING 정산서에 carriedToSettlementId 설정
+        if (pendingSettlement != null) {
+            pendingSettlement.updateCarriedToSettlementId(settlement.getSettlementId());
+            settlementRepository.save(pendingSettlement);
         }
 
         if (!items.isEmpty()) {
@@ -219,7 +346,7 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
         }
 
         log.info("[정산 생성] sellerId={}, items={}건, carriedIn={}, finalAmount={}, status={}",
-            sellerId, items.size(), carriedInAmount, totalFinalAmount, status);
+            sellerId, items.size(), carriedInAmount, finalAmount, status);
     }
 
     private boolean alreadySettledForPeriod(UUID sellerId, LocalDateTime periodStart) {
@@ -242,25 +369,13 @@ public class SettlementInternalServiceImpl implements SettlementInternalService 
 
     private Settlement resolveLatestPending(UUID sellerId) {
         return settlementRepository
-            .findBySellerIdAndStatus(sellerId, SettlementStatus.PENDING_MIN_AMOUNT)
+            .findBySellerIdAndStatusAndCarriedToSettlementIdIsNull(sellerId, SettlementStatus.PENDING_MIN_AMOUNT)
             .stream()
             .max(Comparator.comparing(Settlement::getCreatedAt))
             .orElse(null);
     }
 
     private record SellerAmounts(long totalSales, long totalRefund, long totalFee, long settlementAmount) {}
-
-    private void markChainAsPaidByCarryForward(Settlement settlement) {
-        Settlement cursor = settlement;
-        while (cursor != null) {
-            cursor.updateStatus(SettlementStatus.COMPLETED);
-            settlementRepository.save(cursor);
-            UUID nextId = cursor.getCarriedInSettlementId();
-            cursor = (nextId != null)
-                ? settlementRepository.findBySettlementId(nextId).orElse(null)
-                : null;
-        }
-    }
 
     private SettlementStatus parseStatus(String status) {
         if (status == null || status.isBlank()) return null;

--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
@@ -242,7 +242,7 @@ public class SettlementServiceImpl implements SettlementService {
         long newSettlementAmount = readyItems.stream().mapToLong(SettlementItem::getSettlementAmount).sum();
 
         int carriedInAmount = settlementRepository
-            .findBySellerIdAndStatus(sellerId, SettlementStatus.PENDING_MIN_AMOUNT)
+            .findBySellerIdAndStatusAndCarriedToSettlementIdIsNull(sellerId, SettlementStatus.PENDING_MIN_AMOUNT)
             .stream()
             .max(Comparator.comparing(Settlement::getCreatedAt))
             .map(Settlement::getFinalSettlementAmount)

--- a/settlement/src/main/java/com/devticket/settlement/domain/model/Settlement.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/model/Settlement.java
@@ -63,14 +63,14 @@ public class Settlement extends BaseEntity {
     @Column(name = "carried_in_amount", nullable = false)
     private Integer carriedInAmount;
 
-    @Column(name = "carried_in_settlement_id")
-    private UUID carriedInSettlementId;
+    @Column(name = "carried_to_settlement_id")
+    private UUID carriedToSettlementId;
 
 
     @Builder
     public Settlement(Long id, UUID settlementId, UUID sellerId, LocalDateTime periodStartAt, LocalDateTime periodEndAt,
         Integer totalSalesAmount, Integer totalRefundAmount, Integer totalFeeAmount, Integer finalSettlementAmount,
-        SettlementStatus status, LocalDateTime settledAt, Integer carriedInAmount, UUID carriedInSettlementId) {
+        SettlementStatus status, LocalDateTime settledAt, Integer carriedInAmount) {
         this.id = id;
         this.settlementId = (settlementId != null) ? settlementId : UUID.randomUUID();
         this.sellerId = sellerId;
@@ -80,14 +80,17 @@ public class Settlement extends BaseEntity {
         this.totalRefundAmount = totalRefundAmount;
         this.totalFeeAmount = totalFeeAmount;
         this.finalSettlementAmount = finalSettlementAmount;
-        this.status = (status != null) ? status : SettlementStatus.COMPLETED;
+        this.status = (status != null) ? status : SettlementStatus.CONFIRMED;
         this.settledAt = settledAt;
         this.carriedInAmount = (carriedInAmount != null) ? carriedInAmount : 0;
-        this.carriedInSettlementId = carriedInSettlementId;
     }
 
     public void updateStatus(SettlementStatus status) {
         this.status = status;
+    }
+
+    public void updateCarriedToSettlementId(UUID settlementId) {
+        this.carriedToSettlementId = settlementId;
     }
 
 }

--- a/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementItem.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementItem.java
@@ -85,4 +85,9 @@ public class SettlementItem extends BaseEntity {
         this.status = SettlementItemStatus.FINALIZED;
     }
 
+    public void resetToReady() {
+        this.settlementId = null;
+        this.status = SettlementItemStatus.READY;
+    }
+
 }

--- a/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementStatus.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/model/SettlementStatus.java
@@ -1,7 +1,9 @@
 package com.devticket.settlement.domain.model;
 
 public enum SettlementStatus {
-    COMPLETED,          // 정산 완료 (최소 정산금액 충족)
-    PENDING_MIN_AMOUNT, // 정산 보류 (최소 정산금액 미달, 다음 달 이월)
-    CANCELLED           // 정산 취소
+    CONFIRMED,          // 정산서 생성 완료. 지급 대기 상태.
+    PENDING_MIN_AMOUNT, // 지급 보류 (최소 정산금액 1만원 미달, 다음 달 이월)
+    CANCELLED,          // 정산서 취소처리
+    PAID,               // 지급완료
+    PAID_FAILED         // 지급실패 (관리자 재시도 대상)
 }

--- a/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/domain/repository/SettlementRepository.java
@@ -28,5 +28,9 @@ public interface SettlementRepository {
     Settlement save(Settlement settlement);
 
     Page<Settlement> search(SettlementStatus status, UUID sellerId,
-        LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+        LocalDateTime monthStart, LocalDateTime monthEnd, Pageable pageable);
+
+    List<Settlement> findByCarriedToSettlementId(UUID settlementId);
+
+    List<Settlement> findBySellerIdAndStatusAndCarriedToSettlementIdIsNull(UUID sellerId, SettlementStatus status);
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/batch/SettlementItemProcessor.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/batch/SettlementItemProcessor.java
@@ -40,18 +40,18 @@ public class SettlementItemProcessor implements ItemProcessor<InternalSettlement
                 }
 
                 return Settlement.builder()
-                    .sellerId(response.sellerId()) // 응답에서 직접 가져오기
+                    .sellerId(response.sellerId())
                     .periodStartAt(firstDayOfLastMonth.atStartOfDay())
                     .periodEndAt(lastDayOfLastMonth.atTime(23, 59, 59))
                     .totalSalesAmount(event.totalSalesAmount())
                     .totalRefundAmount(event.totalRefundAmount())
                     .totalFeeAmount(feeAmount)
                     .finalSettlementAmount(finalAmount)
-                    .status(SettlementStatus.COMPLETED)
+                    .status(SettlementStatus.CONFIRMED)
                     .settledAt(LocalDateTime.now())
                     .build();
             })
             .filter(s -> s != null)
-            .toList();
+            .collect(java.util.stream.Collectors.toList());
     }
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToCommerceClient.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToCommerceClient.java
@@ -94,4 +94,15 @@ public class SettlementToCommerceClient {
             throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
+
+
+    //정산금 지급처리 : 정산금 -> 예치금 전환
+    public void transferToDeposit(UUID sellerId, int amount) {
+        // TODO: Wallet 서비스 연동 구현
+        log.info("[Wallet] 예치금 전환 요청 - sellerId: {}, amount: {}", sellerId, amount);
+    }
+
+
+
+
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/external/dto/AdminSettlementDetailResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/external/dto/AdminSettlementDetailResponse.java
@@ -1,0 +1,32 @@
+package com.devticket.settlement.infrastructure.external.dto;
+
+import com.devticket.settlement.presentation.dto.EventItemResponse;
+import java.util.List;
+import java.util.UUID;
+
+public record AdminSettlementDetailResponse(
+    UUID settlementId,
+    UUID sellerId,
+    String periodStart,
+    String periodEnd,
+    Long totalSalesAmount,
+    Long totalRefundAmount,
+    Long totalFeeAmount,
+    Long settlementAmount,
+    Long carriedInAmount,
+    Long finalSettlementAmount,
+    String status,
+    String settledAt,
+    UUID carriedToSettlementId,
+    List<CarriedInSettlement> carriedInSettlements,
+    List<EventItemResponse> settlementItems
+) {
+
+    public record CarriedInSettlement(
+        UUID settlementId,
+        String periodStart,
+        String periodEnd,
+        Long finalSettlementAmount,
+        String status
+    ) {}
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/external/dto/InternalSettlementResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/external/dto/InternalSettlementResponse.java
@@ -9,8 +9,11 @@ public record InternalSettlementResponse(
     Long totalSalesAmount,
     Long totalRefundAmount,
     Long totalFeeAmount,
+    Long carriedInAmount,
     Long finalSettlementAmount,
     String status,
-    String settledAt
+    String settledAt,
+    UUID carriedToSettlementId,
+    UUID sellerId
 ) {
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementJpaRepository.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementJpaRepository.java
@@ -30,16 +30,20 @@ public interface SettlementJpaRepository extends JpaRepository<Settlement, Long>
     SELECT s FROM Settlement s
     WHERE (CAST(:status AS string) IS NULL OR s.status = :status)
       AND (CAST(:sellerId AS string) IS NULL OR s.sellerId = :sellerId)
-      AND (CAST(:startDate AS string) IS NULL OR s.periodStartAt >= :startDate)
-      AND (CAST(:endDate AS string) IS NULL OR s.periodEndAt <= :endDate)
+      AND (CAST(:monthStart AS string) IS NULL OR s.settledAt >= :monthStart)
+      AND (CAST(:monthEnd AS string) IS NULL OR s.settledAt < :monthEnd)
     ORDER BY s.createdAt DESC
     """)
     Page<Settlement> search(
         @Param("status") SettlementStatus status,
         @Param("sellerId") UUID sellerId,
-        @Param("startDate") LocalDateTime startDate,
-        @Param("endDate") LocalDateTime endDate,
+        @Param("monthStart") LocalDateTime monthStart,
+        @Param("monthEnd") LocalDateTime monthEnd,
         Pageable pageable
     );
+
+    List<Settlement> findByCarriedToSettlementId(UUID carriedToSettlementId);
+
+    List<Settlement> findBySellerIdAndStatusAndCarriedToSettlementIdIsNull(UUID sellerId, SettlementStatus status);
 
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementRepositoryImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/persistence/repository/SettlementRepositoryImpl.java
@@ -70,5 +70,14 @@ public class SettlementRepositoryImpl implements SettlementRepository {
         return settlementJpaRepository.search(status, sellerId, startDate, endDate, pageable);
     }
 
+    @Override
+    public List<Settlement> findByCarriedToSettlementId(UUID settlementId) {
+        return settlementJpaRepository.findByCarriedToSettlementId(settlementId);
+    }
+
+    @Override
+    public List<Settlement> findBySellerIdAndStatusAndCarriedToSettlementIdIsNull(UUID sellerId, SettlementStatus status) {
+        return settlementJpaRepository.findBySellerIdAndStatusAndCarriedToSettlementIdIsNull(sellerId, status);
+    }
 
 }

--- a/settlement/src/main/java/com/devticket/settlement/presentation/controller/InternalSettlementController.java
+++ b/settlement/src/main/java/com/devticket/settlement/presentation/controller/InternalSettlementController.java
@@ -1,20 +1,24 @@
  package com.devticket.settlement.presentation.controller;
 
 import com.devticket.settlement.application.service.SettlementInternalService;
+import com.devticket.settlement.infrastructure.external.dto.AdminSettlementDetailResponse;
 import com.devticket.settlement.infrastructure.external.dto.InternalSettlementPageResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
-@RequestMapping("/internal/settlements")
+@RequestMapping("/api/admin/settlements")
 @RequiredArgsConstructor
 public class InternalSettlementController {
 
@@ -24,18 +28,25 @@ public class InternalSettlementController {
     public ResponseEntity<InternalSettlementPageResponse> getSettlements(
         @RequestParam(required = false) String status,
         @RequestParam(required = false) UUID sellerId,
-        @RequestParam(required = false) String startDate,
-        @RequestParam(required = false) String endDate,
+        @RequestParam(required = false) String yearMonth,
         @PageableDefault(size = 20) Pageable pageable
     ) {
         return ResponseEntity.ok(
-            settlementInternalService.getSettlements(status, sellerId, startDate, endDate, pageable)
+            settlementInternalService.getSettlements(status, sellerId, yearMonth, pageable)
         );
+    }
+
+    @GetMapping("/{settlementId}")
+    public ResponseEntity<AdminSettlementDetailResponse> getSettlementDetail(
+        @PathVariable UUID settlementId
+    ) {
+        return ResponseEntity.ok(settlementInternalService.getSettlementDetail(settlementId));
     }
 
     @PostMapping("/run")
     public ResponseEntity<Void> runSettlement() {
-        settlementInternalService.runSettlement();
+        //settlementInternalService.runSettlement();
+        settlementInternalService.createSettlementFromItems();
         return ResponseEntity.ok().build();
     }
 
@@ -43,6 +54,18 @@ public class InternalSettlementController {
     @PostMapping("/create-from-items")
     public ResponseEntity<Void> createSettlementFromItems() {
         settlementInternalService.createSettlementFromItems();
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{settlementId}/cancel")
+    public ResponseEntity<Void> cancelSettlement(@PathVariable UUID settlementId) {
+        settlementInternalService.cancelSettlement(settlementId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{settlementId}/payment")
+    public ResponseEntity<Void> processPayment(@PathVariable UUID settlementId) {
+        settlementInternalService.processPayment(settlementId);
         return ResponseEntity.ok().build();
     }
 }


### PR DESCRIPTION
## 관련 이슈
- close #508

## 작업 내용
- 관리자 정산목록조회, 정산세부내역 조회
- 정산 취소
- 정산금 지급 처리 

## 변경 사항
- Settlement 엔티티 수정 : 
  carriedInSettlementId -> carriedToSettlementId변경(이월된 정산이 여러건인 케이스 고려)
- getSettlement 정산목록조회 : 월별 조회 방식으로 변경
- getSettlementDetail : 정산 세부내역 조회 
- cancelSettlemen : 정산 취소
- processPayment : 지급처리

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷
프론트 수정반영
<img width="900" height="450" alt="image" src="https://github.com/user-attachments/assets/34dfe4a9-3de5-41de-9cbf-05ca28e029f8" />

## 참고 사항
