### PR TITLE
[Payment] feat: 정산서비스 내부요청 API추가 _ 정산금을 예치금으로 전환처리

### DIFF
--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
@@ -1,6 +1,5 @@
 package com.devticket.payment.wallet.application.service;
 
-import com.devticket.payment.wallet.application.event.PaymentCompletedEvent;
 import com.devticket.payment.wallet.presentation.dto.WalletBalanceResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmResponse;
@@ -38,4 +37,6 @@ public interface WalletService {
     void processBatchRefund(UUID eventId);
 
     void recoverStalePendingCharge(UUID chargeId);
+
+    void depositFromSettlement(SettlementDepositRequest request);
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
@@ -1,5 +1,7 @@
 package com.devticket.payment.wallet.application.service;
 
+import com.devticket.payment.wallet.application.event.PaymentCompletedEvent;
+import com.devticket.payment.wallet.presentation.dto.SettlementDepositRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletBalanceResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmResponse;

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -547,12 +548,12 @@ public class WalletServiceImpl implements WalletService {
             return;
         }
 
-        // 지갑이 없으면 생성
-        walletRepository.findByUserId(request.userId())
-            .orElseGet(() -> walletRepository.save(Wallet.create(request.userId())));
+        // 지갑이 없으면 생성, 있으면 무시 (ON CONFLICT DO NOTHING — 동시 정산 요청 경합 흡수)
+        walletRepository.insertWalletIfAbsent(request.userId());
 
         walletRepository.chargeBalanceAtomic(request.userId(), request.amount());
 
+        // clearAutomatically = true 로 캐시 초기화됐으므로 최신 잔액을 재조회
         Wallet wallet = walletRepository.findByUserId(request.userId())
             .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
 
@@ -560,7 +561,13 @@ public class WalletServiceImpl implements WalletService {
             wallet.getId(), request.userId(), transactionKey,
             request.amount(), wallet.getBalance()
         );
-        walletTransactionRepository.save(tx);
+        try {
+            walletTransactionRepository.saveAndFlush(tx);
+        } catch (DataIntegrityViolationException e) {
+            // 동시 재시도가 먼저 커밋 — 이 TX의 잔액 변경은 롤백으로 보호되고 호출자엔 멱등 성공으로 응답
+            log.info("[Settlement] 동시 중복 정산 감지 — 멱등 처리. settlementId={}", request.settlementId());
+            throw new WalletException(WalletErrorCode.SETTLEMENT_ALREADY_PROCESSED);
+        }
 
         log.info("[Settlement] 정산금 예치금 전환 완료 — settlementId={}, userId={}, amount={}, balanceAfter={}",
             request.settlementId(), request.userId(), request.amount(), wallet.getBalance());

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -37,6 +37,7 @@ import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
 import com.devticket.payment.wallet.domain.repository.WalletRepository;
 import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
 import com.devticket.payment.wallet.infrastructure.client.dto.InternalEventOrdersResponse;
+import com.devticket.payment.wallet.presentation.dto.SettlementDepositRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletBalanceResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmResponse;
@@ -530,6 +531,39 @@ public class WalletServiceImpl implements WalletService {
             walletCharge.fail();
             log.info("[Recovery] PG 상태 '{}' — chargeId={} → FAILED", pgStatus.status(), chargeId);
         }
+    }
+
+    // =====================================================================
+    // Settlement 요청 — 정산금을 예치금으로 전환
+    // =====================================================================
+
+    @Override
+    @Transactional
+    public void depositFromSettlement(SettlementDepositRequest request) {
+        String transactionKey = "SETTLEMENT_" + request.settlementId();
+
+        if (walletTransactionRepository.existsByTransactionKey(transactionKey)) {
+            log.info("[Settlement] 이미 처리된 정산 — settlementId={}", request.settlementId());
+            return;
+        }
+
+        // 지갑이 없으면 생성
+        walletRepository.findByUserId(request.userId())
+            .orElseGet(() -> walletRepository.save(Wallet.create(request.userId())));
+
+        walletRepository.chargeBalanceAtomic(request.userId(), request.amount());
+
+        Wallet wallet = walletRepository.findByUserId(request.userId())
+            .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
+
+        WalletTransaction tx = WalletTransaction.createSettlement(
+            wallet.getId(), request.userId(), transactionKey,
+            request.amount(), wallet.getBalance()
+        );
+        walletTransactionRepository.save(tx);
+
+        log.info("[Settlement] 정산금 예치금 전환 완료 — settlementId={}, userId={}, amount={}, balanceAfter={}",
+            request.settlementId(), request.userId(), request.amount(), wallet.getBalance());
     }
 
     // =====================================================================

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/enums/WalletTransactionType.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/enums/WalletTransactionType.java
@@ -4,5 +4,6 @@ public enum WalletTransactionType {
     CHARGE,
     USE,
     REFUND,
-    WITHDRAW
+    WITHDRAW,
+    SETTLEMENT
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/exception/WalletErrorCode.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/exception/WalletErrorCode.java
@@ -16,7 +16,8 @@ public enum WalletErrorCode implements ErrorCode {
     CHARGE_AMOUNT_MISMATCH(400, "WALLET_006", "충전 금액이 일치하지 않습니다."),
     CHARGE_NOT_FOUND(404, "WALLET_007", "충전 요청을 찾을 수 없습니다."),
     CHARGE_NOT_PENDING(409, "WALLET_008", "대기 상태가 아닌 충전 건입니다."),
-    INVALID_CHARGE_REQUEST(400, "WALLET_009", "유효하지 않은 충전 요청입니다.");
+    INVALID_CHARGE_REQUEST(400, "WALLET_009", "유효하지 않은 충전 요청입니다."),
+    SETTLEMENT_ALREADY_PROCESSED(409, "WALLET_010", "이미 처리된 정산 건입니다.");
 
     private final int status;
     private final String code;

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/model/WalletTransaction.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/model/WalletTransaction.java
@@ -135,6 +135,24 @@ public class WalletTransaction extends BaseEntity {
         return walletTransaction;
     }
 
+    public static WalletTransaction createSettlement(
+        Long walletId,
+        UUID userId,
+        String transactionKey,
+        Integer amount,
+        Integer balanceAfter
+    ) {
+        WalletTransaction walletTransaction = new WalletTransaction();
+        walletTransaction.walletTransactionId = UUID.randomUUID();
+        walletTransaction.walletId = walletId;
+        walletTransaction.userId = userId;
+        walletTransaction.transactionKey = transactionKey;
+        walletTransaction.type = WalletTransactionType.SETTLEMENT;
+        walletTransaction.amount = amount;
+        walletTransaction.balanceAfter = balanceAfter;
+        return walletTransaction;
+    }
+
     public void softDelete() {
         this.deletedAt = LocalDateTime.now();
     }

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/repository/WalletTransactionRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/repository/WalletTransactionRepository.java
@@ -8,6 +8,8 @@ public interface WalletTransactionRepository {
 
     WalletTransaction save(WalletTransaction walletTransaction);
 
+    WalletTransaction saveAndFlush(WalletTransaction walletTransaction);
+
     boolean existsByTransactionKey(String transactionKey);
 
     Page<WalletTransaction> findAllByWalletId(Long walletId, Pageable pageable);

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletTransactionRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletTransactionRepositoryImpl.java
@@ -19,6 +19,11 @@ public class WalletTransactionRepositoryImpl implements WalletTransactionReposit
     }
 
     @Override
+    public WalletTransaction saveAndFlush(WalletTransaction walletTransaction) {
+        return walletTransactionJpaRepository.saveAndFlush(walletTransaction);
+    }
+
+    @Override
     public boolean existsByTransactionKey(String transactionKey) {
         return walletTransactionJpaRepository.existsByTransactionKey(transactionKey);
     }

--- a/payment/src/main/java/com/devticket/payment/wallet/presentation/controller/WalletInternalController.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/presentation/controller/WalletInternalController.java
@@ -1,0 +1,32 @@
+package com.devticket.payment.wallet.presentation.controller;
+
+import com.devticket.payment.wallet.application.service.WalletService;
+import com.devticket.payment.wallet.presentation.dto.SettlementDepositRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/internal/wallet")
+@RequiredArgsConstructor
+public class WalletInternalController {
+
+    private final WalletService walletService;
+
+    /**
+     * Settlement → Payment: 정산금을 판매자 예치금으로 전환.
+     * 성공 204 → Settlement가 지급완료 처리, 실패 4xx/5xx → 지급실패 처리.
+     */
+    @PostMapping("/settlement-deposit")
+    public ResponseEntity<Void> depositFromSettlement(
+        @Valid @RequestBody SettlementDepositRequest request) {
+        walletService.depositFromSettlement(request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/payment/src/main/java/com/devticket/payment/wallet/presentation/controller/WalletInternalController.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/presentation/controller/WalletInternalController.java
@@ -1,6 +1,8 @@
 package com.devticket.payment.wallet.presentation.controller;
 
 import com.devticket.payment.wallet.application.service.WalletService;
+import com.devticket.payment.wallet.domain.exception.WalletErrorCode;
+import com.devticket.payment.wallet.domain.exception.WalletException;
 import com.devticket.payment.wallet.presentation.dto.SettlementDepositRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +28,15 @@ public class WalletInternalController {
     @PostMapping("/settlement-deposit")
     public ResponseEntity<Void> depositFromSettlement(
         @Valid @RequestBody SettlementDepositRequest request) {
-        walletService.depositFromSettlement(request);
+        try {
+            walletService.depositFromSettlement(request);
+        } catch (WalletException e) {
+            if (e.getErrorCode() == WalletErrorCode.SETTLEMENT_ALREADY_PROCESSED) {
+                // 동시 재시도 경합 — 잔액은 롤백으로 보호, 호출자엔 성공 응답
+                return ResponseEntity.noContent().build();
+            }
+            throw e;
+        }
         return ResponseEntity.noContent().build();
     }
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/presentation/dto/SettlementDepositRequest.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/presentation/dto/SettlementDepositRequest.java
@@ -1,0 +1,12 @@
+package com.devticket.payment.wallet.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.UUID;
+
+public record SettlementDepositRequest(
+    @NotNull UUID settlementId,
+    @NotNull UUID userId,
+    @Positive int amount
+) {
+}


### PR DESCRIPTION
## 관련 이슈
- close #537

## 작업 내용
- 호출 : Settlement -> Payment
- 정산금을 예치금으로 전환처리

## 변경 사항
- 상태값 추가 : WalletTransactionType - SETTLEMENT
- WalletService,WalletServiceImpl : depositFromSettlement추가
- WalletTransaction 팩토리메서드 추가 : createSettlement추가 
- WalletInternalController : POST /internal/wallet/settlement-deposit 엔드포인트 추가 

- 코덱스 리뷰건 수정반영 
  - Wallet생성 충돌 :  insertWalletIfAbsent(ON CONFLICT DO NOTHING) + 재조회 패턴으로 교체
  - WalletTransaction생성 충돌 : WalletTransactionRepositoryImpl - saveAndFlush 메서드로 교체

## 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과 (해당 시)
- [ ] Swagger 동작 확인

## 스크린샷

## 참고 사항
CI실패 ---> Refund테스트 관련 에러여서 Ci실패 상태로 PR올립니다.
RefundSagaIntegrationTest의 OutboxService.save()가 @Transactional(propagation = MANDATORY) 으로 설정되어 있어 반드시 호출자가 먼저 트랜잭션을 열어야 합니다.  
