### PR TITLE
[ai service] : feat 콜드스타트 인기 이벤트 폴백 및 추천 흐름 수정

### DIFF
--- a/ai/src/main/java/org/example/ai/application/service/RecommendationService.java
+++ b/ai/src/main/java/org/example/ai/application/service/RecommendationService.java
@@ -104,20 +104,26 @@ public class RecommendationService {
 
         // 1.1 임베딩 값이 비었을 경우
         if(embeddingList.isEmpty()){
-            PopularEventListRequest popularEventRquest = new PopularEventListRequest(5);
-            PopularEventListResponse response = eventRepository.getPopularEvents(popularEventRquest);
-            List<String> popularEventIds = response.events().stream()
-                .map(PopularEventListResponse.EventInfo::eventId)
-                .toList();
-
-            return new RecommendationResponse(userId, popularEventIds);
+            try {
+                PopularEventListRequest popularEventRequest = new PopularEventListRequest(5);
+                PopularEventListResponse response = eventRepository.getPopularEvents(popularEventRequest);
+                log.info("[ColdStart] popular 응답: {}", response);
+                List<String> popularEventIds = response.data().stream()
+                    .map(PopularEventListResponse.EventInfo::id)
+                    .toList();
+                log.info("[ColdStart] popularEventIds: {}", popularEventIds);
+                return new RecommendationResponse(userId, popularEventIds);
+            } catch (Exception e) {
+                log.error("[ColdStart] popular 처리 실패", e);
+                throw e;
+            }
         }
 
         // 2. 테크 스택의 평균 벡터 연산
         float[] queryVector = combineVector(embeddingList);
 
         // 3. knn 검색
-        List<Map<String, Object>> events = searchKnn(queryVector,5);
+        List<Map<String, Object>> events = searchKnn(queryVector, 5);
 
         // 4. event_id 담기
         List<String> eventIds = events.stream()
@@ -128,17 +134,21 @@ public class RecommendationService {
         if(eventIds.size() < 5){
             int neededCount = 5 - eventIds.size();
 
-            PopularEventListRequest popularEventRquest = new PopularEventListRequest(neededCount);
-            PopularEventListResponse response = eventRepository.getPopularEvents(popularEventRquest);
+            try {
+                PopularEventListRequest popularEventRequest = new PopularEventListRequest(neededCount);
+                PopularEventListResponse response = eventRepository.getPopularEvents(popularEventRequest);
+                log.info("[ColdStart] popular 보충 응답: {}", response);
+                List<String> popularEventIds = response.data().stream()
+                    .map(PopularEventListResponse.EventInfo::id)
+                    .toList();
 
-            List<String> popularEventIds = response.events().stream()
-                .map(PopularEventListResponse.EventInfo::eventId)
-                .toList();
-
-            List<String> combined = new ArrayList<>(eventIds);
-            combined.addAll(popularEventIds);
-
-            return new RecommendationResponse(userId, combined);
+                List<String> combined = new ArrayList<>(eventIds);
+                combined.addAll(popularEventIds);
+                return new RecommendationResponse(userId, combined);
+            } catch (Exception e) {
+                log.error("[ColdStart] popular 보충 처리 실패", e);
+                throw e;
+            }
         }
 
         return new RecommendationResponse(userId, eventIds);
@@ -193,7 +203,7 @@ public class RecommendationService {
 
             // kNN 쿼리문
             SearchResponse<Map> response = elasticsearchClient.search(s -> s
-                    .index("event-index")
+                    .index("event")
                     .knn(k -> k
                         .field("embedding")
                         .queryVector(queryList)

--- a/ai/src/main/java/org/example/ai/infrastructure/config/WebClientConfig.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/config/WebClientConfig.java
@@ -1,15 +1,23 @@
 package org.example.ai.infrastructure.config;
 
+import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
 
 @Configuration
 public class WebClientConfig {
 
     @Bean
     public WebClient webClient(){
-        return WebClient.builder().build();
+        return WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(
+                HttpClient.create()
+                    .responseTimeout(Duration.ofSeconds(5))
+            ))
+            .build();
     }
 
 }

--- a/ai/src/main/java/org/example/ai/infrastructure/external/client/EventServiceClient.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/external/client/EventServiceClient.java
@@ -21,7 +21,9 @@ public class EventServiceClient {
     private String eventServiceUrl;
 
     public PopularEventListResponse getPopularEvents(PopularEventListRequest request) {
-        log.info("[EventClient] 인기 이벤트 조회 - neededCount: {}", request.neededCount());
+        log.info("[EventClient] 인기 이벤트 조회 - needed: {}", request.needed());
+        log.info("[EventClient] 요청 URL: {}", eventServiceUrl + "/internal/events/popular");
+        log.info("[EventClient] 요청 body: {}", request);
 
         try {
             PopularEventListResponse response = webClient.post()
@@ -29,12 +31,14 @@ public class EventServiceClient {
                 .bodyValue(request)
                 .retrieve()
                 .bodyToMono(PopularEventListResponse.class)
+                .doOnSuccess(r -> log.info("[EventClient] 응답 성공: {}", r))
+                .doOnError(e -> log.error("[EventClient] 응답 실패", e))
                 .block();
 
-            return response != null ? response : new PopularEventListResponse(List.of());
+            return response != null ? response : new PopularEventListResponse(List.of(),null, null);
         } catch (Exception e) {
             log.error("[EventClient] 인기 이벤트 조회 실패", e);
-            return new PopularEventListResponse(List.of());
+            return new PopularEventListResponse(List.of(),null, null);
         }
     }
 

--- a/ai/src/main/java/org/example/ai/infrastructure/external/dto/req/PopularEventListRequest.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/external/dto/req/PopularEventListRequest.java
@@ -1,7 +1,7 @@
 package org.example.ai.infrastructure.external.dto.req;
 
 public record PopularEventListRequest(
-    int neededCount
+    int needed
 ) {
 
 }

--- a/ai/src/main/java/org/example/ai/infrastructure/external/dto/res/PopularEventListResponse.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/external/dto/res/PopularEventListResponse.java
@@ -3,11 +3,11 @@ package org.example.ai.infrastructure.external.dto.res;
 import java.util.List;
 
 public record PopularEventListResponse(
-    List<EventInfo> events
+    List<EventInfo> data,
+    String message,
+    Integer status
 ) {
     public record EventInfo(
-        String eventId
-    ){
-
-    }
+        String id
+    ) {}
 }

--- a/ai/src/main/java/org/example/ai/infrastructure/persistence/repository/EventEmbeddingRepositoryImpl.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/persistence/repository/EventEmbeddingRepositoryImpl.java
@@ -20,7 +20,7 @@ public class EventEmbeddingRepositoryImpl implements EventEmbeddingRepository {
         try {
             // es에서 eventId로 embedding 값 단건 조회
             var response = elasticsearchClient.get(g->g
-                .index("event-index")
+                .index("event")
                 .id(eventId)
                     .sourceIncludes("embedding")
                 , java.util.Map.class

--- a/ai/src/main/java/org/example/ai/infrastructure/persistence/repository/EventRepositoryImpl.java
+++ b/ai/src/main/java/org/example/ai/infrastructure/persistence/repository/EventRepositoryImpl.java
@@ -15,7 +15,6 @@ public class EventRepositoryImpl implements EventRepository {
 
     @Override
     public PopularEventListResponse getPopularEvents(PopularEventListRequest popularEventRquest) {
-        eventServiceClient.getPopularEvents(popularEventRquest);
-        return null;
+        return eventServiceClient.getPopularEvents(popularEventRquest);
     }
 }

--- a/ai/src/test/java/org/example/ai/application/service/RecommendationServiceTest.java
+++ b/ai/src/test/java/org/example/ai/application/service/RecommendationServiceTest.java
@@ -94,7 +94,7 @@ public class RecommendationServiceTest {
             .willReturn(new UserTechStackResponse("user-1", List.of()));
 
         given(eventRepository.getPopularEvents(any()))
-            .willReturn(new PopularEventListResponse(List.of()));
+            .willReturn(new PopularEventListResponse(List.of(), null, null));
 
 
 


### PR DESCRIPTION


## 작업 내용
- RecommendationService.searchKnn 인덱스명 event-index → event 변경
- PopularEventListRequest 필드명 neededCount → needed 변경
- PopularEventListResponse 응답 구조 Event Service 형식에 맞게 수정 (data, message, status 래퍼)
- EventRepositoryImpl.getPopularEvents return null 버그 수정
- WebClient 타임아웃 설정 추가 (5초)

## 변경 파일
- application/service/RecommendationService.java
- infrastructure/external/dto/req/PopularEventListRequest.java
- infrastructure/external/dto/res/PopularEventListResponse.java
- infrastructure/persistence/repository/EventRepositoryImpl.java
- infrastructure/config/WebClientConfig.java