### PR TITLE
[Commerce] fix: OrderErrorCode 머지 충돌로 발생한 컴파일 실패 수정

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/order/domain/exception/OrderErrorCode.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/domain/exception/OrderErrorCode.java
@@ -27,9 +27,8 @@ public enum OrderErrorCode implements ErrorCode {
     REFUND_NOT_REFUNDABLE(400, "ORDER_016", "환불 요청이 불가능한 주문 상태입니다."),
     REFUND_ROLLBACK_INVALID(400, "ORDER_017", "환불 보상 롤백이 불가능한 주문 상태입니다."),
     REFUND_COMPLETE_INVALID(400, "ORDER_018", "환불 확정이 불가능한 주문 상태입니다."),
-    INVALID_ORDER_STATUS_FILTER(400, "ORDER_019", "유효하지 않은 주문 상태 필터 값입니다.");
-    INVALID_ORDER_STATUS_FILTER(400, "ORDER_016", "유효하지 않은 주문 상태 필터 값입니다."),
-    ORDER_CREATION_CONFLICT(409, "ORDER_017", "동시 요청으로 주문이 생성됐으나 주문 조회에 실패했습니다.");
+    INVALID_ORDER_STATUS_FILTER(400, "ORDER_019", "유효하지 않은 주문 상태 필터 값입니다."),
+    ORDER_CREATION_CONFLICT(409, "ORDER_020", "동시 요청으로 주문이 생성됐으나 주문 조회에 실패했습니다.");
 
     private final int status;
     private final String code;


### PR DESCRIPTION
## 📌 작업 내용

`OrderErrorCode`에서 `develop/commerce` 병합 시 잘못 해결된 머지 충돌로 인해 `:compileJava`가 실패하던 문제를 수정합니다.

```
OrderErrorCode.java:31: error: enum constant not expected here
    INVALID_ORDER_STATUS_FILTER(400, "ORDER_016", "유효하지 않은 주문 상태 필터 값입니다."),
```

## 🔍 원인

`feat/commerce-refund-saga-orchestration` 브랜치와 `develop/commerce` 브랜치가 각각 새로운 enum 상수를 추가한 상태에서 병합되면서, 양쪽 변경 사항이 세미콜론을 건너뛴 채 그대로 남아 아래 두 가지 문제가 있었습니다.

1. **enum 종료 세미콜론 위치 오류** — `ORDER_019` 뒤에 세미콜론으로 enum 선언이 끝났는데도 뒤에 상수 두 개가 이어져 컴파일 불가
2. **`INVALID_ORDER_STATUS_FILTER` 중복 선언** — 같은 상수가 `ORDER_016`과 `ORDER_019` 두 코드로 중복 선언
3. **에러 코드 번호 충돌** — `ORDER_CREATION_CONFLICT`의 코드가 `ORDER_017`로 잡혀 있어 기존 `REFUND_ROLLBACK_INVALID(ORDER_017)`와 중복

## 🔧 변경 사항

- 중복된 `INVALID_ORDER_STATUS_FILTER(ORDER_016)` 선언 제거 (정상 선언 `ORDER_019`만 유지)
- enum 종료 세미콜론을 `ORDER_CREATION_CONFLICT` 끝으로 이동
- `ORDER_CREATION_CONFLICT` 코드를 `ORDER_017` → `ORDER_020`으로 재할당 (코드 번호 체계 규칙 준수)

| 상수 | 변경 전 | 변경 후 |
|---|---|---|
| `INVALID_ORDER_STATUS_FILTER` | `ORDER_016`/`ORDER_019` 중복 | `ORDER_019` |
| `ORDER_CREATION_CONFLICT` | `ORDER_017` (충돌) | `ORDER_020` |

## ✅ 테스트

- [x] `./gradlew compileJava` 성공 확인
- [x] `./gradlew compileTestJava` 성공 확인
- [x] `./gradlew build -x test` 성공 확인
- [x] `OrderErrorCode` 참조처(`OrderService`, `Order`, `OrderRefundTransitionTest`) 영향 없음 — 상수명만 참조, 코드 문자열 미참조

## 📎 영향 범위

- `commerce` 서비스 한정
- 런타임 동작 변경 없음 (에러 코드 번호만 재할당, 상수명은 동일)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3BZD2XdEH28ChQTF7JwpS)_