### PR TITLE
[Event] fix: 오탈자 수정

### DIFF
--- a/event/src/main/java/com/devticket/event/domain/enums/PaymentMethod.java
+++ b/event/src/main/java/com/devticket/event/domain/enums/PaymentMethod.java
@@ -1,0 +1,6 @@
+package com.devticket.event.domain.enums;
+
+public enum PaymentMethod {
+    WALLET,
+    PG
+}

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventInternalController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventInternalController.java
@@ -44,7 +44,6 @@ public class EventInternalController {
 
     private final EventInternalService eventInternalService;
     private final EventService eventService;
-    private final EventRecommendationService eventRecommendationService;
 
     @GetMapping
     public ResponseEntity<SuccessResponse<InternalPagedEventResponse>> getEvents(
@@ -181,14 +180,8 @@ public class EventInternalController {
         @RequestBody @Valid InternalEventForceCancelRequest request) {
         eventService.forceCancel(eventId, request.reason());
         return ResponseEntity.noContent().build();
- 
-    @GetMapping("/recommendations")
-    public ResponseEntity<SuccessResponse<InternalRecommendationResponse>> getRecommendations(
-        @RequestHeader("X-User-Id") UUID userId) {
-        return ResponseEntity.ok(SuccessResponse.success(
-            eventRecommendationService.getRecommendations(userId)
-        ));
-    
+    }
+
     @PostMapping("/popular")
     public ResponseEntity<SuccessResponse<List<InternalPopularEventResponse>>> getPopularEvents(
         @RequestBody InternalPopularEventRequest request) {


### PR DESCRIPTION
## Summary
This PR removes the event recommendations endpoint from the internal controller and introduces a new `PaymentMethod` enum to support payment type classification.

## Key Changes
- **Removed** the `getRecommendations()` endpoint from `EventInternalController` that was returning event recommendations based on user ID
- **Removed** the unused `EventRecommendationService` dependency injection from `EventInternalController`
- **Fixed** malformed method closing (missing closing brace for `forceCancel()` method)
- **Added** new `PaymentMethod` enum with two payment types: `WALLET` and `PG`

## Implementation Details
- The `PaymentMethod` enum is located in the `com.devticket.event.domain.enums` package and provides a type-safe way to represent payment methods in the system
- The removal of the recommendations endpoint simplifies the internal controller and eliminates an unused service dependency

https://claude.ai/code/session_01B5PrfCoUkN4abpEeEMv72s