### PR TITLE
[Commerce] fix: 환불 시 계산 정합성 수정

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -324,10 +324,14 @@ public class OrderService implements OrderUsecase {
                             continue;
                         }
 
-                        if (OrderStatus.PAID.equals(order.getStatus())) {
+                        OrderStatus orderStatus = order.getStatus();
+                        if (OrderStatus.PAID.equals(orderStatus)) {
                             totalSales += item.getPrice() * item.getQuantity();
                             soldQty += item.getQuantity();
-                        } else if (OrderStatus.CANCELLED.equals(order.getStatus())) {
+                        } else if (OrderStatus.CANCELLED.equals(orderStatus)
+                            || OrderStatus.REFUND_PENDING.equals(orderStatus)
+                            || OrderStatus.REFUNDED.equals(orderStatus)) {
+                            // REFUND_PENDING/REFUNDED: Saga 로 확정된 환불 — CANCELLED 와 동일하게 환불 집계에 포함.
                             totalRefund += item.getPrice() * item.getQuantity();
                             refundQty += item.getQuantity();
                         }

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/RefundFanoutService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/RefundFanoutService.java
@@ -7,6 +7,8 @@ import com.devticket.commerce.common.messaging.event.refund.EventForceCancelledE
 import com.devticket.commerce.common.messaging.event.refund.RefundRequestedEvent;
 import com.devticket.commerce.common.outbox.OutboxService;
 import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.model.OrderItem;
+import com.devticket.commerce.order.domain.repository.OrderItemRepository;
 import com.devticket.commerce.order.domain.repository.OrderRepository;
 import com.devticket.commerce.ticket.domain.enums.TicketStatus;
 import com.devticket.commerce.ticket.domain.model.Ticket;
@@ -15,7 +17,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RefundFanoutService {
 
     private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
     private final TicketRepository ticketRepository;
     private final OutboxService outboxService;
     private final MessageDeduplicationService deduplicationService;
@@ -63,16 +68,34 @@ public class RefundFanoutService {
             // 대상 티켓 — 이 이벤트에 해당하면서 ISSUED 인 것만
             List<Ticket> orderTickets = ticketRepository
                 .findAllByOrderIdAndStatus(order.getId(), TicketStatus.ISSUED);
-            List<UUID> ticketIds = orderTickets.stream()
+            List<Ticket> targetTickets = orderTickets.stream()
                 .filter(t -> t.getEventId().equals(event.eventId()))
-                .map(Ticket::getTicketId)
                 .toList();
 
-            if (ticketIds.isEmpty()) {
+            if (targetTickets.isEmpty()) {
                 log.warn("[event.force-cancelled] ISSUED 티켓 없음 — skip. orderId={}, eventId={}",
                     order.getOrderId(), event.eventId());
                 continue;
             }
+
+            // 환불 금액 — 대상 티켓 합계로 한정 (다중 이벤트 주문의 과환불 방지).
+            // 티켓 : OrderItem = N:1 (결제 완료 시 OrderItem.quantity 만큼 티켓 생성),
+            // 각 티켓의 단가는 해당 OrderItem.price 와 동일하므로 단가 × 티켓수 로 산정.
+            Map<UUID, Integer> priceByOrderItemId = orderItemRepository.findAllByOrderId(order.getId())
+                .stream()
+                .collect(Collectors.toMap(OrderItem::getOrderItemId, OrderItem::getPrice));
+            int refundAmount = targetTickets.stream()
+                .mapToInt(t -> priceByOrderItemId.getOrDefault(t.getOrderItemId(), 0))
+                .sum();
+
+            if (refundAmount <= 0) {
+                log.warn("[event.force-cancelled] 환불 금액 산정 실패 — skip. orderId={}, eventId={}",
+                    order.getOrderId(), event.eventId());
+                continue;
+            }
+
+            List<UUID> ticketIds = targetTickets.stream().map(Ticket::getTicketId).toList();
+            boolean wholeOrder = ticketIds.size() == orderTickets.size();
 
             RefundRequestedEvent request = new RefundRequestedEvent(
                 UUID.randomUUID(),           // refundId — Commerce 생성
@@ -82,9 +105,9 @@ public class RefundFanoutService {
                 order.getPaymentId(),         // payment.completed 수신 시 기록된 값
                 order.getPaymentMethod(),
                 ticketIds,
-                order.getTotalAmount(),       // 전체 환불 금액
+                refundAmount,                 // 대상 티켓 합계
                 100,                          // refundRate — 강제 취소는 100%
-                true,                         // wholeOrder — 강제 취소는 항상 전체 환불
+                wholeOrder,                   // 대상 티켓이 주문 전체 티켓과 일치할 때만 true
                 reason,
                 now
             );

--- a/commerce/src/main/java/com/devticket/commerce/order/domain/exception/OrderErrorCode.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/exception/OrderErrorCode.java
@@ -26,7 +26,8 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_ORDER_STATUS_TRANSITION(400, "ORDER_015", "현재 주문 상태에서 허용되지 않는 전이입니다."),
     REFUND_NOT_REFUNDABLE(400, "ORDER_016", "환불 요청이 불가능한 주문 상태입니다."),
     REFUND_ROLLBACK_INVALID(400, "ORDER_017", "환불 보상 롤백이 불가능한 주문 상태입니다."),
-    REFUND_COMPLETE_INVALID(400, "ORDER_018", "환불 확정이 불가능한 주문 상태입니다.");
+    REFUND_COMPLETE_INVALID(400, "ORDER_018", "환불 확정이 불가능한 주문 상태입니다."),
+    INVALID_ORDER_STATUS_FILTER(400, "ORDER_019", "유효하지 않은 주문 상태 필터 값입니다.");
 
     private final int status;
     private final String code;

--- a/commerce/src/test/java/com/devticket/commerce/order/application/service/RefundFanoutServiceTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/order/application/service/RefundFanoutServiceTest.java
@@ -11,8 +11,11 @@ import com.devticket.commerce.common.enums.PaymentMethod;
 import com.devticket.commerce.common.messaging.KafkaTopics;
 import com.devticket.commerce.common.messaging.MessageDeduplicationService;
 import com.devticket.commerce.common.messaging.event.refund.EventForceCancelledEvent;
+import com.devticket.commerce.common.messaging.event.refund.RefundRequestedEvent;
 import com.devticket.commerce.common.outbox.OutboxService;
 import com.devticket.commerce.order.domain.model.Order;
+import com.devticket.commerce.order.domain.model.OrderItem;
+import com.devticket.commerce.order.domain.repository.OrderItemRepository;
 import com.devticket.commerce.order.domain.repository.OrderRepository;
 import com.devticket.commerce.ticket.domain.enums.TicketStatus;
 import com.devticket.commerce.ticket.domain.model.Ticket;
@@ -28,6 +31,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -36,6 +40,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class RefundFanoutServiceTest {
 
     @Mock private OrderRepository orderRepository;
+    @Mock private OrderItemRepository orderItemRepository;
     @Mock private TicketRepository ticketRepository;
     @Mock private OutboxService outboxService;
     @Mock private MessageDeduplicationService deduplicationService;
@@ -50,7 +55,8 @@ class RefundFanoutServiceTest {
     @BeforeEach
     void setUp() {
         service = new RefundFanoutService(
-            orderRepository, ticketRepository, outboxService, deduplicationService, objectMapper);
+            orderRepository, orderItemRepository, ticketRepository,
+            outboxService, deduplicationService, objectMapper);
     }
 
     private String toJson(Object event) {
@@ -74,21 +80,32 @@ class RefundFanoutServiceTest {
         return Ticket.create(UUID.randomUUID(), UUID.randomUUID(), eventId);
     }
 
+    private Ticket ticketOf(UUID orderItemId, UUID eventId) {
+        return Ticket.create(orderItemId, UUID.randomUUID(), eventId);
+    }
+
+    private OrderItem orderItemOf(Long orderId, UUID eventId, int price, int quantity) {
+        return OrderItem.create(orderId, UUID.randomUUID(), eventId, price, quantity, quantity + 10);
+    }
+
     @Test
     void 이벤트에_해당하는_ISSUED_티켓_있는_오더에_refund_requested_발행() {
         UUID messageId = UUID.randomUUID();
         UUID eventId = UUID.randomUUID();
         Order o1 = paidOrderWithPayment();
-        Ticket t1 = ticketOf(eventId);
-        Ticket t2 = ticketOf(eventId);
+        OrderItem item = orderItemOf(o1.getId(), eventId, 10_000, 2);
+        Ticket t1 = ticketOf(item.getOrderItemId(), eventId);
+        Ticket t2 = ticketOf(item.getOrderItemId(), eventId);
 
-        EventForceCancelledEvent payload = new EventForceCancelledEvent(eventId, "admin", Instant.now());
+        EventForceCancelledEvent payload = new EventForceCancelledEvent(eventId, UUID.randomUUID(), "admin", Instant.now());
 
         given(deduplicationService.isDuplicate(messageId)).willReturn(false);
         given(orderRepository.findAllByEventIdAndStatus(eventId, OrderStatus.PAID))
             .willReturn(List.of(o1));
         given(ticketRepository.findAllByOrderIdAndStatus(o1.getId(), TicketStatus.ISSUED))
             .willReturn(List.of(t1, t2));
+        given(orderItemRepository.findAllByOrderId(o1.getId()))
+            .willReturn(List.of(item));
 
         service.processEventForceCancelled(messageId, KafkaTopics.EVENT_FORCE_CANCELLED, toJson(payload));
 
@@ -99,6 +116,46 @@ class RefundFanoutServiceTest {
     }
 
     @Test
+    void 다중_이벤트_주문_강제취소시_대상_티켓_합계로만_환불_요청() {
+        UUID messageId = UUID.randomUUID();
+        UUID cancelledEventId = UUID.randomUUID();
+        UUID otherEventId = UUID.randomUUID();
+        Order order = paidOrderWithPayment();
+
+        OrderItem cancelledItem = orderItemOf(order.getId(), cancelledEventId, 10_000, 2);
+        OrderItem otherItem = orderItemOf(order.getId(), otherEventId, 5_000, 3);
+
+        Ticket c1 = ticketOf(cancelledItem.getOrderItemId(), cancelledEventId);
+        Ticket c2 = ticketOf(cancelledItem.getOrderItemId(), cancelledEventId);
+        Ticket other1 = ticketOf(otherItem.getOrderItemId(), otherEventId);
+
+        EventForceCancelledEvent payload = new EventForceCancelledEvent(cancelledEventId, UUID.randomUUID(), "admin", Instant.now());
+
+        given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+        given(orderRepository.findAllByEventIdAndStatus(cancelledEventId, OrderStatus.PAID))
+            .willReturn(List.of(order));
+        given(ticketRepository.findAllByOrderIdAndStatus(order.getId(), TicketStatus.ISSUED))
+            .willReturn(List.of(c1, c2, other1));
+        given(orderItemRepository.findAllByOrderId(order.getId()))
+            .willReturn(List.of(cancelledItem, otherItem));
+
+        service.processEventForceCancelled(messageId, KafkaTopics.EVENT_FORCE_CANCELLED, toJson(payload));
+
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        then(outboxService).should().save(
+            anyString(), anyString(), eq("REFUND_REQUESTED"),
+            eq(KafkaTopics.REFUND_REQUESTED), eventCaptor.capture());
+
+        RefundRequestedEvent published = (RefundRequestedEvent) eventCaptor.getValue();
+        // 대상 티켓 2장 × 단가 10,000 = 20,000 — 주문 전체(30,000) 가 아닌 해당 이벤트 티켓 합계
+        org.assertj.core.api.Assertions.assertThat(published.refundAmount()).isEqualTo(20_000);
+        org.assertj.core.api.Assertions.assertThat(published.ticketIds())
+            .containsExactlyInAnyOrder(c1.getTicketId(), c2.getTicketId());
+        // 다른 이벤트 티켓이 남아있으므로 wholeOrder = false
+        org.assertj.core.api.Assertions.assertThat(published.wholeOrder()).isFalse();
+    }
+
+    @Test
     void 해당_이벤트_티켓이_없는_오더는_건너뜀() {
         UUID messageId = UUID.randomUUID();
         UUID eventId = UUID.randomUUID();
@@ -106,7 +163,7 @@ class RefundFanoutServiceTest {
         Order o1 = paidOrderWithPayment();
         Ticket t1 = ticketOf(otherEventId); // 다른 이벤트 티켓만
 
-        EventForceCancelledEvent payload = new EventForceCancelledEvent(eventId, "admin", Instant.now());
+        EventForceCancelledEvent payload = new EventForceCancelledEvent(eventId, UUID.randomUUID(), "admin", Instant.now());
 
         given(deduplicationService.isDuplicate(messageId)).willReturn(false);
         given(orderRepository.findAllByEventIdAndStatus(eventId, OrderStatus.PAID))
@@ -124,7 +181,7 @@ class RefundFanoutServiceTest {
     void PAID_주문이_없으면_fan_out_생략() {
         UUID messageId = UUID.randomUUID();
         UUID eventId = UUID.randomUUID();
-        EventForceCancelledEvent payload = new EventForceCancelledEvent(eventId, "admin", Instant.now());
+        EventForceCancelledEvent payload = new EventForceCancelledEvent(eventId, UUID.randomUUID(), "admin", Instant.now());
 
         given(deduplicationService.isDuplicate(messageId)).willReturn(false);
         given(orderRepository.findAllByEventIdAndStatus(eventId, OrderStatus.PAID)).willReturn(List.of());

--- a/commerce/src/test/java/com/devticket/commerce/order/presentation/consumer/PaymentCompletedConsumerTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/order/presentation/consumer/PaymentCompletedConsumerTest.java
@@ -10,7 +10,8 @@ import static org.mockito.Mockito.never;
 
 import com.devticket.commerce.common.messaging.KafkaTopics;
 import com.devticket.commerce.order.application.usecase.OrderUsecase;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -36,7 +37,8 @@ class PaymentCompletedConsumerTest {
 
     @BeforeEach
     void setUp() {
-        consumer = new PaymentCompletedConsumer(orderUsecase, new ObjectMapper());
+        ObjectMapper objectMapper = JsonMapper.builder().build();
+        consumer = new PaymentCompletedConsumer(orderUsecase, objectMapper);
     }
 
     // ── 헬퍼 ──────────────────────────────────────────────────────────

--- a/commerce/src/test/java/com/devticket/commerce/ticket/application/service/RefundTicketServiceTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/ticket/application/service/RefundTicketServiceTest.java
@@ -13,6 +13,7 @@ import com.devticket.commerce.common.messaging.MessageDeduplicationService;
 import com.devticket.commerce.common.messaging.event.refund.RefundTicketCancelEvent;
 import com.devticket.commerce.common.messaging.event.refund.RefundTicketCompensateEvent;
 import com.devticket.commerce.common.outbox.OutboxService;
+import com.devticket.commerce.order.domain.repository.OrderRepository;
 import com.devticket.commerce.ticket.domain.enums.TicketStatus;
 import com.devticket.commerce.ticket.domain.model.Ticket;
 import com.devticket.commerce.ticket.domain.repository.TicketRepository;
@@ -37,6 +38,7 @@ class RefundTicketServiceTest {
     @Mock private TicketRepository ticketRepository;
     @Mock private OutboxService outboxService;
     @Mock private MessageDeduplicationService deduplicationService;
+    @Mock private OrderRepository orderRepository;
 
     private final ObjectMapper objectMapper = JsonMapper.builder()
         .addModule(new JavaTimeModule())
@@ -48,7 +50,7 @@ class RefundTicketServiceTest {
     @BeforeEach
     void setUp() {
         refundTicketService = new RefundTicketService(
-            ticketRepository, outboxService, deduplicationService, objectMapper);
+            ticketRepository, outboxService, deduplicationService, orderRepository, objectMapper);
     }
 
     private Ticket ticketWith(UUID eventId, TicketStatus status) {
@@ -80,7 +82,7 @@ class RefundTicketServiceTest {
         Ticket t2 = ticketWith(eventId, TicketStatus.ISSUED);
         List<UUID> ids = List.of(t1.getTicketId(), t2.getTicketId());
         RefundTicketCancelEvent event = new RefundTicketCancelEvent(
-            UUID.randomUUID(), orderId, ids, Instant.now());
+            UUID.randomUUID(), orderId, ids, true, Instant.now());
 
         given(deduplicationService.isDuplicate(messageId)).willReturn(false);
         given(ticketRepository.findAllByTicketIdIn(ids)).willReturn(List.of(t1, t2));
@@ -106,7 +108,7 @@ class RefundTicketServiceTest {
         Ticket t3 = ticketWith(eventB, TicketStatus.ISSUED);
         List<UUID> ids = List.of(t1.getTicketId(), t2.getTicketId(), t3.getTicketId());
         RefundTicketCancelEvent event = new RefundTicketCancelEvent(
-            UUID.randomUUID(), orderId, ids, Instant.now());
+            UUID.randomUUID(), orderId, ids, true, Instant.now());
 
         given(deduplicationService.isDuplicate(messageId)).willReturn(false);
         given(ticketRepository.findAllByTicketIdIn(ids)).willReturn(List.of(t1, t2, t3));
@@ -127,7 +129,7 @@ class RefundTicketServiceTest {
         Ticket t2 = ticketWith(UUID.randomUUID(), TicketStatus.REFUNDED);
         List<UUID> ids = List.of(t1.getTicketId(), t2.getTicketId());
         RefundTicketCancelEvent event = new RefundTicketCancelEvent(
-            UUID.randomUUID(), orderId, ids, Instant.now());
+            UUID.randomUUID(), orderId, ids, true, Instant.now());
 
         given(deduplicationService.isDuplicate(messageId)).willReturn(false);
         given(ticketRepository.findAllByTicketIdIn(ids)).willReturn(List.of(t1, t2));
@@ -147,7 +149,7 @@ class RefundTicketServiceTest {
         UUID orderId = UUID.randomUUID();
         List<UUID> ids = List.of(UUID.randomUUID(), UUID.randomUUID());
         RefundTicketCancelEvent event = new RefundTicketCancelEvent(
-            UUID.randomUUID(), orderId, ids, Instant.now());
+            UUID.randomUUID(), orderId, ids, true, Instant.now());
 
         given(deduplicationService.isDuplicate(messageId)).willReturn(false);
         given(ticketRepository.findAllByTicketIdIn(ids)).willReturn(List.of());


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in the refund process for event force cancellations when orders contain tickets from multiple events. Previously, the entire order amount was refunded regardless of which event was cancelled. Now, only the tickets belonging to the cancelled event are refunded.

## Key Changes

- **Refund amount calculation**: Changed from using `order.getTotalAmount()` to calculating the sum of prices for only the cancelled event's tickets
  - Added `OrderItemRepository` dependency to `RefundFanoutService` to retrieve pricing information
  - Implemented price lookup by `OrderItemId` to accurately calculate refund amounts
  - Added validation to skip orders if refund amount calculation fails

- **Multi-event order handling**: 
  - Introduced `wholeOrder` flag logic that correctly identifies whether all tickets in an order are being refunded
  - Previously hardcoded as `true`, now dynamically set based on whether cancelled event tickets match total order tickets
  - Prevents incorrect "whole order" refund claims for partial cancellations

- **Event model updates**:
  - Updated `EventForceCancelledEvent` constructor to include `eventId` parameter (UUID) for better event tracking
  - Updated all test cases to use the new event constructor signature

- **Settlement data accuracy**: Enhanced `OrderService.getSettlementData()` to include `REFUND_PENDING` and `REFUNDED` statuses in refund aggregation, treating them equivalently to `CANCELLED` status for accurate financial reporting

- **Test coverage**: Added comprehensive test case `다중_이벤트_주문_강제취소시_대상_티켓_합계로만_환불_요청` to verify correct refund calculation for multi-event orders

- **Minor fixes**: Updated Jackson ObjectMapper imports in test to use correct dependency version

## Implementation Details

The refund amount is now calculated as:
```
refundAmount = sum of (OrderItem.price for each cancelled event ticket)
```

This ensures that when an order contains tickets from multiple events and only one event is force-cancelled, only the relevant tickets' value is refunded, preventing over-refunding.

https://claude.ai/code/session_01AGmek7rKGY4GTycT4tindm