### PR TITLE
[Commerce] docs: API/DTO/Service summary 재생성 스크립트 추가 + Commerce 반영

### DIFF
--- a/docs/api-summary.json
+++ b/docs/api-summary.json
@@ -77,7 +77,7 @@
     "method": "penalizeUser",
     "httpMethod": "PATCH",
     "path": "/admin/users/{userId}/status",
-    "summary": "회원 목록 조회",
+    "summary": "회원 제재 api",
     "source": "admin/src/main/java/com/devticket/admin/presentation/controller/AdminUsersController.java"
   },
   {
@@ -86,7 +86,7 @@
     "method": "updateUserRole",
     "httpMethod": "PATCH",
     "path": "/admin/users/{userId}/role",
-    "summary": "회원 제재 api",
+    "summary": "회원 권한 변경 api",
     "source": "admin/src/main/java/com/devticket/admin/presentation/controller/AdminUsersController.java"
   },
   {
@@ -99,11 +99,182 @@
     "source": "apigateway/src/main/java/com/devticket/apigateway/presentation/GatewayHealthController.java"
   },
   {
+    "module": "commerce",
+    "controller": "CartController",
+    "method": "addToCart",
+    "httpMethod": "POST",
+    "path": "/api/cart/items",
+    "summary": "add to cart",
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/controller/CartController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "CartController",
+    "method": "getCart",
+    "httpMethod": "GET",
+    "path": "/api/cart",
+    "summary": "get cart",
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/controller/CartController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "CartController",
+    "method": "updateCartItemQuantity",
+    "httpMethod": "PATCH",
+    "path": "/api/cart/items/{cartItemId}",
+    "summary": "update cart item quantity",
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/controller/CartController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "CartController",
+    "method": "deleteCartItem",
+    "httpMethod": "DELETE",
+    "path": "/api/cart/items/{cartItemId}",
+    "summary": "delete cart item",
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/controller/CartController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "CartController",
+    "method": "deleteCartItemAll",
+    "httpMethod": "DELETE",
+    "path": "/api/cart",
+    "summary": "delete cart item all",
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/controller/CartController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "InternalOrderController",
+    "method": "getOrderInfo",
+    "httpMethod": "GET",
+    "path": "/internal/orders/{orderId}",
+    "summary": "get order info",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/controller/InternalOrderController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "InternalOrderController",
+    "method": "getOrderListForSettlement",
+    "httpMethod": "GET",
+    "path": "/internal/orders/{id}/items",
+    "summary": "get order list for settlement",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/controller/InternalOrderController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "InternalOrderController",
+    "method": "getSettlementData",
+    "httpMethod": "GET",
+    "path": "/internal/orders/settlement-data",
+    "summary": "get settlement data",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/controller/InternalOrderController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "InternalOrderController",
+    "method": "completeOrder",
+    "httpMethod": "POST",
+    "path": "/internal/orders/{orderId}/payment-completed",
+    "summary": "complete order",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/controller/InternalOrderController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "InternalOrderController",
+    "method": "failOrder",
+    "httpMethod": "PATCH",
+    "path": "/internal/orders/{orderId}/payment-failed",
+    "summary": "fail order",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/controller/InternalOrderController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "InternalOrderController",
+    "method": "getOrderItemByTicketId",
+    "httpMethod": "GET",
+    "path": "/internal/order-items/by-ticket/{ticketId}",
+    "summary": "get order item by ticket id",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/controller/InternalOrderController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "InternalOrderController",
+    "method": "completeRefund",
+    "httpMethod": "PATCH",
+    "path": "/internal/tickets/{ticketId}/refund-completed",
+    "summary": "complete refund",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/controller/InternalOrderController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "OrderController",
+    "method": "createOrderByCart",
+    "httpMethod": "POST",
+    "path": "/api/orders",
+    "summary": "create order by cart",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "OrderController",
+    "method": "getOrderDetail",
+    "httpMethod": "GET",
+    "path": "/api/orders/{orderId}",
+    "summary": "get order detail",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "OrderController",
+    "method": "cancelOrder",
+    "httpMethod": "PATCH",
+    "path": "/api/orders/{orderId}/cancel",
+    "summary": "cancel order",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/controller/OrderController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "SellerTicketController",
+    "method": "getParticipantList",
+    "httpMethod": "GET",
+    "path": "/seller/events/{eventId}/participants",
+    "summary": "get participant list",
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/SellerTicketController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "TicketController",
+    "method": "getTicketList",
+    "httpMethod": "GET",
+    "path": "/api/tickets",
+    "summary": "get ticket list",
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/TicketController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "TicketController",
+    "method": "getTicketDetail",
+    "httpMethod": "GET",
+    "path": "/api/tickets/{ticketId}",
+    "summary": "get ticket detail",
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/TicketController.java"
+  },
+  {
+    "module": "commerce",
+    "controller": "TicketController",
+    "method": "createTickets",
+    "httpMethod": "POST",
+    "path": "/api/tickets",
+    "summary": "create tickets",
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/controller/TicketController.java"
+  },
+  {
     "module": "event",
     "controller": "EventController",
     "method": "createEvent",
     "httpMethod": "POST",
-    "path": "/",
+    "path": "/api/events",
     "summary": "create event",
     "source": "event/src/main/java/com/devticket/event/presentation/controller/EventController.java"
   },
@@ -112,7 +283,7 @@
     "controller": "EventController",
     "method": "getEvent",
     "httpMethod": "GET",
-    "path": "/{eventId}",
+    "path": "/api/events/{eventId}",
     "summary": "get event",
     "source": "event/src/main/java/com/devticket/event/presentation/controller/EventController.java"
   },
@@ -121,7 +292,7 @@
     "controller": "EventController",
     "method": "getEventList",
     "httpMethod": "GET",
-    "path": "/",
+    "path": "/api/events",
     "summary": "get event list",
     "source": "event/src/main/java/com/devticket/event/presentation/controller/EventController.java"
   },
@@ -130,7 +301,7 @@
     "controller": "EventController",
     "method": "getSellerEventDetail",
     "httpMethod": "GET",
-    "path": "/seller/{eventId}",
+    "path": "/api/events/seller/{eventId}",
     "summary": "get seller event detail",
     "source": "event/src/main/java/com/devticket/event/presentation/controller/EventController.java"
   },
@@ -139,7 +310,7 @@
     "controller": "EventController",
     "method": "getEventSummary",
     "httpMethod": "GET",
-    "path": "/{eventId}/statistics",
+    "path": "/api/events/{eventId}/statistics",
     "summary": "get event summary",
     "source": "event/src/main/java/com/devticket/event/presentation/controller/EventController.java"
   },
@@ -148,7 +319,7 @@
     "controller": "EventController",
     "method": "updateEvent",
     "httpMethod": "PATCH",
-    "path": "/{eventId}",
+    "path": "/api/events/{eventId}",
     "summary": "update event",
     "source": "event/src/main/java/com/devticket/event/presentation/controller/EventController.java"
   },
@@ -220,8 +391,8 @@
     "controller": "AuthController",
     "method": "signup",
     "httpMethod": "POST",
-    "path": "/signup",
-    "summary": "회원가입 Step 1",
+    "path": "/api/auth/signup",
+    "summary": "signup",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/AuthController.java"
   },
   {
@@ -229,8 +400,8 @@
     "controller": "AuthController",
     "method": "login",
     "httpMethod": "POST",
-    "path": "/login",
-    "summary": "일반 로그인",
+    "path": "/api/auth/login",
+    "summary": "login",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/AuthController.java"
   },
   {
@@ -238,8 +409,8 @@
     "controller": "AuthController",
     "method": "socialLogin",
     "httpMethod": "POST",
-    "path": "/social/google",
-    "summary": "구글 소셜 로그인",
+    "path": "/api/auth/social/google",
+    "summary": "social login",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/AuthController.java"
   },
   {
@@ -247,8 +418,8 @@
     "controller": "AuthController",
     "method": "logout",
     "httpMethod": "POST",
-    "path": "/logout",
-    "summary": "로그아웃",
+    "path": "/api/auth/logout",
+    "summary": "logout",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/AuthController.java"
   },
   {
@@ -256,8 +427,8 @@
     "controller": "AuthController",
     "method": "reissue",
     "httpMethod": "POST",
-    "path": "/reissue",
-    "summary": "토큰 재발급",
+    "path": "/api/auth/reissue",
+    "summary": "reissue",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/AuthController.java"
   },
   {
@@ -265,8 +436,8 @@
     "controller": "InternalMemberController",
     "method": "getMemberInfo",
     "httpMethod": "GET",
-    "path": "/{userId}",
-    "summary": "유저 기본 정보 조회",
+    "path": "/internal/members/{userId}",
+    "summary": "get member info",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java"
   },
   {
@@ -274,8 +445,8 @@
     "controller": "InternalMemberController",
     "method": "getMemberStatus",
     "httpMethod": "GET",
-    "path": "/{userId}/status",
-    "summary": "회원 상태 확인",
+    "path": "/internal/members/{userId}/status",
+    "summary": "get member status",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java"
   },
   {
@@ -283,8 +454,8 @@
     "controller": "InternalMemberController",
     "method": "getMemberRole",
     "httpMethod": "GET",
-    "path": "/{userId}/role",
-    "summary": "권한 확인",
+    "path": "/internal/members/{userId}/role",
+    "summary": "get member role",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java"
   },
   {
@@ -292,17 +463,17 @@
     "controller": "InternalMemberController",
     "method": "getSellerInfo",
     "httpMethod": "GET",
-    "path": "/{userId}/seller-info",
-    "summary": "정산 계좌 조회",
+    "path": "/internal/members/{userId}/seller-info",
+    "summary": "get seller info",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java"
   },
   {
     "module": "member",
     "controller": "InternalMemberController",
     "method": "getSellerApplications",
-    "httpMethod": "PATCH",
-    "path": "/{userId}/status",
-    "summary": "회원 상태 변경",
+    "httpMethod": "GET",
+    "path": "/internal/members/seller-applications",
+    "summary": "판매자 신청 목록 조회",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java"
   },
   {
@@ -310,8 +481,8 @@
     "controller": "InternalMemberController",
     "method": "decideSellerApplication",
     "httpMethod": "PATCH",
-    "path": "/seller-applications/{applicationId}",
-    "summary": "판매자 신청 승인/반려",
+    "path": "/internal/members/seller-applications/{applicationId}",
+    "summary": "decide seller application",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/InternalMemberController.java"
   },
   {
@@ -320,7 +491,7 @@
     "method": "health",
     "httpMethod": "GET",
     "path": "/api/members/health",
-    "summary": "health",
+    "summary": "Member 서비스 헬스 체크",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/MemberController.java"
   },
   {
@@ -328,8 +499,8 @@
     "controller": "SellerApplicationController",
     "method": "apply",
     "httpMethod": "POST",
-    "path": "/",
-    "summary": "판매자 전환 신청",
+    "path": "/api/seller-applications",
+    "summary": "apply",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/SellerApplicationController.java"
   },
   {
@@ -337,8 +508,8 @@
     "controller": "SellerApplicationController",
     "method": "getMyApplication",
     "httpMethod": "GET",
-    "path": "/me",
-    "summary": "신청 상태 조회",
+    "path": "/api/seller-applications/me",
+    "summary": "get my application",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/SellerApplicationController.java"
   },
   {
@@ -346,7 +517,7 @@
     "controller": "TechStackController",
     "method": "getTechStacks",
     "httpMethod": "GET",
-    "path": "/",
+    "path": "/api/tech-stacks",
     "summary": "기술 스택 목록 조회",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/TechStackController.java"
   },
@@ -355,8 +526,8 @@
     "controller": "UserController",
     "method": "createProfile",
     "httpMethod": "POST",
-    "path": "/profile",
-    "summary": "프로필 생성",
+    "path": "/api/users/profile",
+    "summary": "create profile",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/UserController.java"
   },
   {
@@ -364,8 +535,8 @@
     "controller": "UserController",
     "method": "getProfile",
     "httpMethod": "GET",
-    "path": "/me",
-    "summary": "프로필 조회",
+    "path": "/api/users/me",
+    "summary": "get profile",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/UserController.java"
   },
   {
@@ -373,8 +544,8 @@
     "controller": "UserController",
     "method": "updateProfile",
     "httpMethod": "PATCH",
-    "path": "/me",
-    "summary": "프로필 수정",
+    "path": "/api/users/me",
+    "summary": "update profile",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/UserController.java"
   },
   {
@@ -382,8 +553,8 @@
     "controller": "UserController",
     "method": "changePassword",
     "httpMethod": "PATCH",
-    "path": "/me/password",
-    "summary": "비밀번호 변경",
+    "path": "/api/users/me/password",
+    "summary": "change password",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/UserController.java"
   },
   {
@@ -391,8 +562,8 @@
     "controller": "UserController",
     "method": "withdraw",
     "httpMethod": "DELETE",
-    "path": "/me",
-    "summary": "회원 탈퇴",
+    "path": "/api/users/me",
+    "summary": "withdraw",
     "source": "member/src/main/java/com/devticket/member/presentation/controller/UserController.java"
   },
   {
@@ -400,8 +571,8 @@
     "controller": "PaymentController",
     "method": "readyPayment",
     "httpMethod": "POST",
-    "path": "/ready",
-    "summary": "결제 준비",
+    "path": "/api/payments/ready",
+    "summary": "ready payment",
     "source": "payment/src/main/java/com/devticket/payment/payment/presentation/controller/PaymentController.java"
   },
   {
@@ -409,8 +580,8 @@
     "controller": "PaymentController",
     "method": "confirm",
     "httpMethod": "POST",
-    "path": "/confirm",
-    "summary": "confirm",
+    "path": "/api/payments/confirm",
+    "summary": "PG 결제 승인",
     "source": "payment/src/main/java/com/devticket/payment/payment/presentation/controller/PaymentController.java"
   },
   {
@@ -418,8 +589,8 @@
     "controller": "PaymentController",
     "method": "fail",
     "httpMethod": "POST",
-    "path": "/fail",
-    "summary": "fail",
+    "path": "/api/payments/fail",
+    "summary": "PG 결제 실패 처리",
     "source": "payment/src/main/java/com/devticket/payment/payment/presentation/controller/PaymentController.java"
   },
   {
@@ -427,7 +598,7 @@
     "controller": "PaymentInternalController",
     "method": "getPaymentByOrderId",
     "httpMethod": "GET",
-    "path": "/by-order/{orderId}",
+    "path": "/internal/payments/by-order/{orderId}",
     "summary": "get payment by order id",
     "source": "payment/src/main/java/com/devticket/payment/payment/presentation/controller/PaymentInternalController.java"
   },
@@ -436,8 +607,8 @@
     "controller": "RefundController",
     "method": "getRefundInfo",
     "httpMethod": "GET",
-    "path": "/info",
-    "summary": "환불 정보 조회",
+    "path": "/api/refunds/info",
+    "summary": "get refund info",
     "source": "payment/src/main/java/com/devticket/payment/refund/presentation/controller/RefundController.java"
   },
   {
@@ -445,8 +616,8 @@
     "controller": "RefundController",
     "method": "getRefundList",
     "httpMethod": "GET",
-    "path": "/",
-    "summary": "환불 내역 목록 조회",
+    "path": "/api/refunds",
+    "summary": "get refund list",
     "source": "payment/src/main/java/com/devticket/payment/refund/presentation/controller/RefundController.java"
   },
   {
@@ -454,8 +625,8 @@
     "controller": "RefundController",
     "method": "getRefundDetail",
     "httpMethod": "GET",
-    "path": "/{refundId}",
-    "summary": "환불 상세 조회",
+    "path": "/api/refunds/{refundId}",
+    "summary": "get refund detail",
     "source": "payment/src/main/java/com/devticket/payment/refund/presentation/controller/RefundController.java"
   },
   {
@@ -463,7 +634,7 @@
     "controller": "RefundController",
     "method": "refundPgTicket",
     "httpMethod": "POST",
-    "path": "/pg/{ticketId}",
+    "path": "/api/refunds/pg/{ticketId}",
     "summary": "refund pg ticket",
     "source": "payment/src/main/java/com/devticket/payment/refund/presentation/controller/RefundController.java"
   },
@@ -472,8 +643,8 @@
     "controller": "SellerRefundController",
     "method": "getSellerRefundListByEventId",
     "httpMethod": "GET",
-    "path": "/events/{eventId}",
-    "summary": "판매자 이벤트별 환불 내역 조회",
+    "path": "/api/seller/refunds/events/{eventId}",
+    "summary": "get seller refund list by event id",
     "source": "payment/src/main/java/com/devticket/payment/refund/presentation/controller/SellerRefundController.java"
   },
   {
@@ -481,7 +652,7 @@
     "controller": "WalletController",
     "method": "charge",
     "httpMethod": "POST",
-    "path": "/charge",
+    "path": "/api/wallet/charge",
     "summary": "예치금 충전 시작",
     "source": "payment/src/main/java/com/devticket/payment/wallet/presentation/controller/WalletController.java"
   },
@@ -490,7 +661,7 @@
     "controller": "WalletController",
     "method": "confirmCharge",
     "httpMethod": "POST",
-    "path": "/charge/confirm",
+    "path": "/api/wallet/charge/confirm",
     "summary": "예치금 충전 승인",
     "source": "payment/src/main/java/com/devticket/payment/wallet/presentation/controller/WalletController.java"
   },
@@ -499,7 +670,7 @@
     "controller": "WalletController",
     "method": "getBalance",
     "httpMethod": "GET",
-    "path": "/",
+    "path": "/api/wallet",
     "summary": "예치금 잔액 조회",
     "source": "payment/src/main/java/com/devticket/payment/wallet/presentation/controller/WalletController.java"
   },
@@ -508,7 +679,7 @@
     "controller": "WalletController",
     "method": "getTransactions",
     "httpMethod": "GET",
-    "path": "/transactions",
+    "path": "/api/wallet/transactions",
     "summary": "예치금 거래 내역 조회",
     "source": "payment/src/main/java/com/devticket/payment/wallet/presentation/controller/WalletController.java"
   },
@@ -517,7 +688,7 @@
     "controller": "WalletController",
     "method": "withdraw",
     "httpMethod": "POST",
-    "path": "/withdraw",
+    "path": "/api/wallet/withdraw",
     "summary": "예치금 출금 요청",
     "source": "payment/src/main/java/com/devticket/payment/wallet/presentation/controller/WalletController.java"
   },
@@ -554,7 +725,7 @@
     "method": "getSellerSettlements",
     "httpMethod": "GET",
     "path": "/seller/settlements",
-    "summary": "get seller settlements",
+    "summary": "판매자 정산 내용 조회",
     "source": "settlement/src/main/java/com/devticket/settlement/presentation/controller/SettlementController.java"
   },
   {
@@ -563,7 +734,7 @@
     "method": "getSellerSettlement",
     "httpMethod": "GET",
     "path": "/seller/settlements/{settlementId}",
-    "summary": "get seller settlement",
+    "summary": "판매자 정산 내용 상세 조회",
     "source": "settlement/src/main/java/com/devticket/settlement/presentation/controller/SettlementController.java"
   }
 ]

--- a/docs/api-summary.md
+++ b/docs/api-summary.md
@@ -12,8 +12,8 @@
 | GET | `/admin/settlements` | `AdminSettlementController#getAdminSettlementList` | 관리자 정산 내역 조회 API |
 | POST | `/admin/settlements/run` | `AdminSettlementController#runSettlement` | 관리자 정산 프로세스 실행 |
 | GET | `/admin/users` | `AdminUsersController#getUsers` | 회원 목록 조회 |
-| PATCH | `/admin/users/{userId}/role` | `AdminUsersController#updateUserRole` | 회원 제재 api |
-| PATCH | `/admin/users/{userId}/status` | `AdminUsersController#penalizeUser` | 회원 목록 조회 |
+| PATCH | `/admin/users/{userId}/role` | `AdminUsersController#updateUserRole` | 회원 권한 변경 api |
+| PATCH | `/admin/users/{userId}/status` | `AdminUsersController#penalizeUser` | 회원 제재 api |
 | GET | `/api/admin/seller-applications` | `AdminSellerController#getSellerApplicationList` | 판매자 신청 리스트 조회 API |
 | PATCH | `/api/admin/seller-applications/{applicationId}` | `AdminSellerController#decideApplication` | 판매자 신청 승인/반려 API |
 
@@ -23,12 +23,40 @@
 |---|---|---|---|
 | GET | `/health` | `GatewayHealthController#health` | health |
 
+## commerce
+
+| HTTP | Path | Controller#Method | 설명 |
+|---|---|---|---|
+| DELETE | `/api/cart` | `CartController#deleteCartItemAll` | delete cart item all |
+| GET | `/api/cart` | `CartController#getCart` | get cart |
+| POST | `/api/cart/items` | `CartController#addToCart` | add to cart |
+| DELETE | `/api/cart/items/{cartItemId}` | `CartController#deleteCartItem` | delete cart item |
+| PATCH | `/api/cart/items/{cartItemId}` | `CartController#updateCartItemQuantity` | update cart item quantity |
+| POST | `/api/orders` | `OrderController#createOrderByCart` | create order by cart |
+| GET | `/api/orders/{orderId}` | `OrderController#getOrderDetail` | get order detail |
+| PATCH | `/api/orders/{orderId}/cancel` | `OrderController#cancelOrder` | cancel order |
+| GET | `/api/tickets` | `TicketController#getTicketList` | get ticket list |
+| POST | `/api/tickets` | `TicketController#createTickets` | create tickets |
+| GET | `/api/tickets/{ticketId}` | `TicketController#getTicketDetail` | get ticket detail |
+| GET | `/internal/order-items/by-ticket/{ticketId}` | `InternalOrderController#getOrderItemByTicketId` | get order item by ticket id |
+| GET | `/internal/orders/settlement-data` | `InternalOrderController#getSettlementData` | get settlement data |
+| GET | `/internal/orders/{id}/items` | `InternalOrderController#getOrderListForSettlement` | get order list for settlement |
+| GET | `/internal/orders/{orderId}` | `InternalOrderController#getOrderInfo` | get order info |
+| POST | `/internal/orders/{orderId}/payment-completed` | `InternalOrderController#completeOrder` | complete order |
+| PATCH | `/internal/orders/{orderId}/payment-failed` | `InternalOrderController#failOrder` | fail order |
+| PATCH | `/internal/tickets/{ticketId}/refund-completed` | `InternalOrderController#completeRefund` | complete refund |
+| GET | `/seller/events/{eventId}/participants` | `SellerTicketController#getParticipantList` | get participant list |
+
 ## event
 
 | HTTP | Path | Controller#Method | 설명 |
 |---|---|---|---|
-| GET | `/` | `EventController#getEventList` | get event list |
-| POST | `/` | `EventController#createEvent` | create event |
+| GET | `/api/events` | `EventController#getEventList` | get event list |
+| POST | `/api/events` | `EventController#createEvent` | create event |
+| GET | `/api/events/seller/{eventId}` | `EventController#getSellerEventDetail` | get seller event detail |
+| GET | `/api/events/{eventId}` | `EventController#getEvent` | get event |
+| PATCH | `/api/events/{eventId}` | `EventController#updateEvent` | update event |
+| GET | `/api/events/{eventId}/statistics` | `EventController#getEventSummary` | get event summary |
 | POST | `/internal/events/bulk` | `EventInternalController#getBulkEventInfo` | get bulk event info |
 | GET | `/internal/events/by-seller/{sellerId}` | `EventInternalController#getEventsBySeller` | get events by seller |
 | PATCH | `/internal/events/stock-adjustments` | `EventInternalController#adjustStockBulk` | adjust stock bulk |
@@ -36,62 +64,58 @@
 | POST | `/internal/events/{eventId}/deduct-stock` | `EventInternalController#deductStock` | deduct stock |
 | POST | `/internal/events/{eventId}/restore-stock` | `EventInternalController#restoreStock` | restore stock |
 | GET | `/internal/events/{eventId}/validate-purchase` | `EventInternalController#validatePurchase` | validate purchase |
-| GET | `/seller/{eventId}` | `EventController#getSellerEventDetail` | get seller event detail |
-| GET | `/{eventId}` | `EventController#getEvent` | get event |
-| PATCH | `/{eventId}` | `EventController#updateEvent` | update event |
-| GET | `/{eventId}/statistics` | `EventController#getEventSummary` | get event summary |
 
 ## member
 
 | HTTP | Path | Controller#Method | 설명 |
 |---|---|---|---|
-| GET | `/` | `TechStackController#getTechStacks` | 기술 스택 목록 조회 |
-| POST | `/` | `SellerApplicationController#apply` | 판매자 전환 신청 |
-| GET | `/api/members/health` | `MemberController#health` | health |
-| POST | `/login` | `AuthController#login` | 일반 로그인 |
-| POST | `/logout` | `AuthController#logout` | 로그아웃 |
-| DELETE | `/me` | `UserController#withdraw` | 회원 탈퇴 |
-| GET | `/me` | `SellerApplicationController#getMyApplication` | 신청 상태 조회 |
-| GET | `/me` | `UserController#getProfile` | 프로필 조회 |
-| PATCH | `/me` | `UserController#updateProfile` | 프로필 수정 |
-| PATCH | `/me/password` | `UserController#changePassword` | 비밀번호 변경 |
-| POST | `/profile` | `UserController#createProfile` | 프로필 생성 |
-| POST | `/reissue` | `AuthController#reissue` | 토큰 재발급 |
-| PATCH | `/seller-applications/{applicationId}` | `InternalMemberController#decideSellerApplication` | 판매자 신청 승인/반려 |
-| POST | `/signup` | `AuthController#signup` | 회원가입 Step 1 |
-| POST | `/social/google` | `AuthController#socialLogin` | 구글 소셜 로그인 |
-| GET | `/{userId}` | `InternalMemberController#getMemberInfo` | 유저 기본 정보 조회 |
-| GET | `/{userId}/role` | `InternalMemberController#getMemberRole` | 권한 확인 |
-| GET | `/{userId}/seller-info` | `InternalMemberController#getSellerInfo` | 정산 계좌 조회 |
-| GET | `/{userId}/status` | `InternalMemberController#getMemberStatus` | 회원 상태 확인 |
-| PATCH | `/{userId}/status` | `InternalMemberController#getSellerApplications` | 회원 상태 변경 |
+| POST | `/api/auth/login` | `AuthController#login` | login |
+| POST | `/api/auth/logout` | `AuthController#logout` | logout |
+| POST | `/api/auth/reissue` | `AuthController#reissue` | reissue |
+| POST | `/api/auth/signup` | `AuthController#signup` | signup |
+| POST | `/api/auth/social/google` | `AuthController#socialLogin` | social login |
+| GET | `/api/members/health` | `MemberController#health` | Member 서비스 헬스 체크 |
+| POST | `/api/seller-applications` | `SellerApplicationController#apply` | apply |
+| GET | `/api/seller-applications/me` | `SellerApplicationController#getMyApplication` | get my application |
+| GET | `/api/tech-stacks` | `TechStackController#getTechStacks` | 기술 스택 목록 조회 |
+| DELETE | `/api/users/me` | `UserController#withdraw` | withdraw |
+| GET | `/api/users/me` | `UserController#getProfile` | get profile |
+| PATCH | `/api/users/me` | `UserController#updateProfile` | update profile |
+| PATCH | `/api/users/me/password` | `UserController#changePassword` | change password |
+| POST | `/api/users/profile` | `UserController#createProfile` | create profile |
+| GET | `/internal/members/seller-applications` | `InternalMemberController#getSellerApplications` | 판매자 신청 목록 조회 |
+| PATCH | `/internal/members/seller-applications/{applicationId}` | `InternalMemberController#decideSellerApplication` | decide seller application |
+| GET | `/internal/members/{userId}` | `InternalMemberController#getMemberInfo` | get member info |
+| GET | `/internal/members/{userId}/role` | `InternalMemberController#getMemberRole` | get member role |
+| GET | `/internal/members/{userId}/seller-info` | `InternalMemberController#getSellerInfo` | get seller info |
+| GET | `/internal/members/{userId}/status` | `InternalMemberController#getMemberStatus` | get member status |
 
 ## payment
 
 | HTTP | Path | Controller#Method | 설명 |
 |---|---|---|---|
-| GET | `/` | `RefundController#getRefundList` | 환불 내역 목록 조회 |
-| GET | `/` | `WalletController#getBalance` | 예치금 잔액 조회 |
-| GET | `/by-order/{orderId}` | `PaymentInternalController#getPaymentByOrderId` | get payment by order id |
-| POST | `/charge` | `WalletController#charge` | 예치금 충전 시작 |
-| POST | `/charge/confirm` | `WalletController#confirmCharge` | 예치금 충전 승인 |
-| POST | `/confirm` | `PaymentController#confirm` | confirm |
-| GET | `/events/{eventId}` | `SellerRefundController#getSellerRefundListByEventId` | 판매자 이벤트별 환불 내역 조회 |
-| POST | `/fail` | `PaymentController#fail` | fail |
-| GET | `/info` | `RefundController#getRefundInfo` | 환불 정보 조회 |
-| POST | `/pg/{ticketId}` | `RefundController#refundPgTicket` | refund pg ticket |
-| POST | `/ready` | `PaymentController#readyPayment` | 결제 준비 |
-| GET | `/transactions` | `WalletController#getTransactions` | 예치금 거래 내역 조회 |
-| POST | `/withdraw` | `WalletController#withdraw` | 예치금 출금 요청 |
-| GET | `/{refundId}` | `RefundController#getRefundDetail` | 환불 상세 조회 |
+| POST | `/api/payments/confirm` | `PaymentController#confirm` | PG 결제 승인 |
+| POST | `/api/payments/fail` | `PaymentController#fail` | PG 결제 실패 처리 |
+| POST | `/api/payments/ready` | `PaymentController#readyPayment` | ready payment |
+| GET | `/api/refunds` | `RefundController#getRefundList` | get refund list |
+| GET | `/api/refunds/info` | `RefundController#getRefundInfo` | get refund info |
+| POST | `/api/refunds/pg/{ticketId}` | `RefundController#refundPgTicket` | refund pg ticket |
+| GET | `/api/refunds/{refundId}` | `RefundController#getRefundDetail` | get refund detail |
+| GET | `/api/seller/refunds/events/{eventId}` | `SellerRefundController#getSellerRefundListByEventId` | get seller refund list by event id |
+| GET | `/api/wallet` | `WalletController#getBalance` | 예치금 잔액 조회 |
+| POST | `/api/wallet/charge` | `WalletController#charge` | 예치금 충전 시작 |
+| POST | `/api/wallet/charge/confirm` | `WalletController#confirmCharge` | 예치금 충전 승인 |
+| GET | `/api/wallet/transactions` | `WalletController#getTransactions` | 예치금 거래 내역 조회 |
+| POST | `/api/wallet/withdraw` | `WalletController#withdraw` | 예치금 출금 요청 |
+| GET | `/internal/payments/by-order/{orderId}` | `PaymentInternalController#getPaymentByOrderId` | get payment by order id |
 
 ## settlement
 
 | HTTP | Path | Controller#Method | 설명 |
 |---|---|---|---|
 | GET | `/internal/orders/settlement-data` | `MockCommerceController#getSettlementData` | get settlement data |
-| GET | `/seller/settlements` | `SettlementController#getSellerSettlements` | get seller settlements |
+| GET | `/seller/settlements` | `SettlementController#getSellerSettlements` | 판매자 정산 내용 조회 |
 | GET | `/seller/settlements/fetch` | `SettlementController#fetchSettlementData` | fetch settlement data |
-| GET | `/seller/settlements/{settlementId}` | `SettlementController#getSellerSettlement` | get seller settlement |
+| GET | `/seller/settlements/{settlementId}` | `SettlementController#getSellerSettlement` | 판매자 정산 내용 상세 조회 |
 | GET | `/test/batch` | `SettlementController#runBatch` | run batch |
 

--- a/docs/dto-summary.json
+++ b/docs/dto-summary.json
@@ -402,6 +402,692 @@
     "source": "admin/src/main/java/com/devticket/admin/presentation/dto/res/UserListResponse.java"
   },
   {
+    "module": "commerce",
+    "name": "CartItemQuantityRequest",
+    "kind": "record",
+    "fieldCount": 1,
+    "fields": [
+      {
+        "name": "quantity",
+        "type": "int"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/req/CartItemQuantityRequest.java"
+  },
+  {
+    "module": "commerce",
+    "name": "CartItemRequest",
+    "kind": "record",
+    "fieldCount": 2,
+    "fields": [
+      {
+        "name": "eventId",
+        "type": "UUID"
+      },
+      {
+        "name": "quantity",
+        "type": "int"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/req/CartItemRequest.java"
+  },
+  {
+    "module": "commerce",
+    "name": "CartClearResponse",
+    "kind": "record",
+    "fieldCount": 1,
+    "fields": [
+      {
+        "name": "message",
+        "type": "String"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartClearResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "CartItemDeleteResponse",
+    "kind": "record",
+    "fieldCount": 1,
+    "fields": [
+      {
+        "name": "message",
+        "type": "String"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDeleteResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "CartItemDetail",
+    "kind": "record",
+    "fieldCount": 5,
+    "fields": [
+      {
+        "name": "cartItemId",
+        "type": "UUID"
+      },
+      {
+        "name": "eventId",
+        "type": "UUID"
+      },
+      {
+        "name": "eventTitle",
+        "type": "String"
+      },
+      {
+        "name": "price",
+        "type": "int"
+      },
+      {
+        "name": "quantity",
+        "type": "int"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDetail.java"
+  },
+  {
+    "module": "commerce",
+    "name": "CartItemQuantityResponse",
+    "kind": "record",
+    "fieldCount": 2,
+    "fields": [
+      {
+        "name": "cartItemId",
+        "type": "String"
+      },
+      {
+        "name": "quantity",
+        "type": "int"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemQuantityResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "CartItemResponse",
+    "kind": "record",
+    "fieldCount": 3,
+    "fields": [
+      {
+        "name": "cartId",
+        "type": "String"
+      },
+      {
+        "name": "items",
+        "type": "List<CartItemDetail>"
+      },
+      {
+        "name": "totalAmount",
+        "type": "long"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "CartResponse",
+    "kind": "record",
+    "fieldCount": 3,
+    "fields": [
+      {
+        "name": "cartId",
+        "type": "String"
+      },
+      {
+        "name": "items",
+        "type": "List<CartItemDetail>"
+      },
+      {
+        "name": "totalAmount",
+        "type": "int"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "CartOrderRequest",
+    "kind": "record",
+    "fieldCount": 1,
+    "fields": [
+      {
+        "name": "cartItemIds",
+        "type": "List<UUID>"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/CartOrderRequest.java"
+  },
+  {
+    "module": "commerce",
+    "name": "OrderListRequest",
+    "kind": "record",
+    "fieldCount": 3,
+    "fields": [
+      {
+        "name": "page",
+        "type": "int"
+      },
+      {
+        "name": "size",
+        "type": "int"
+      },
+      {
+        "name": "status",
+        "type": "String"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/OrderListRequest.java"
+  },
+  {
+    "module": "commerce",
+    "name": "OrderRequest",
+    "kind": "record",
+    "fieldCount": 1,
+    "fields": [
+      {
+        "name": "cartItemEventIds",
+        "type": "List<String>"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/OrderRequest.java"
+  },
+  {
+    "module": "commerce",
+    "name": "InternalOrderInfoResponse",
+    "kind": "record",
+    "fieldCount": 7,
+    "fields": [
+      {
+        "name": "id",
+        "type": "UUID"
+      },
+      {
+        "name": "userId",
+        "type": "UUID"
+      },
+      {
+        "name": "orderNumber",
+        "type": "String"
+      },
+      {
+        "name": "paymentMethod",
+        "type": "String"
+      },
+      {
+        "name": "totalAmount",
+        "type": "Integer"
+      },
+      {
+        "name": "status",
+        "type": "String"
+      },
+      {
+        "name": "orderedAt",
+        "type": "String"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderInfoResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "InternalOrderItemResponse",
+    "kind": "record",
+    "fieldCount": 10,
+    "fields": [
+      {
+        "name": "id",
+        "type": "Long"
+      },
+      {
+        "name": "orderItemId",
+        "type": "UUID"
+      },
+      {
+        "name": "orderId",
+        "type": "Long"
+      },
+      {
+        "name": "userId",
+        "type": "UUID"
+      },
+      {
+        "name": "eventId",
+        "type": "UUID"
+      },
+      {
+        "name": "price",
+        "type": "int"
+      },
+      {
+        "name": "quantity",
+        "type": "int"
+      },
+      {
+        "name": "subtotalAmount",
+        "type": "int"
+      },
+      {
+        "name": "createdAt",
+        "type": "LocalDateTime"
+      },
+      {
+        "name": "updatedAt",
+        "type": "LocalDateTime"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderItemResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "InternalOrderItemsResponse",
+    "kind": "record",
+    "fieldCount": 2,
+    "fields": [
+      {
+        "name": "eventId",
+        "type": "Long"
+      },
+      {
+        "name": "orders",
+        "type": "List<InternalOrderItemsResponse.OrderItems>"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderItemsResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "InternalSettlementDataResponse",
+    "kind": "record",
+    "fieldCount": 4,
+    "fields": [
+      {
+        "name": "sellerId",
+        "type": "UUID"
+      },
+      {
+        "name": "periodStart",
+        "type": "String"
+      },
+      {
+        "name": "periodEnd",
+        "type": "String"
+      },
+      {
+        "name": "eventSettlements",
+        "type": "List<EventSettlements>"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalSettlementDataResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "OrderCancelResponse",
+    "kind": "record",
+    "fieldCount": 3,
+    "fields": [
+      {
+        "name": "orderId",
+        "type": "String"
+      },
+      {
+        "name": "status",
+        "type": "String"
+      },
+      {
+        "name": "cancelledAt",
+        "type": "String"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderCancelResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "OrderDetailItemResponse",
+    "kind": "record",
+    "fieldCount": 4,
+    "fields": [
+      {
+        "name": "eventId",
+        "type": "UUID"
+      },
+      {
+        "name": "eventTitle",
+        "type": "String"
+      },
+      {
+        "name": "quantity",
+        "type": "int"
+      },
+      {
+        "name": "price",
+        "type": "int"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailItemResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "OrderDetailResponse",
+    "kind": "record",
+    "fieldCount": 6,
+    "fields": [
+      {
+        "name": "orderId",
+        "type": "UUID"
+      },
+      {
+        "name": "status",
+        "type": "OrderStatus"
+      },
+      {
+        "name": "totalAmount",
+        "type": "int"
+      },
+      {
+        "name": "orderItems",
+        "type": "List<OrderDetailItemResponse>"
+      },
+      {
+        "name": "paymentMethod",
+        "type": "PaymentMethod"
+      },
+      {
+        "name": "createdAt",
+        "type": "LocalDateTime"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "OrderItemsResponse",
+    "kind": "record",
+    "fieldCount": 4,
+    "fields": [
+      {
+        "name": "eventId",
+        "type": "UUID"
+      },
+      {
+        "name": "eventTitle",
+        "type": "String"
+      },
+      {
+        "name": "quantity",
+        "type": "int"
+      },
+      {
+        "name": "price",
+        "type": "int"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderItemsResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "OrderListResponse",
+    "kind": "record",
+    "fieldCount": 3,
+    "fields": [
+      {
+        "name": "orders",
+        "type": "List<OrderSummary>"
+      },
+      {
+        "name": "totalPages",
+        "type": "int"
+      },
+      {
+        "name": "totalElements",
+        "type": "long"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderListResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "OrderResponse",
+    "kind": "record",
+    "fieldCount": 5,
+    "fields": [
+      {
+        "name": "orderId",
+        "type": "UUID"
+      },
+      {
+        "name": "totalAmount",
+        "type": "Long"
+      },
+      {
+        "name": "orderStatus",
+        "type": "OrderStatus"
+      },
+      {
+        "name": "orderItems",
+        "type": "List<OrderItemsResponse>"
+      },
+      {
+        "name": "createdAt",
+        "type": "LocalDateTime"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "OrderSummary",
+    "kind": "record",
+    "fieldCount": 4,
+    "fields": [
+      {
+        "name": "orderId",
+        "type": "UUID"
+      },
+      {
+        "name": "totalAmount",
+        "type": "int"
+      },
+      {
+        "name": "status",
+        "type": "OrderStatus"
+      },
+      {
+        "name": "createdAt",
+        "type": "LocalDateTime"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderSummary.java"
+  },
+  {
+    "module": "commerce",
+    "name": "SellerEventParticipantListRequest",
+    "kind": "record",
+    "fieldCount": 3,
+    "fields": [
+      {
+        "name": "page",
+        "type": "Integer"
+      },
+      {
+        "name": "size",
+        "type": "Integer"
+      },
+      {
+        "name": "keyword",
+        "type": "String"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/SellerEventParticipantListRequest.java"
+  },
+  {
+    "module": "commerce",
+    "name": "TicketListRequest",
+    "kind": "record",
+    "fieldCount": 2,
+    "fields": [
+      {
+        "name": "page",
+        "type": "int"
+      },
+      {
+        "name": "size",
+        "type": "int"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/TicketListRequest.java"
+  },
+  {
+    "module": "commerce",
+    "name": "TicketRequest",
+    "kind": "record",
+    "fieldCount": 1,
+    "fields": [
+      {
+        "name": "orderId",
+        "type": "Long"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/TicketRequest.java"
+  },
+  {
+    "module": "commerce",
+    "name": "SellerEventParticipantListResponse",
+    "kind": "record",
+    "fieldCount": 5,
+    "fields": [
+      {
+        "name": "sellerEventParticipantListResponse",
+        "type": "List<SellerEventParticipantResponse>"
+      },
+      {
+        "name": "page",
+        "type": "int"
+      },
+      {
+        "name": "size",
+        "type": "int"
+      },
+      {
+        "name": "totalElements",
+        "type": "long"
+      },
+      {
+        "name": "totalPages",
+        "type": "int"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantListResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "SellerEventParticipantResponse",
+    "kind": "record",
+    "fieldCount": 6,
+    "fields": [
+      {
+        "name": "ticketId",
+        "type": "String"
+      },
+      {
+        "name": "orderId",
+        "type": "String"
+      },
+      {
+        "name": "userId",
+        "type": "String"
+      },
+      {
+        "name": "email",
+        "type": "String"
+      },
+      {
+        "name": "purchasedAt",
+        "type": "String"
+      },
+      {
+        "name": "orderNumber",
+        "type": "String"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "TicketDetailResponse",
+    "kind": "record",
+    "fieldCount": 6,
+    "fields": [
+      {
+        "name": "ticketId",
+        "type": "UUID"
+      },
+      {
+        "name": "eventId",
+        "type": "UUID"
+      },
+      {
+        "name": "eventTitle",
+        "type": "String"
+      },
+      {
+        "name": "eventDateTime",
+        "type": "String"
+      },
+      {
+        "name": "status",
+        "type": "String"
+      },
+      {
+        "name": "issuedAt",
+        "type": "String"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketDetailResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "TicketListResponse",
+    "kind": "record",
+    "fieldCount": 3,
+    "fields": [
+      {
+        "name": "totalPages",
+        "type": "int"
+      },
+      {
+        "name": "totalElements",
+        "type": "Long"
+      },
+      {
+        "name": "tickets",
+        "type": "List<TicketDetailResponse>"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketListResponse.java"
+  },
+  {
+    "module": "commerce",
+    "name": "TicketResponse",
+    "kind": "record",
+    "fieldCount": 3,
+    "fields": [
+      {
+        "name": "orderItemId",
+        "type": "Long"
+      },
+      {
+        "name": "totalCount",
+        "type": "Integer"
+      },
+      {
+        "name": "tickets",
+        "type": "List<TicketInfo>"
+      }
+    ],
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketResponse.java"
+  },
+  {
     "module": "event",
     "name": "EventDetailResponse",
     "kind": "record",
@@ -879,7 +1565,7 @@
     "fields": [
       {
         "name": "eventIds",
-        "type": "List<UUID>"
+        "type": "List< UUID>"
       }
     ],
     "source": "event/src/main/java/com/devticket/event/presentation/dto/internal/InternalBulkEventInfoRequest.java"
@@ -979,7 +1665,7 @@
       },
       {
         "name": "purchasable",
-        "type": "// Long id → UUID eventId boolean"
+        "type": "boolean"
       },
       {
         "name": "reason",
@@ -2164,8 +2850,8 @@
         "type": "boolean"
       },
       {
-        "name": "\"WALLET\"",
-        "type": "String paymentMethod // \"PG\" or"
+        "name": "paymentMethod",
+        "type": "String"
       }
     ],
     "source": "payment/src/main/java/com/devticket/payment/refund/presentation/dto/RefundInfoResponse.java"
@@ -2250,8 +2936,8 @@
         "type": "LocalDateTime"
       },
       {
-        "name": "추가",
-        "type": "LocalDateTime completedAt //TODO: 환불자 이름"
+        "name": "completedAt",
+        "type": "LocalDateTime"
       }
     ],
     "source": "payment/src/main/java/com/devticket/payment/refund/presentation/dto/SellerRefundListItemResponse.java"

--- a/docs/dto-summary.md
+++ b/docs/dto-summary.md
@@ -143,6 +143,262 @@
 |---|---|
 | `status` | `String` |
 
+## commerce
+
+### CartClearResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartClearResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `message` | `String` |
+
+### CartItemDeleteResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDeleteResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `message` | `String` |
+
+### CartItemDetail (record)
+- source: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemDetail.java`
+| 필드명 | 타입 |
+|---|---|
+| `cartItemId` | `UUID` |
+| `eventId` | `UUID` |
+| `eventTitle` | `String` |
+| `price` | `int` |
+| `quantity` | `int` |
+
+### CartItemQuantityRequest (record)
+- source: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/req/CartItemQuantityRequest.java`
+| 필드명 | 타입 |
+|---|---|
+| `quantity` | `int` |
+
+### CartItemQuantityResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemQuantityResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `cartItemId` | `String` |
+| `quantity` | `int` |
+
+### CartItemRequest (record)
+- source: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/req/CartItemRequest.java`
+| 필드명 | 타입 |
+|---|---|
+| `eventId` | `UUID` |
+| `quantity` | `int` |
+
+### CartItemResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `cartId` | `String` |
+| `items` | `List<CartItemDetail>` |
+| `totalAmount` | `long` |
+
+### CartOrderRequest (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/CartOrderRequest.java`
+| 필드명 | 타입 |
+|---|---|
+| `cartItemIds` | `List<UUID>` |
+
+### CartResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `cartId` | `String` |
+| `items` | `List<CartItemDetail>` |
+| `totalAmount` | `int` |
+
+### InternalOrderInfoResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderInfoResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `id` | `UUID` |
+| `userId` | `UUID` |
+| `orderNumber` | `String` |
+| `paymentMethod` | `String` |
+| `totalAmount` | `Integer` |
+| `status` | `String` |
+| `orderedAt` | `String` |
+
+### InternalOrderItemResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderItemResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `id` | `Long` |
+| `orderItemId` | `UUID` |
+| `orderId` | `Long` |
+| `userId` | `UUID` |
+| `eventId` | `UUID` |
+| `price` | `int` |
+| `quantity` | `int` |
+| `subtotalAmount` | `int` |
+| `createdAt` | `LocalDateTime` |
+| `updatedAt` | `LocalDateTime` |
+
+### InternalOrderItemsResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalOrderItemsResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `eventId` | `Long` |
+| `orders` | `List<InternalOrderItemsResponse.OrderItems>` |
+
+### InternalSettlementDataResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/InternalSettlementDataResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `sellerId` | `UUID` |
+| `periodStart` | `String` |
+| `periodEnd` | `String` |
+| `eventSettlements` | `List<EventSettlements>` |
+
+### OrderCancelResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderCancelResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `orderId` | `String` |
+| `status` | `String` |
+| `cancelledAt` | `String` |
+
+### OrderDetailItemResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailItemResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `eventId` | `UUID` |
+| `eventTitle` | `String` |
+| `quantity` | `int` |
+| `price` | `int` |
+
+### OrderDetailResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `orderId` | `UUID` |
+| `status` | `OrderStatus` |
+| `totalAmount` | `int` |
+| `orderItems` | `List<OrderDetailItemResponse>` |
+| `paymentMethod` | `PaymentMethod` |
+| `createdAt` | `LocalDateTime` |
+
+### OrderItemsResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderItemsResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `eventId` | `UUID` |
+| `eventTitle` | `String` |
+| `quantity` | `int` |
+| `price` | `int` |
+
+### OrderListRequest (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/OrderListRequest.java`
+| 필드명 | 타입 |
+|---|---|
+| `page` | `int` |
+| `size` | `int` |
+| `status` | `String` |
+
+### OrderListResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderListResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `orders` | `List<OrderSummary>` |
+| `totalPages` | `int` |
+| `totalElements` | `long` |
+
+### OrderRequest (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/req/OrderRequest.java`
+| 필드명 | 타입 |
+|---|---|
+| `cartItemEventIds` | `List<String>` |
+
+### OrderResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `orderId` | `UUID` |
+| `totalAmount` | `Long` |
+| `orderStatus` | `OrderStatus` |
+| `orderItems` | `List<OrderItemsResponse>` |
+| `createdAt` | `LocalDateTime` |
+
+### OrderSummary (record)
+- source: `commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderSummary.java`
+| 필드명 | 타입 |
+|---|---|
+| `orderId` | `UUID` |
+| `totalAmount` | `int` |
+| `status` | `OrderStatus` |
+| `createdAt` | `LocalDateTime` |
+
+### SellerEventParticipantListRequest (record)
+- source: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/SellerEventParticipantListRequest.java`
+| 필드명 | 타입 |
+|---|---|
+| `page` | `Integer` |
+| `size` | `Integer` |
+| `keyword` | `String` |
+
+### SellerEventParticipantListResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantListResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `sellerEventParticipantListResponse` | `List<SellerEventParticipantResponse>` |
+| `page` | `int` |
+| `size` | `int` |
+| `totalElements` | `long` |
+| `totalPages` | `int` |
+
+### SellerEventParticipantResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/SellerEventParticipantResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `ticketId` | `String` |
+| `orderId` | `String` |
+| `userId` | `String` |
+| `email` | `String` |
+| `purchasedAt` | `String` |
+| `orderNumber` | `String` |
+
+### TicketDetailResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketDetailResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `ticketId` | `UUID` |
+| `eventId` | `UUID` |
+| `eventTitle` | `String` |
+| `eventDateTime` | `String` |
+| `status` | `String` |
+| `issuedAt` | `String` |
+
+### TicketListRequest (record)
+- source: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/TicketListRequest.java`
+| 필드명 | 타입 |
+|---|---|
+| `page` | `int` |
+| `size` | `int` |
+
+### TicketListResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketListResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `totalPages` | `int` |
+| `totalElements` | `Long` |
+| `tickets` | `List<TicketDetailResponse>` |
+
+### TicketRequest (record)
+- source: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/req/TicketRequest.java`
+| 필드명 | 타입 |
+|---|---|
+| `orderId` | `Long` |
+
+### TicketResponse (record)
+- source: `commerce/src/main/java/com/devticket/commerce/ticket/presentation/dto/res/TicketResponse.java`
+| 필드명 | 타입 |
+|---|---|
+| `orderItemId` | `Long` |
+| `totalCount` | `Integer` |
+| `tickets` | `List<TicketInfo>` |
+
 ## event
 
 ### EventDetailResponse (record)
@@ -205,7 +461,7 @@
 - source: `event/src/main/java/com/devticket/event/presentation/dto/internal/InternalBulkEventInfoRequest.java`
 | 필드명 | 타입 |
 |---|---|
-| `eventIds` | `List<UUID>` |
+| `eventIds` | `List< UUID>` |
 
 ### InternalBulkEventInfoResponse (record)
 - source: `event/src/main/java/com/devticket/event/presentation/dto/internal/InternalBulkEventInfoResponse.java`
@@ -241,7 +497,7 @@
 | 필드명 | 타입 |
 |---|---|
 | `eventId` | `UUID` |
-| `purchasable` | `// Long id → UUID eventId boolean` |
+| `purchasable` | `boolean` |
 | `reason` | `PurchaseUnavailableReason` |
 | `maxQuantity` | `Integer` |
 | `title` | `String` |
@@ -768,7 +1024,7 @@
 | `refundRate` | `Integer` |
 | `dDay` | `long` |
 | `refundable` | `boolean` |
-| `"WALLET"` | `String paymentMethod // "PG" or` |
+| `paymentMethod` | `String` |
 
 ### RefundListItemResponse (record)
 - source: `payment/src/main/java/com/devticket/payment/refund/presentation/dto/RefundListItemResponse.java`
@@ -795,7 +1051,7 @@
 | `status` | `String` |
 | `paymentMethod` | `String` |
 | `requestedAt` | `LocalDateTime` |
-| `추가` | `LocalDateTime completedAt //TODO: 환불자 이름` |
+| `completedAt` | `LocalDateTime` |
 
 ### WalletBalanceResponse (record)
 - source: `payment/src/main/java/com/devticket/payment/wallet/presentation/dto/WalletBalanceResponse.java`

--- a/docs/service-status.json
+++ b/docs/service-status.json
@@ -2,16 +2,16 @@
   {
     "module": "admin",
     "service": "AdminSellerService",
-    "method": "getSellerApplicationList",
-    "description": "get seller application list 기능을 제공",
+    "method": "decideApplication",
+    "description": "decide application 기능을 제공",
     "source": "admin/src/main/java/com/devticket/admin/application/service/AdminSellerService.java"
   },
   {
     "module": "admin",
-    "service": "AdminSellerServiceImpl",
+    "service": "AdminSellerService",
     "method": "getSellerApplicationList",
     "description": "get seller application list 기능을 제공",
-    "source": "admin/src/main/java/com/devticket/admin/application/service/AdminSellerServiceImpl.java"
+    "source": "admin/src/main/java/com/devticket/admin/application/service/AdminSellerService.java"
   },
   {
     "module": "admin",
@@ -22,9 +22,30 @@
   },
   {
     "module": "admin",
+    "service": "AdminSellerServiceImpl",
+    "method": "getSellerApplicationList",
+    "description": "get seller application list 기능을 제공",
+    "source": "admin/src/main/java/com/devticket/admin/application/service/AdminSellerServiceImpl.java"
+  },
+  {
+    "module": "admin",
     "service": "AdminUserService",
     "method": "getMembers",
     "description": "get members 기능을 제공",
+    "source": "admin/src/main/java/com/devticket/admin/application/service/AdminUserService.java"
+  },
+  {
+    "module": "admin",
+    "service": "AdminUserService",
+    "method": "penalizeUser",
+    "description": "penalize user 기능을 제공",
+    "source": "admin/src/main/java/com/devticket/admin/application/service/AdminUserService.java"
+  },
+  {
+    "module": "admin",
+    "service": "AdminUserService",
+    "method": "updateUserRole",
+    "description": "update user role 기능을 제공",
     "source": "admin/src/main/java/com/devticket/admin/application/service/AdminUserService.java"
   },
   {
@@ -49,18 +70,179 @@
     "source": "admin/src/main/java/com/devticket/admin/application/service/AdminUserServiceImpl.java"
   },
   {
+    "module": "commerce",
+    "service": "CartService",
+    "method": "clearCart",
+    "description": "clear cart 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "CartService",
+    "method": "deleteTicket",
+    "description": "delete ticket 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "CartService",
+    "method": "findByUserId",
+    "description": "find by user id 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "CartService",
+    "method": "getCart",
+    "description": "get cart 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "CartService",
+    "method": "save",
+    "description": "save 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "CartService",
+    "method": "updateTicket",
+    "description": "update ticket 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "OrderService",
+    "method": "cancelOrder",
+    "description": "cancel order 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "OrderService",
+    "method": "completeOrder",
+    "description": "complete order 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "OrderService",
+    "method": "completeRefund",
+    "description": "complete refund 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "OrderService",
+    "method": "createOrderByCart",
+    "description": "create order by cart 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "OrderService",
+    "method": "failOrder",
+    "description": "fail order 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "OrderService",
+    "method": "getOrderDetail",
+    "description": "get order detail 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "OrderService",
+    "method": "getOrderInfo",
+    "description": "get order info 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "OrderService",
+    "method": "getOrderItemByTicketId",
+    "description": "get order item by ticket id 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "OrderService",
+    "method": "getOrderList",
+    "description": "get order list 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "OrderService",
+    "method": "getOrderListForSettlement",
+    "description": "get order list for settlement 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "OrderService",
+    "method": "getSettelmentData",
+    "description": "get settelment data 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "TicketService",
+    "method": "createTicket",
+    "description": "create ticket 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "TicketService",
+    "method": "getParticipantList",
+    "description": "get participant list 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "TicketService",
+    "method": "getTicketDetail",
+    "description": "get ticket detail 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java"
+  },
+  {
+    "module": "commerce",
+    "service": "TicketService",
+    "method": "getTicketList",
+    "description": "get ticket list 기능을 제공",
+    "source": "commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java"
+  },
+  {
+    "module": "payment",
+    "service": "PaymentService",
+    "method": "confirmPgPayment",
+    "description": "confirm pg payment 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/payment/application/service/PaymentService.java"
+  },
+  {
+    "module": "payment",
+    "service": "PaymentService",
+    "method": "failPgPayment",
+    "description": "fail pg payment 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/payment/application/service/PaymentService.java"
+  },
+  {
+    "module": "payment",
+    "service": "PaymentService",
+    "method": "getPaymentByOrderId",
+    "description": "get payment by order id 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/payment/application/service/PaymentService.java"
+  },
+  {
     "module": "payment",
     "service": "PaymentService",
     "method": "readyPayment",
     "description": "ready payment 기능을 제공",
     "source": "payment/src/main/java/com/devticket/payment/payment/application/service/PaymentService.java"
-  },
-  {
-    "module": "payment",
-    "service": "PaymentServiceImpl",
-    "method": "readyPayment",
-    "description": "ready payment 기능을 제공",
-    "source": "payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java"
   },
   {
     "module": "payment",
@@ -85,6 +267,20 @@
   },
   {
     "module": "payment",
+    "service": "PaymentServiceImpl",
+    "method": "readyPayment",
+    "description": "ready payment 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java"
+  },
+  {
+    "module": "payment",
+    "service": "RefundService",
+    "method": "getRefundDetail",
+    "description": "get refund detail 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/refund/application/service/RefundService.java"
+  },
+  {
+    "module": "payment",
     "service": "RefundService",
     "method": "getRefundInfo",
     "description": "get refund info 기능을 제공",
@@ -92,16 +288,37 @@
   },
   {
     "module": "payment",
+    "service": "RefundService",
+    "method": "getRefundList",
+    "description": "get refund list 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/refund/application/service/RefundService.java"
+  },
+  {
+    "module": "payment",
+    "service": "RefundService",
+    "method": "getSellerRefundListByEventId",
+    "description": "get seller refund list by event id 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/refund/application/service/RefundService.java"
+  },
+  {
+    "module": "payment",
+    "service": "RefundService",
+    "method": "refundPgTicket",
+    "description": "refund pg ticket 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/refund/application/service/RefundService.java"
+  },
+  {
+    "module": "payment",
     "service": "RefundServiceImpl",
-    "method": "getRefundInfo",
-    "description": "get refund info 기능을 제공",
+    "method": "getRefundDetail",
+    "description": "get refund detail 기능을 제공",
     "source": "payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java"
   },
   {
     "module": "payment",
     "service": "RefundServiceImpl",
-    "method": "refundPgTicket",
-    "description": "refund pg ticket 기능을 제공",
+    "method": "getRefundInfo",
+    "description": "get refund info 기능을 제공",
     "source": "payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java"
   },
   {
@@ -114,15 +331,15 @@
   {
     "module": "payment",
     "service": "RefundServiceImpl",
-    "method": "getRefundDetail",
-    "description": "get refund detail 기능을 제공",
+    "method": "getSellerRefundListByEventId",
+    "description": "get seller refund list by event id 기능을 제공",
     "source": "payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java"
   },
   {
     "module": "payment",
     "service": "RefundServiceImpl",
-    "method": "getSellerRefundListByEventId",
-    "description": "get seller refund list by event id 기능을 제공",
+    "method": "refundPgTicket",
+    "description": "refund pg ticket 기능을 제공",
     "source": "payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java"
   },
   {
@@ -130,6 +347,55 @@
     "service": "WalletService",
     "method": "charge",
     "description": "charge 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java"
+  },
+  {
+    "module": "payment",
+    "service": "WalletService",
+    "method": "confirmCharge",
+    "description": "confirm charge 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java"
+  },
+  {
+    "module": "payment",
+    "service": "WalletService",
+    "method": "getBalance",
+    "description": "get balance 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java"
+  },
+  {
+    "module": "payment",
+    "service": "WalletService",
+    "method": "getTransactions",
+    "description": "get transactions 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java"
+  },
+  {
+    "module": "payment",
+    "service": "WalletService",
+    "method": "processBatchRefund",
+    "description": "process batch refund 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java"
+  },
+  {
+    "module": "payment",
+    "service": "WalletService",
+    "method": "processWalletPayment",
+    "description": "process wallet payment 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java"
+  },
+  {
+    "module": "payment",
+    "service": "WalletService",
+    "method": "restoreBalance",
+    "description": "restore balance 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java"
+  },
+  {
+    "module": "payment",
+    "service": "WalletService",
+    "method": "withdraw",
+    "description": "withdraw 기능을 제공",
     "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java"
   },
   {
@@ -149,13 +415,6 @@
   {
     "module": "payment",
     "service": "WalletServiceImpl",
-    "method": "withdraw",
-    "description": "withdraw 기능을 제공",
-    "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java"
-  },
-  {
-    "module": "payment",
-    "service": "WalletServiceImpl",
     "method": "getBalance",
     "description": "get balance 기능을 제공",
     "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java"
@@ -165,6 +424,13 @@
     "service": "WalletServiceImpl",
     "method": "getTransactions",
     "description": "get transactions 기능을 제공",
+    "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java"
+  },
+  {
+    "module": "payment",
+    "service": "WalletServiceImpl",
+    "method": "processBatchRefund",
+    "description": "process batch refund 기능을 제공",
     "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java"
   },
   {
@@ -184,8 +450,8 @@
   {
     "module": "payment",
     "service": "WalletServiceImpl",
-    "method": "processBatchRefund",
-    "description": "process batch refund 기능을 제공",
+    "method": "withdraw",
+    "description": "withdraw 기능을 제공",
     "source": "payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java"
   },
   {
@@ -193,6 +459,20 @@
     "service": "SettlementService",
     "method": "fetchSettlementData",
     "description": "fetch settlement data 기능을 제공",
+    "source": "settlement/src/main/java/com/devticket/settlement/application/service/SettlementService.java"
+  },
+  {
+    "module": "settlement",
+    "service": "SettlementService",
+    "method": "getSellerSettlementDetail",
+    "description": "get seller settlement detail 기능을 제공",
+    "source": "settlement/src/main/java/com/devticket/settlement/application/service/SettlementService.java"
+  },
+  {
+    "module": "settlement",
+    "service": "SettlementService",
+    "method": "getSellerSettlements",
+    "description": "get seller settlements 기능을 제공",
     "source": "settlement/src/main/java/com/devticket/settlement/application/service/SettlementService.java"
   },
   {
@@ -205,15 +485,15 @@
   {
     "module": "settlement",
     "service": "SettlementServiceImpl",
-    "method": "getSellerSettlements",
-    "description": "get seller settlements 기능을 제공",
+    "method": "getSellerSettlementDetail",
+    "description": "get seller settlement detail 기능을 제공",
     "source": "settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java"
   },
   {
     "module": "settlement",
     "service": "SettlementServiceImpl",
-    "method": "getSellerSettlementDetail",
-    "description": "get seller settlement detail 기능을 제공",
+    "method": "getSellerSettlements",
+    "description": "get seller settlements 기능을 제공",
     "source": "settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java"
   }
 ]

--- a/docs/service-status.md
+++ b/docs/service-status.md
@@ -3,15 +3,18 @@
 ## admin / AdminSellerService
 
 - `getSellerApplicationList`: get seller application list 기능을 제공.
+- `decideApplication`: decide application 기능을 제공.
 
 ## admin / AdminSellerServiceImpl
 
-- `decideApplication`: decide application 기능을 제공.
 - `getSellerApplicationList`: get seller application list 기능을 제공.
+- `decideApplication`: decide application 기능을 제공.
 
 ## admin / AdminUserService
 
 - `getMembers`: get members 기능을 제공.
+- `penalizeUser`: penalize user 기능을 제공.
+- `updateUserRole`: update user role 기능을 제공.
 
 ## admin / AdminUserServiceImpl
 
@@ -19,51 +22,97 @@
 - `penalizeUser`: penalize user 기능을 제공.
 - `updateUserRole`: update user role 기능을 제공.
 
+## commerce / CartService
+
+- `findByUserId`: find by user id 기능을 제공.
+- `save`: save 기능을 제공.
+- `getCart`: get cart 기능을 제공.
+- `clearCart`: clear cart 기능을 제공.
+- `updateTicket`: update ticket 기능을 제공.
+- `deleteTicket`: delete ticket 기능을 제공.
+
+## commerce / OrderService
+
+- `createOrderByCart`: create order by cart 기능을 제공.
+- `getOrderDetail`: get order detail 기능을 제공.
+- `getOrderList`: get order list 기능을 제공.
+- `getOrderInfo`: get order info 기능을 제공.
+- `getOrderListForSettlement`: get order list for settlement 기능을 제공.
+- `failOrder`: fail order 기능을 제공.
+- `completeOrder`: complete order 기능을 제공.
+- `getSettelmentData`: get settelment data 기능을 제공.
+- `cancelOrder`: cancel order 기능을 제공.
+- `getOrderItemByTicketId`: get order item by ticket id 기능을 제공.
+- `completeRefund`: complete refund 기능을 제공.
+
+## commerce / TicketService
+
+- `getTicketList`: get ticket list 기능을 제공.
+- `getTicketDetail`: get ticket detail 기능을 제공.
+- `createTicket`: create ticket 기능을 제공.
+- `getParticipantList`: get participant list 기능을 제공.
+
 ## payment / PaymentService
 
 - `readyPayment`: ready payment 기능을 제공.
-
-## payment / PaymentServiceImpl
-
 - `confirmPgPayment`: confirm pg payment 기능을 제공.
 - `failPgPayment`: fail pg payment 기능을 제공.
 - `getPaymentByOrderId`: get payment by order id 기능을 제공.
+
+## payment / PaymentServiceImpl
+
 - `readyPayment`: ready payment 기능을 제공.
+- `confirmPgPayment`: confirm pg payment 기능을 제공.
+- `failPgPayment`: fail pg payment 기능을 제공.
+- `getPaymentByOrderId`: get payment by order id 기능을 제공.
 
 ## payment / RefundService
 
 - `getRefundInfo`: get refund info 기능을 제공.
+- `refundPgTicket`: refund pg ticket 기능을 제공.
+- `getRefundList`: get refund list 기능을 제공.
+- `getRefundDetail`: get refund detail 기능을 제공.
+- `getSellerRefundListByEventId`: get seller refund list by event id 기능을 제공.
 
 ## payment / RefundServiceImpl
 
-- `getRefundDetail`: get refund detail 기능을 제공.
 - `getRefundInfo`: get refund info 기능을 제공.
-- `getRefundList`: get refund list 기능을 제공.
-- `getSellerRefundListByEventId`: get seller refund list by event id 기능을 제공.
 - `refundPgTicket`: refund pg ticket 기능을 제공.
+- `getRefundList`: get refund list 기능을 제공.
+- `getRefundDetail`: get refund detail 기능을 제공.
+- `getSellerRefundListByEventId`: get seller refund list by event id 기능을 제공.
 
 ## payment / WalletService
 
 - `charge`: charge 기능을 제공.
+- `confirmCharge`: confirm charge 기능을 제공.
+- `withdraw`: withdraw 기능을 제공.
+- `getBalance`: get balance 기능을 제공.
+- `getTransactions`: get transactions 기능을 제공.
+- `processWalletPayment`: process wallet payment 기능을 제공.
+- `restoreBalance`: restore balance 기능을 제공.
+- `processBatchRefund`: process batch refund 기능을 제공.
 
 ## payment / WalletServiceImpl
 
 - `charge`: charge 기능을 제공.
 - `confirmCharge`: confirm charge 기능을 제공.
+- `withdraw`: withdraw 기능을 제공.
 - `getBalance`: get balance 기능을 제공.
 - `getTransactions`: get transactions 기능을 제공.
-- `processBatchRefund`: process batch refund 기능을 제공.
 - `processWalletPayment`: process wallet payment 기능을 제공.
 - `restoreBalance`: restore balance 기능을 제공.
-- `withdraw`: withdraw 기능을 제공.
+- `processBatchRefund`: process batch refund 기능을 제공.
 
 ## settlement / SettlementService
 
 - `fetchSettlementData`: fetch settlement data 기능을 제공.
+- `getSellerSettlements`: get seller settlements 기능을 제공.
+- `getSellerSettlementDetail`: get seller settlement detail 기능을 제공.
 
 ## settlement / SettlementServiceImpl
 
 - `fetchSettlementData`: fetch settlement data 기능을 제공.
-- `getSellerSettlementDetail`: get seller settlement detail 기능을 제공.
 - `getSellerSettlements`: get seller settlements 기능을 제공.
+- `getSellerSettlementDetail`: get seller settlement detail 기능을 제공.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,48 @@
+# scripts/
+
+## gen-docs.py
+
+`docs/api-summary.*`, `docs/dto-summary.*`, `docs/service-status.*` 6개 파일을
+레포 소스(Controller / DTO / Service)로부터 자동 재생성합니다.
+
+### 사용법
+
+```bash
+# 레포 루트(develop/docs)에서 실행
+python scripts/gen-docs.py            # 6개 파일 덮어쓰기
+python scripts/gen-docs.py --check    # diff 예상만 stdout, 쓰기 안 함
+```
+
+Python 3.9+ 표준 라이브러리만 사용 (외부 패키지 없음).
+
+### 스캔 규칙
+
+| 대상 | 입력 경로 패턴 | 추출 내용 |
+|------|--------------|---------|
+| API | `{module}/src/main/java/**/*Controller.java` | `@(Get\|Post\|Patch\|Delete\|Put)Mapping` + 클래스 `@RequestMapping` prefix + `@Operation(summary=...)` |
+| DTO | `{module}/src/main/java/**/presentation/dto/**/*.java` | `public record` / `public class` 의 필드 (annotation 제거 후 `타입 이름` 쌍) |
+| Service | `{module}/src/main/java/**/application/service/*.java` | `public` 메서드 + `interface` 의 추상 메서드 |
+
+대상 모듈: `admin`, `apigateway`, `commerce`, `event`, `member`, `payment`, `settlement`
+(frontend 는 TS/React 라 범위 외)
+
+### 원본과의 차이
+
+PR #323 (HyWChoi, 2026-04-07) 에서 Codex task 로 1회 생성된 출력을 기반으로 포맷을
+재현했습니다. 단, 다음 두 가지 방향에서 출력이 개선되었습니다.
+
+1. **Commerce 모듈 포함** — 원본 생성 시점에 누락
+2. **정확도 향상 (의도된 개선)**
+   - 클래스 레벨 `@RequestMapping` prefix 결합 (event `/` → `/api/events` 등)
+   - 메서드–summary 매칭 교정 (원본의 행 섞임 수정)
+   - interface 추상 메서드 포함
+   - `@Schema(example="(...")` 등 미종결 문자열 리터럴에 의한 필드 파싱 실패 복구
+
+원본을 byte 단위로 재현하지는 않습니다.
+
+### 한계
+
+- 정규식 기반 파서라 극단적 Java 문법(중첩 제네릭 + 람다 혼합 등)에 취약할 수 있습니다.
+  파싱 실패는 해당 항목 스킵으로 처리되며 빌드는 중단되지 않습니다.
+- `@Operation(summary=...)` 가 없으면 메서드명의 camelCase 를 공백으로 분리해 fallback.
+- record/class 외의 DTO 타입(enum, sealed interface 등)은 대상 외.

--- a/scripts/gen-docs.py
+++ b/scripts/gen-docs.py
@@ -1,0 +1,647 @@
+#!/usr/bin/env python3
+"""
+docs/api-summary.*, docs/dto-summary.*, docs/service-status.* 자동 재생성 스크립트.
+
+원 저자: HyWChoi (PR #323, Codex task — ephemeral)
+본 스크립트는 PR #323의 출력 포맷을 재현하여 커밋 가능한 형태로 복원한 재작성본입니다.
+Commerce 모듈 누락 해소 및 향후 모듈 추가 대응이 목적.
+
+사용:
+    python scripts/gen-docs.py              # 전체 재생성
+    python scripts/gen-docs.py --check      # diff만 stdout 출력 (쓰기 안 함)
+
+스캔 규칙:
+  - API     : `**/presentation/controller/*Controller.java`
+              `@Operation(summary="...")` + `@GetMapping/@PostMapping/...`
+              클래스 레벨 `@RequestMapping` prefix 결합
+  - DTO     : `**/presentation/dto/**/*.java`
+              `public record` 또는 `public class` 의 필드 추출
+  - Service : `**/application/service/*.java`
+              `public` 메서드 시그니처 추출, 생성자 제외
+
+한계 / 주의:
+  - 정규식 기반 파서라 일반적이지 않은 Java 문법에 취약 (중첩 제네릭, 람다 등은
+    가능한 범위에서 방어적으로 처리).
+  - @Operation summary 누락 시 methodName 의 camelCase 를 공백 분리해 fallback.
+  - frontend 모듈은 TS/React 라 본 스크립트 범위 외.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
+
+MODULES: list[str] = [
+    "admin",
+    "apigateway",
+    "commerce",
+    "event",
+    "member",
+    "payment",
+    "settlement",
+]
+
+HTTP_ANNOTATIONS = {
+    "GetMapping": "GET",
+    "PostMapping": "POST",
+    "PatchMapping": "PATCH",
+    "DeleteMapping": "DELETE",
+    "PutMapping": "PUT",
+}
+
+
+# ---------------------------------------------------------------------------
+# Java 파서 유틸
+# ---------------------------------------------------------------------------
+
+_STRING_RE = re.compile(r'"(?:\\.|[^"\\])*"')
+
+
+def mask_strings(src: str) -> str:
+    """Java 문자열 리터럴을 중립 placeholder 로 치환.
+
+    리터럴 안에 괄호·콤마·따옴표 이스케이프 등이 있어도 annotation/field
+    파싱을 방해하지 않도록 `""` 형태로만 남김. 원본 값이 필요 없는 스캔
+    단계에서만 사용."""
+    return _STRING_RE.sub('""', src)
+
+
+def strip_comments(src: str) -> str:
+    """Java 주석 (//..., /* ... */) 제거."""
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.DOTALL)
+    src = re.sub(r"//[^\n]*", "", src)
+    return src
+
+
+def camel_to_words(name: str) -> str:
+    """camelCase / PascalCase → 공백 분리 소문자."""
+    spaced = re.sub(r"(?<!^)(?=[A-Z])", " ", name)
+    return spaced.lower()
+
+
+def rel_source(path: Path) -> str:
+    """REPO_ROOT 기준 상대 경로 (forward slash)."""
+    return str(path.relative_to(REPO_ROOT)).replace("\\", "/")
+
+
+def split_top_level(s: str, sep: str = ",") -> list[str]:
+    """중첩 괄호/제네릭을 고려해 최상위 구분자 기준으로 분할."""
+    parts: list[str] = []
+    depth = 0
+    buf: list[str] = []
+    for ch in s:
+        if ch in "<([{":
+            depth += 1
+            buf.append(ch)
+        elif ch in ">)]}":
+            depth -= 1
+            buf.append(ch)
+        elif ch == sep and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    if buf:
+        parts.append("".join(buf))
+    return parts
+
+
+# ---------------------------------------------------------------------------
+# Controller 스캔
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ApiEntry:
+    module: str
+    controller: str
+    method: str
+    httpMethod: str
+    path: str
+    summary: str
+    source: str
+    order: int = 0  # 원본 파일 내 선언 순서 (정렬용)
+
+
+def _extract_annotation_value(anno_body: str) -> str | None:
+    """`@GetMapping("/x")` 또는 `@GetMapping(value = "/x")` 등에서 path 추출."""
+    m = re.search(r'"([^"]*)"', anno_body)
+    return m.group(1) if m else None
+
+
+def _find_class_base_path(content: str) -> str:
+    m = re.search(
+        r'@RequestMapping\s*\(([^)]*)\)\s*(?:@\w+(?:\([^)]*\))?\s*)*\s*public\s+(?:class|interface)',
+        content,
+        re.DOTALL,
+    )
+    if not m:
+        return ""
+    path = _extract_annotation_value(m.group(1))
+    return path or ""
+
+
+def _extract_summary(annotations: str) -> str | None:
+    m = re.search(
+        r'@Operation\s*\(([^)]*)\)',
+        annotations,
+        re.DOTALL,
+    )
+    if not m:
+        return None
+    body = m.group(1)
+    s = re.search(r'summary\s*=\s*"([^"]*)"', body)
+    if s:
+        return s.group(1)
+    return None
+
+
+def scan_controllers(module: str) -> list[ApiEntry]:
+    base = REPO_ROOT / module / "src" / "main" / "java"
+    if not base.exists():
+        return []
+
+    results: list[ApiEntry] = []
+    files = sorted(
+        base.rglob("*Controller.java"),
+        key=lambda p: (str(p.parent).lower(), p.name.lower()),
+    )
+    for f in files:
+        # 테스트 / 내부 경로 필터 — presentation 또는 controller 디렉터리 포함
+        parts = {p.lower() for p in f.parts}
+        if "test" in parts:
+            continue
+        raw = f.read_text(encoding="utf-8")
+        content = strip_comments(raw)
+
+        class_match = re.search(r'public\s+(?:class|interface)\s+(\w+)', content)
+        if not class_match:
+            continue
+        controller_name = class_match.group(1)
+
+        base_path = _find_class_base_path(content)
+
+        # 메서드 단위 추출:
+        #   (연속 annotation 블록) + (HTTP mapping annotation) + (선택 annotation)
+        #   + `public ReturnType methodName(`
+        # 2단계 파싱:
+        #   1) @(Get|Post|...)Mapping 위치 전부 찾기
+        #   2) 각 위치에 대해 앞(annotation 블록)과 뒤(메서드 선언) 파싱
+        mapping_re = re.compile(
+            r'@(Get|Post|Patch|Delete|Put)Mapping\s*(?:\(([^)]*)\))?',
+        )
+        method_head_re = re.compile(
+            r'\s*((?:@\w+(?:\s*\([^)]*\))?\s*)*)'
+            r'public\s+'
+            r'(?:(?:final|static|abstract|synchronized|default)\s+)*'
+            r'[\w<>,\s?\[\]]+?\s+(\w+)\s*\(',
+            re.DOTALL,
+        )
+        for hm in mapping_re.finditer(content):
+            http_tag, mapping_body = hm.group(1), hm.group(2)
+            http = HTTP_ANNOTATIONS[f"{http_tag}Mapping"]
+
+            sub_path = _extract_annotation_value(mapping_body or "") or ""
+            full_path = (base_path + sub_path) if sub_path else base_path
+            if not full_path:
+                full_path = "/"
+
+            # 직전 annotation 블록 (같은 메서드 소속):
+            # 현재 HTTP 매핑 앞쪽에서 가까운 `)` 또는 `;` 또는 `{`까지 거슬러 올라가며 annotation 수집.
+            # 간단화: 현재 위치에서 이전 HTTP 매핑 끝 또는 이전 메서드 `}`/`;` 이후 텍스트를 pre_region 으로.
+            start = 0
+            for prev in mapping_re.finditer(content, 0, hm.start()):
+                start = prev.end()
+            # 이전 메서드 `}` 또는 `;`가 더 뒤에 있으면 그 이후로 경계 갱신
+            brace = max(content.rfind("}", 0, hm.start()), content.rfind(";", 0, hm.start()))
+            if brace > start:
+                start = brace + 1
+
+            pre_region = content[start:hm.start()]
+
+            # 직후: 첫 번째 `public ReturnType methodName(`
+            tail = content[hm.end():]
+            mh = method_head_re.match(tail)
+            if not mh:
+                continue
+            mid_anno, method_name = mh.group(1), mh.group(2)
+
+            summary = _extract_summary(pre_region + mid_anno)
+            if not summary:
+                summary = camel_to_words(method_name)
+
+            results.append(
+                ApiEntry(
+                    module=module,
+                    controller=controller_name,
+                    method=method_name,
+                    httpMethod=http,
+                    path=full_path,
+                    summary=summary,
+                    source=rel_source(f),
+                    order=len(results),
+                )
+            )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# DTO 스캔
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DtoField:
+    name: str
+    type: str
+
+
+@dataclass
+class DtoEntry:
+    module: str
+    name: str
+    kind: str  # "record" | "class"
+    group: str  # "request" | "response"
+    source: str
+    fields: list[DtoField] = field(default_factory=list)
+
+
+def _dto_group(source: str) -> str:
+    parts = source.split("/")
+    for seg in ("req", "request"):
+        if seg in parts:
+            return "request"
+    for seg in ("res", "response"):
+        if seg in parts:
+            return "response"
+    # 내부 DTO (internal 등) 도 response 쪽에 가까운 경향이 있으나 이름으로 최종 판정
+    return "response" if "Response" in source else "request"
+
+
+def _parse_record_fields(inner: str) -> list[DtoField]:
+    # annotation 제거 (다중 매개변수에 걸친 @Xxx(...) 포함)
+    cleaned = re.sub(r'@\w+(?:\s*\([^()]*(?:\([^()]*\)[^()]*)*\))?', '', inner, flags=re.DOTALL)
+    fields: list[DtoField] = []
+    for raw in split_top_level(cleaned):
+        tok = raw.strip()
+        if not tok:
+            continue
+        m = re.match(r'^([\w.\s<>,?\[\]]+?)\s+(\w+)\s*$', tok, re.DOTALL)
+        if not m:
+            continue
+        type_str = " ".join(m.group(1).split())
+        fields.append(DtoField(name=m.group(2), type=type_str))
+    return fields
+
+
+def _parse_class_fields(body: str) -> list[DtoField]:
+    # `private Type name;` 또는 `public Type name;` 형태
+    fields: list[DtoField] = []
+    body = re.sub(r'@\w+(?:\s*\([^()]*(?:\([^()]*\)[^()]*)*\))?', '', body, flags=re.DOTALL)
+    for m in re.finditer(
+        r'(?:private|protected|public)\s+(?:final\s+)?([\w.<>,?\[\]\s]+?)\s+(\w+)\s*(?:=\s*[^;]+)?;',
+        body,
+    ):
+        type_str = " ".join(m.group(1).split())
+        # 메서드는 다음 토큰이 `(`이지만 `;`로 종료되는 필드만 매치하므로 메서드 제외됨
+        fields.append(DtoField(name=m.group(2), type=type_str))
+    return fields
+
+
+def scan_dtos(module: str) -> list[DtoEntry]:
+    base = REPO_ROOT / module / "src" / "main" / "java"
+    if not base.exists():
+        return []
+
+    results: list[DtoEntry] = []
+    files = sorted(
+        base.rglob("*.java"),
+        key=lambda p: p.name.lower(),
+    )
+    for f in files:
+        parts = [p for p in f.parts]
+        if "presentation" not in parts:
+            continue
+        # presentation/dto/... 경로만
+        try:
+            idx = parts.index("presentation")
+        except ValueError:
+            continue
+        if idx + 1 >= len(parts) or parts[idx + 1] != "dto":
+            continue
+        if "test" in {p.lower() for p in parts}:
+            continue
+
+        raw = f.read_text(encoding="utf-8")
+        content = mask_strings(strip_comments(raw))
+
+        # record 우선
+        rec = re.search(
+            r'public\s+record\s+(\w+)\s*\((.*?)\)\s*(?:implements[^{]+)?\{',
+            content,
+            re.DOTALL,
+        )
+        if rec:
+            src = rel_source(f)
+            results.append(
+                DtoEntry(
+                    module=module,
+                    name=rec.group(1),
+                    kind="record",
+                    group=_dto_group(src),
+                    source=src,
+                    fields=_parse_record_fields(rec.group(2)),
+                )
+            )
+            continue
+
+        cls = re.search(
+            r'public\s+class\s+(\w+)[^{]*\{(.*)\}',
+            content,
+            re.DOTALL,
+        )
+        if cls:
+            src = rel_source(f)
+            results.append(
+                DtoEntry(
+                    module=module,
+                    name=cls.group(1),
+                    kind="class",
+                    group=_dto_group(src),
+                    source=src,
+                    fields=_parse_class_fields(cls.group(2)),
+                )
+            )
+    # scan 단계는 파일 발견 순서 유지. 최종 정렬은 렌더러에서 수행
+    # (MD는 이름 오름차순, JSON은 그룹별 + 이름).
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Service 스캔
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ServiceEntry:
+    module: str
+    service: str
+    method: str
+    description: str
+    source: str
+
+
+def scan_services(module: str) -> list[ServiceEntry]:
+    base = REPO_ROOT / module / "src" / "main" / "java"
+    if not base.exists():
+        return []
+
+    results: list[ServiceEntry] = []
+    files = sorted(
+        base.rglob("*.java"),
+        key=lambda p: p.name.lower(),
+    )
+    for f in files:
+        parts = [p for p in f.parts]
+        if "application" not in parts or "service" not in parts:
+            continue
+        if "test" in {p.lower() for p in parts}:
+            continue
+
+        raw = f.read_text(encoding="utf-8")
+        content = mask_strings(strip_comments(raw))
+
+        is_interface = bool(re.search(r'public\s+interface\s+\w+', content))
+        class_match = re.search(r'public\s+(?:class|interface)\s+(\w+)', content)
+        if not class_match:
+            continue
+        service_name = class_match.group(1)
+
+        # class: `public ReturnType methodName(...)`
+        # interface: 수식어 없이 `ReturnType methodName(...);`
+        if is_interface:
+            method_iter = re.finditer(
+                r'(?:@\w+(?:\s*\([^)]*\))?\s*)*'
+                r'(?:(?:public|default|static|abstract)\s+)*'
+                r'([\w<>,\s?\[\]]+?)\s+(\w+)\s*\([^)]*\)\s*(?:throws\s+[\w.,\s]+)?\s*;',
+                content,
+            )
+        else:
+            method_iter = re.finditer(
+                r'(?<!\.)\bpublic\s+'
+                r'(?:(?:final|static|synchronized)\s+)*'
+                r'(?!class\b|record\b|interface\b|enum\b)'
+                r'([\w<>,\s?\[\]]+?)\s+(\w+)\s*\(',
+                content,
+            )
+
+        seen: set[tuple[str, str]] = set()
+        for m in method_iter:
+            return_type = m.group(1).strip()
+            method_name = m.group(2)
+            if method_name == service_name:
+                continue  # 생성자 제외
+            if return_type in {"class", "record", "interface", "enum"}:
+                continue
+            if (service_name, method_name) in seen:
+                continue
+            seen.add((service_name, method_name))
+            results.append(
+                ServiceEntry(
+                    module=module,
+                    service=service_name,
+                    method=method_name,
+                    description=f"{camel_to_words(method_name)} 기능을 제공",
+                    source=rel_source(f),
+                )
+            )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# 렌더러
+# ---------------------------------------------------------------------------
+
+def render_api_md(entries: list[ApiEntry]) -> str:
+    lines: list[str] = [
+        "# API 문서 요약",
+        "",
+        "자동 생성 기준: `*Controller.java`의 RequestMapping/메서드 매핑을 기반으로 정리했습니다.",
+        "",
+    ]
+    by_module: dict[str, list[ApiEntry]] = {}
+    for e in entries:
+        by_module.setdefault(e.module, []).append(e)
+    for mod in sorted(by_module.keys()):
+        lines.append(f"## {mod}")
+        lines.append("")
+        lines.append("| HTTP | Path | Controller#Method | 설명 |")
+        lines.append("|---|---|---|---|")
+        # MD 는 path 알파벳 순 (원본 동작 재현)
+        bucket = sorted(
+            by_module[mod],
+            key=lambda x: (x.path, x.httpMethod, x.controller, x.method),
+        )
+        for e in bucket:
+            lines.append(
+                f"| {e.httpMethod} | `{e.path}` | `{e.controller}#{e.method}` | {e.summary} |"
+            )
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def render_api_json(entries: list[ApiEntry]) -> str:
+    # JSON 은 모듈 → 컨트롤러 파일 알파벳 → 파일 내 선언 순서
+    data = [
+        {
+            "module": e.module,
+            "controller": e.controller,
+            "method": e.method,
+            "httpMethod": e.httpMethod,
+            "path": e.path,
+            "summary": e.summary,
+            "source": e.source,
+        }
+        for e in sorted(entries, key=lambda x: (x.module, x.source, x.order))
+    ]
+    return json.dumps(data, ensure_ascii=False, indent=2) + "\n"
+
+
+def render_dto_md(entries: list[DtoEntry]) -> str:
+    lines: list[str] = [
+        "# DTO 문서 요약",
+        "",
+        "자동 생성 기준: `presentation/dto` 하위 Java `record/class`를 기준으로 정리했습니다.",
+        "",
+    ]
+    by_module: dict[str, list[DtoEntry]] = {}
+    for e in entries:
+        by_module.setdefault(e.module, []).append(e)
+    for mod in sorted(by_module.keys()):
+        lines.append(f"## {mod}")
+        lines.append("")
+        # MD 는 단순 이름 알파벳 순 (원본 Codex 스크립트 동작 재현)
+        for dto in sorted(by_module[mod], key=lambda d: d.name.lower()):
+            lines.append(f"### {dto.name} ({dto.kind})")
+            lines.append(f"- source: `{dto.source}`")
+            lines.append("| 필드명 | 타입 |")
+            lines.append("|---|---|")
+            for fd in dto.fields:
+                lines.append(f"| `{fd.name}` | `{fd.type}` |")
+            lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def render_dto_json(entries: list[DtoEntry]) -> str:
+    # 원본 정렬: 모듈 → 파일의 parent 디렉터리 경로 → 이름
+    # (admin 은 `dto/req` / `dto/res` 분리, event 는 `dto/` / `dto/internal/` 분리)
+    def _key(e: DtoEntry) -> tuple:
+        parent = e.source.rsplit("/", 1)[0] if "/" in e.source else ""
+        return (e.module, parent, e.name.lower())
+
+    data = [
+        {
+            "module": e.module,
+            "name": e.name,
+            "kind": e.kind,
+            "fieldCount": len(e.fields),
+            "fields": [{"name": f.name, "type": f.type} for f in e.fields],
+            "source": e.source,
+        }
+        for e in sorted(entries, key=_key)
+    ]
+    return json.dumps(data, ensure_ascii=False, indent=2) + "\n"
+
+
+def render_service_md(entries: list[ServiceEntry]) -> str:
+    lines: list[str] = [
+        "# 구현된 서비스 현황 (메서드별 1줄 요약)",
+        "",
+    ]
+    by_pair: dict[tuple[str, str], list[ServiceEntry]] = {}
+    for e in entries:
+        by_pair.setdefault((e.module, e.service), []).append(e)
+    for (mod, svc) in sorted(by_pair.keys()):
+        lines.append(f"## {mod} / {svc}")
+        lines.append("")
+        for e in by_pair[(mod, svc)]:
+            lines.append(f"- `{e.method}`: {e.description}.")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def render_service_json(entries: list[ServiceEntry]) -> str:
+    data = [
+        {
+            "module": e.module,
+            "service": e.service,
+            "method": e.method,
+            "description": e.description,
+            "source": e.source,
+        }
+        for e in sorted(entries, key=lambda x: (x.module, x.service, x.method))
+    ]
+    return json.dumps(data, ensure_ascii=False, indent=2) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# 메인
+# ---------------------------------------------------------------------------
+
+def gather() -> tuple[list[ApiEntry], list[DtoEntry], list[ServiceEntry]]:
+    apis: list[ApiEntry] = []
+    dtos: list[DtoEntry] = []
+    services: list[ServiceEntry] = []
+    for mod in MODULES:
+        apis.extend(scan_controllers(mod))
+        dtos.extend(scan_dtos(mod))
+        services.extend(scan_services(mod))
+    return apis, dtos, services
+
+
+OUTPUTS = [
+    ("api-summary.md", render_api_md, "apis"),
+    ("api-summary.json", render_api_json, "apis"),
+    ("dto-summary.md", render_dto_md, "dtos"),
+    ("dto-summary.json", render_dto_json, "dtos"),
+    ("service-status.md", render_service_md, "services"),
+    ("service-status.json", render_service_json, "services"),
+]
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true", help="diff만 출력 (쓰기 안 함)")
+    args = ap.parse_args(argv)
+
+    apis, dtos, services = gather()
+    sources = {"apis": apis, "dtos": dtos, "services": services}
+
+    changed = 0
+    for fname, renderer, key in OUTPUTS:
+        new_content = renderer(sources[key])
+        target = DOCS_DIR / fname
+        old_content = target.read_text(encoding="utf-8") if target.exists() else ""
+        if new_content == old_content:
+            print(f"  = {fname}")
+            continue
+        changed += 1
+        if args.check:
+            print(f"  ! {fname} (would change, +/-{abs(len(new_content) - len(old_content))} chars)")
+        else:
+            target.write_text(new_content, encoding="utf-8")
+            print(f"  * {fname} (written)")
+
+    print(f"\n모듈 {len(MODULES)}개 스캔: controllers={len(apis)}, dtos={len(dtos)}, services={len(services)}")
+    if args.check:
+        return 1 if changed else 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

- PR #323 에서 추가된 `docs/api-summary.{md,json}`, `docs/dto-summary.{md,json}`, `docs/service-status.{md,json}` 6개 파일을 재생성할 수 있는 Python 스크립트를 `scripts/gen-docs.py` 로 추가합니다
- PR #323 은 Codex task 로 1회 생성된 결과물만 커밋되어 스크립트 본체는 레포에 없고, 결과물 기준 Commerce 모듈이 누락된 상태였습니다. 본 PR 에서 재생성 가능한 형태로 복원 + Commerce 누락 해소 + 정확도 개선을 적용합니다

## Changes

- `scripts/gen-docs.py` 신규 (Python 3, 표준 라이브러리만 사용)
- `scripts/README.md` — 사용법, 스캔 규칙, 한계, 원본과의 차이 명시
- `docs/api-summary.md` / `docs/api-summary.json`
- `docs/dto-summary.md` / `docs/dto-summary.json`
- `docs/service-status.md` / `docs/service-status.json`

## 원본과의 차이 (byte-diff 발생 원인)

원본 Codex 스크립트가 커밋돼 있지 않아 출력 포맷만 맞추고 파싱은 독립적으로 재구현했습니다. byte 단위 재현은 목표로 하지 않았고, 아래는 **현재 코드 기준 정확도 향상** 결과입니다:

1. **클래스 레벨 \`@RequestMapping\` prefix 결합**
   - event: \`/\` → \`/api/events\` 외 다수
   - member: \`/login\` → \`/api/members/login\` 외 다수
2. **메서드 ↔ \`@Operation(summary)\` 매칭 교정**
   - admin \`AdminUsersController\` 의 \`penalizeUser\` / \`updateUserRole\` summary 가 원본에서 뒤섞여 있던 것으로 추정되어 현재 코드 기준으로 교정
3. **interface 추상 메서드 포함**
   - admin \`AdminSellerService\`, \`AdminUserService\` 등 인터페이스 메서드가 \`service-status\` 에 빠져 있던 것을 복구
4. **미종결 문자열 리터럴로 인한 필드 파싱 실패 복구**
   - \`AdminEventSearchRequest\` 필드가 원본에서 1개만 잡혔던 문제 (\`@Schema(example=\"(DRAFT, ON_SALE, ...\"\` 의 미종결 \`(\` 가 파서를 깬 케이스)

## Testing

- 생성된 JSON 파일들의 문법 검증을 위해 \`python -m json.tool docs/api-summary.json\` 및 \`python -m json.tool docs/dto-summary.json\` 과 \`python -m json.tool docs/service-status.json\` 을 수행했고 모두 정상(성공)으로 확인했습니다
- \`scripts/gen-docs.py\` 가 저장소의 컨트롤러/DTO/서비스를 정상으로 스캔하여 \`docs/\` 하위에 Markdown/JSON 파일을 생성하는 것을 확인했습니다 (스캔 결과: controllers=82, dtos=122, services=71 — 7개 모듈 대상, frontend 제외)

## 참고

- \`scripts/gen-docs.py\` 는 수동 실행만 지원하며, CI 자동화는 본 PR 범위에 포함하지 않았습니다
- 대상 모듈: \`admin\`, \`apigateway\`, \`commerce\`, \`event\`, \`member\`, \`payment\`, \`settlement\` (frontend 는 TS/React 라 본 스크립트 범위 외)