### PR TITLE
[Payment] 환불 메시지 이중 발행 완화

### DIFF
--- a/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
@@ -173,10 +173,20 @@ public class RefundSagaOrchestrator {
             refundTicketRepository.saveAll(rts);
         }
 
-        // (2) quantity 계산도 ticketIds 로 변경
-        int quantity = event.quantity() > 0
-            ? event.quantity()
-            : (event.ticketIds() != null ? event.ticketIds().size() : existing.size());
+        // (2) quantity 계산 — 우선순위: event.quantity > event.ticketIds.size > RefundTicket > ledger.remainingTickets
+        // whole-order 환불에서 Commerce 가 빈 ticketIds 를 보내도 재고가 0 으로 복구되지 않도록 보정.
+        int quantity;
+        if (event.quantity() > 0) {
+            quantity = event.quantity();
+        } else if (event.ticketIds() != null && !event.ticketIds().isEmpty()) {
+            quantity = event.ticketIds().size();
+        } else if (!existing.isEmpty()) {
+            quantity = existing.size();
+        } else {
+            quantity = orderRefundRepository.findByOrderId(event.orderId())
+                .map(OrderRefund::getRemainingTickets)
+                .orElse(0);
+        }
 
         state.advance(SagaStep.STOCK_RESTORING);
         sagaStateRepository.save(state);

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/TicketIssueFailedConsumer.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/TicketIssueFailedConsumer.java
@@ -3,24 +3,9 @@ package com.devticket.payment.refund.presentation.consumer;
 import com.devticket.payment.common.messaging.KafkaTopics;
 import com.devticket.payment.common.messaging.MessageDeduplicationService;
 import com.devticket.payment.common.messaging.OutboxPayloadExtractor;
-import com.devticket.payment.common.outbox.OutboxService;
-import com.devticket.payment.payment.domain.model.Payment;
-import com.devticket.payment.payment.domain.repository.PaymentRepository;
-import com.devticket.payment.refund.application.saga.event.RefundRequestedEvent;
 import com.devticket.payment.refund.application.saga.event.TicketIssueFailedEvent;
-import com.devticket.payment.refund.domain.RefundRateConstants;
-import com.devticket.payment.refund.domain.exception.RefundErrorCode;
-import com.devticket.payment.refund.domain.exception.RefundException;
-import com.devticket.payment.refund.domain.model.OrderRefund;
-import com.devticket.payment.refund.domain.model.Refund;
-import com.devticket.payment.refund.domain.model.RefundTicket;
-import com.devticket.payment.refund.domain.repository.OrderRefundRepository;
-import com.devticket.payment.refund.domain.repository.RefundRepository;
-import com.devticket.payment.refund.domain.repository.RefundTicketRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,23 +14,21 @@ import org.apache.kafka.common.header.Header;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * ticket.issue-failed 수신 → Saga 진입점 A.
  * 시스템 귀책이므로 100% 환불로 OrderRefund + Refund 를 생성하고 refund.requested 를 발행한다.
+ *
+ * 실제 비즈니스 로직 + dedup markProcessed 는 {@link TicketIssueFailedHandler} 의
+ * @Transactional 메서드에서 원자적으로 처리한다. (self-invocation 회피)
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class TicketIssueFailedConsumer {
 
+    private final TicketIssueFailedHandler handler;
     private final MessageDeduplicationService deduplicationService;
-    private final PaymentRepository paymentRepository;
-    private final RefundRepository refundRepository;
-    private final OrderRefundRepository orderRefundRepository;
-    private final RefundTicketRepository refundTicketRepository;
-    private final OutboxService outboxService;
     private final ObjectMapper objectMapper;
 
     @KafkaListener(
@@ -62,79 +45,12 @@ public class TicketIssueFailedConsumer {
         try {
             TicketIssueFailedEvent event = OutboxPayloadExtractor.extract(
                 objectMapper, record.value(), TicketIssueFailedEvent.class);
-            handle(event, messageId, record.topic());
+            handler.handleAndMark(event, messageId, record.topic());
             ack.acknowledge();
         } catch (Exception e) {
             log.error("[Consumer] ticket.issue-failed 처리 실패 — messageId={}", messageId, e);
             throw new RuntimeException("ticket.issue-failed 처리 실패", e);
         }
-    }
-
-    @Transactional
-    protected void handle(TicketIssueFailedEvent event, UUID messageId, String topic) {
-        Payment payment = paymentRepository.findByPaymentId(event.paymentId())
-            .orElseThrow(() -> new RefundException(RefundErrorCode.PAYMENT_NOT_FOUND));
-
-        List<UUID> issuedTicketIds = event.issuedTicketIds() != null ? event.issuedTicketIds() : List.of();
-        int ticketCount = issuedTicketIds.isEmpty() ? 1 : issuedTicketIds.size();
-        int refundAmount = event.refundAmount() > 0 ? event.refundAmount() : payment.getAmount();
-
-        OrderRefund ledger = orderRefundRepository.findByOrderId(event.orderId())
-            .orElseGet(() -> orderRefundRepository.save(
-                OrderRefund.create(
-                    event.orderId(),
-                    event.userId(),
-                    payment.getPaymentId(),
-                    payment.getPaymentMethod(),
-                    payment.getAmount(),
-                    ticketCount
-                )
-            ));
-
-        Refund refund = Refund.create(
-            ledger.getOrderRefundId(),
-            event.orderId(),
-            payment.getPaymentId(),
-            event.userId(),
-            refundAmount,
-            RefundRateConstants.FULL
-        );
-        refundRepository.save(refund);
-
-        if (!issuedTicketIds.isEmpty()) {
-            List<RefundTicket> rts = issuedTicketIds.stream()
-                .map(tid -> RefundTicket.of(refund.getRefundId(), tid))
-                .toList();
-            refundTicketRepository.saveAll(rts);
-        }
-
-        RefundRequestedEvent requested = new RefundRequestedEvent(
-            refund.getRefundId(),
-            ledger.getOrderRefundId(),
-            event.orderId(),
-            event.userId(),
-            payment.getPaymentId(),
-            payment.getPaymentMethod(),
-            issuedTicketIds,
-            refundAmount,
-            RefundRateConstants.FULL,
-            issuedTicketIds.isEmpty(),
-            event.reason(),
-            Instant.now()
-        );
-
-        outboxService.save(
-            refund.getRefundId().toString(),
-            KafkaTopics.REFUND_REQUESTED,
-            KafkaTopics.REFUND_REQUESTED,
-            event.orderId().toString(),
-            requested
-        );
-
-        deduplicationService.markProcessed(messageId, topic);
-
-        log.info("[Consumer] ticket.issue-failed 환불 진입 — refundId={}, orderId={}, amount={}",
-            refund.getRefundId(), event.orderId(), refundAmount);
     }
 
     private UUID extractMessageId(ConsumerRecord<String, String> record) {

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/TicketIssueFailedHandler.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/TicketIssueFailedHandler.java
@@ -1,0 +1,110 @@
+package com.devticket.payment.refund.presentation.consumer;
+
+import com.devticket.payment.common.messaging.KafkaTopics;
+import com.devticket.payment.common.messaging.MessageDeduplicationService;
+import com.devticket.payment.common.outbox.OutboxService;
+import com.devticket.payment.payment.domain.model.Payment;
+import com.devticket.payment.payment.domain.repository.PaymentRepository;
+import com.devticket.payment.refund.application.saga.event.RefundRequestedEvent;
+import com.devticket.payment.refund.application.saga.event.TicketIssueFailedEvent;
+import com.devticket.payment.refund.domain.RefundRateConstants;
+import com.devticket.payment.refund.domain.exception.RefundErrorCode;
+import com.devticket.payment.refund.domain.exception.RefundException;
+import com.devticket.payment.refund.domain.model.OrderRefund;
+import com.devticket.payment.refund.domain.model.Refund;
+import com.devticket.payment.refund.domain.model.RefundTicket;
+import com.devticket.payment.refund.domain.repository.OrderRefundRepository;
+import com.devticket.payment.refund.domain.repository.RefundRepository;
+import com.devticket.payment.refund.domain.repository.RefundTicketRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * {@link TicketIssueFailedConsumer} 의 @Transactional 경계를 제공하는 Handler.
+ * 같은 클래스 내 self-invocation 으로 프록시가 우회되는 문제를 피하기 위해 별도 빈으로 분리하여
+ * 비즈니스 로직과 dedup markProcessed 를 하나의 트랜잭션에서 원자적으로 처리한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TicketIssueFailedHandler {
+
+    private final PaymentRepository paymentRepository;
+    private final RefundRepository refundRepository;
+    private final OrderRefundRepository orderRefundRepository;
+    private final RefundTicketRepository refundTicketRepository;
+    private final OutboxService outboxService;
+    private final MessageDeduplicationService deduplicationService;
+
+    @Transactional
+    public void handleAndMark(TicketIssueFailedEvent event, UUID messageId, String topic) {
+        Payment payment = paymentRepository.findByPaymentId(event.paymentId())
+            .orElseThrow(() -> new RefundException(RefundErrorCode.PAYMENT_NOT_FOUND));
+
+        List<UUID> issuedTicketIds = event.issuedTicketIds() != null ? event.issuedTicketIds() : List.of();
+        int ticketCount = issuedTicketIds.isEmpty() ? 1 : issuedTicketIds.size();
+        int refundAmount = event.refundAmount() > 0 ? event.refundAmount() : payment.getAmount();
+
+        OrderRefund ledger = orderRefundRepository.findByOrderId(event.orderId())
+            .orElseGet(() -> orderRefundRepository.save(
+                OrderRefund.create(
+                    event.orderId(),
+                    event.userId(),
+                    payment.getPaymentId(),
+                    payment.getPaymentMethod(),
+                    payment.getAmount(),
+                    ticketCount
+                )
+            ));
+
+        Refund refund = Refund.create(
+            ledger.getOrderRefundId(),
+            event.orderId(),
+            payment.getPaymentId(),
+            event.userId(),
+            refundAmount,
+            RefundRateConstants.FULL
+        );
+        refundRepository.save(refund);
+
+        if (!issuedTicketIds.isEmpty()) {
+            List<RefundTicket> rts = issuedTicketIds.stream()
+                .map(tid -> RefundTicket.of(refund.getRefundId(), tid))
+                .toList();
+            refundTicketRepository.saveAll(rts);
+        }
+
+        RefundRequestedEvent requested = new RefundRequestedEvent(
+            refund.getRefundId(),
+            ledger.getOrderRefundId(),
+            event.orderId(),
+            event.userId(),
+            payment.getPaymentId(),
+            payment.getPaymentMethod(),
+            issuedTicketIds,
+            refundAmount,
+            RefundRateConstants.FULL,
+            issuedTicketIds.isEmpty(),
+            event.reason(),
+            Instant.now()
+        );
+
+        outboxService.save(
+            refund.getRefundId().toString(),
+            KafkaTopics.REFUND_REQUESTED,
+            KafkaTopics.REFUND_REQUESTED,
+            event.orderId().toString(),
+            requested
+        );
+
+        deduplicationService.markProcessed(messageId, topic);
+
+        log.info("[Consumer] ticket.issue-failed 환불 진입 — refundId={}, orderId={}, amount={}",
+            refund.getRefundId(), event.orderId(), refundAmount);
+    }
+}

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/RefundCompletedHandler.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/RefundCompletedHandler.java
@@ -8,23 +8,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.devticket.payment.common.messaging.MessageDeduplicationService;
-import com.devticket.payment.wallet.application.service.WalletService;
 
 @Service
 @RequiredArgsConstructor
 public class RefundCompletedHandler {
 
-    private final WalletService walletService;
     private final MessageDeduplicationService deduplicationService;
-
-    @Transactional
-    public void restoreBalanceAndMarkProcessed(
-        UUID userId, int amount, UUID refundId, UUID orderId,
-        UUID messageId, String topic
-    ) {
-        walletService.restoreBalance(userId, amount, refundId, orderId);
-        deduplicationService.markProcessed(messageId, topic);
-    }
 
     @Transactional
     public void markProcessedOnly(UUID messageId, String topic) {

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/WalletEventConsumer.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/WalletEventConsumer.java
@@ -2,10 +2,6 @@ package com.devticket.payment.wallet.infrastructure.kafka;
 
 import com.devticket.payment.common.messaging.KafkaTopics;
 import com.devticket.payment.common.messaging.MessageDeduplicationService;
-import com.devticket.payment.common.messaging.OutboxPayloadExtractor;
-import com.devticket.payment.payment.domain.enums.PaymentMethod;
-import com.devticket.payment.wallet.application.event.RefundCompletedEvent;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -23,10 +19,13 @@ public class WalletEventConsumer {
 
     private final RefundCompletedHandler refundCompletedHandler;
     private final MessageDeduplicationService deduplicationService;
-    private final ObjectMapper objectMapper;
 
     /**
-     * refund.completed 소비 paymentMethod=WALLET인 경우에만 예치금 잔액 복구
+     * refund.completed 소비 — dedup 기록 전용.
+     *
+     * WALLET / WALLET_PG / PG 모두 {@link com.devticket.payment.refund.application.saga.RefundSagaOrchestrator}
+     * 가 saga 내부에서 PG 취소 + Wallet 복구를 수행한다. Consumer 에서 restore 를 다시 실행하면
+     * 이중 적립이 발생하므로 여기서는 dedup 마킹만 남긴다.
      *
      * NOTE: event.force-cancelled / event.sale-stopped 의 fan-out 은 Commerce 서비스 책임이다.
      * Payment 는 Commerce 가 orderId 별로 발행한 refund.requested 를 소비하여 Saga 를 진행하므로
@@ -47,26 +46,8 @@ public class WalletEventConsumer {
         }
 
         try {
-            RefundCompletedEvent event = OutboxPayloadExtractor.extract(
-                objectMapper, record.value(), RefundCompletedEvent.class);
-
-            if (PaymentMethod.WALLET == event.paymentMethod()) {
-                // restoreBalance + markProcessed를 하나의 @Transactional에서 처리
-                refundCompletedHandler.restoreBalanceAndMarkProcessed(
-                    event.userId(),
-                    event.refundAmount(),
-                    event.refundId(),
-                    event.orderId(),
-                    messageUUID,
-                    record.topic()
-                );
-            } else {
-                // PG/WALLET_PG 결제건은 Saga 내부에서 이미 PG 취소 + Wallet 복구 수행 — dedup만 기록
-                refundCompletedHandler.markProcessedOnly(messageUUID, record.topic());
-            }
-
+            refundCompletedHandler.markProcessedOnly(messageUUID, record.topic());
             ack.acknowledge();
-
         } catch (Exception e) {
             log.error("[Consumer] refund.completed 처리 실패 — messageId={}, error={}",
                 messageUUID, e.getMessage(), e);

--- a/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
@@ -76,9 +76,9 @@ class RefundSagaOrchestratorTest {
 
     private RefundRequestedEvent newRequested(PaymentMethod method, boolean wholeOrder) {
         return new RefundRequestedEvent(
-            refundId, orderId, userId, paymentId, method,
+            refundId, UUID.randomUUID(), orderId, userId, paymentId, method,
             wholeOrder ? List.of() : List.of(UUID.randomUUID()),
-            10_000, 100, wholeOrder, Instant.now()
+            10_000, 100, wholeOrder, "test-reason", Instant.now()
         );
     }
 

--- a/payment/src/test/java/com/devticket/payment/refund/integration/RefundSagaIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/integration/RefundSagaIntegrationTest.java
@@ -106,6 +106,7 @@ class RefundSagaIntegrationTest {
 
         RefundRequestedEvent requested = new RefundRequestedEvent(
             refund.getRefundId(),
+            ledger.getOrderRefundId(),
             payment.getOrderId(),
             payment.getUserId(),
             payment.getPaymentId(),
@@ -114,6 +115,7 @@ class RefundSagaIntegrationTest {
             payment.getAmount(),
             100,
             false,
+            "integration-test",
             Instant.now()
         );
 
@@ -153,9 +155,10 @@ class RefundSagaIntegrationTest {
         ));
 
         RefundRequestedEvent requested = new RefundRequestedEvent(
-            refund.getRefundId(), payment.getOrderId(), payment.getUserId(),
-            payment.getPaymentId(), payment.getPaymentMethod(),
-            List.of(UUID.randomUUID()), payment.getAmount(), 100, false, Instant.now()
+            refund.getRefundId(), ledger.getOrderRefundId(), payment.getOrderId(),
+            payment.getUserId(), payment.getPaymentId(), payment.getPaymentMethod(),
+            List.of(UUID.randomUUID()), payment.getAmount(), 100, false,
+            "integration-test", Instant.now()
         );
         publishOutbox(KafkaTopics.REFUND_REQUESTED, refund.getRefundId().toString(),
             payment.getOrderId().toString(), requested);
@@ -251,8 +254,8 @@ class RefundSagaIntegrationTest {
                 KafkaTopics.REFUND_TICKET_DONE,
                 KafkaTopics.REFUND_TICKET_DONE,
                 orderId.toString(),
-                new RefundTicketDoneEvent(refundId, orderId, UUID.randomUUID(),
-                    List.of(UUID.randomUUID()), Instant.now())
+                new RefundTicketDoneEvent(refundId, orderId,
+                    List.of(UUID.randomUUID()), UUID.randomUUID(), 1, Instant.now())
             );
         }
 


### PR DESCRIPTION
## Summary
This PR refactors the refund processing flow to prevent double-processing of wallet restorations and improves transactional consistency by separating business logic from message deduplication concerns.

## Key Changes

### 1. Extract TicketIssueFailedHandler for Transactional Boundary
- Created new `TicketIssueFailedHandler` service to handle the `@Transactional` boundary
- Moved all business logic from `TicketIssueFailedConsumer.handle()` to `TicketIssueFailedHandler.handleAndMark()`
- This prevents self-invocation proxy bypass issues and ensures business logic + dedup marking happen atomically in a single transaction
- `TicketIssueFailedConsumer` now acts as a thin Kafka listener that delegates to the handler

### 2. Simplify WalletEventConsumer to Dedup-Only
- Removed wallet balance restoration logic from `WalletEventConsumer.consumeRefundCompleted()`
- Now only marks messages as processed (dedup)
- Rationale: The `RefundSagaOrchestrator` already handles PG cancellation + wallet restoration internally within the saga, so consumer-level restoration would cause double-crediting
- Removed unused `ObjectMapper` and `OutboxPayloadExtractor` dependencies from consumer
- Simplified `RefundCompletedHandler` to only provide `markProcessedOnly()` method

### 3. Improve Quantity Calculation in RefundSagaOrchestrator
- Enhanced `onTicketDone()` quantity calculation with clear priority order:
  1. `event.quantity()` if > 0
  2. `event.ticketIds().size()` if present and non-empty
  3. Existing `RefundTicket` count
  4. `OrderRefund.remainingTickets` as fallback
- Prevents inventory from being incorrectly reset to 0 when Commerce sends empty ticketIds for whole-order refunds

### 4. Update Event Signatures
- Added `orderRefundId` parameter to `RefundRequestedEvent` constructor
- Added `reason` parameter to `RefundRequestedEvent` constructor
- Updated `RefundTicketDoneEvent` constructor signature to match new parameter order
- Updated all test cases to use new event signatures

## Implementation Details
- The handler pattern ensures that message deduplication and business logic execute within the same database transaction, preventing message reprocessing if the transaction rolls back
- Wallet restoration is now exclusively handled by the saga orchestrator, eliminating the risk of duplicate balance updates
- The quantity calculation fallback chain ensures robust handling of edge cases where ticket information may be incomplete or missing

https://claude.ai/code/session_01CFHW8EYLc7NZygiqKU4V8S