### PR TITLE
[event] feat: 인기 이벤트 내부 API 응답에 eventId(UUID) 반환으로 변경

### DIFF
--- a/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
@@ -41,7 +41,7 @@ public class EventController {
         return ResponseEntity.ok(SuccessResponse.success(response));
     }
 
-    @GetMapping("/recommendations")
+    @GetMapping("/user/recommendations")
     public ResponseEntity<SuccessResponse<RecommendationResponse>> getRecommendations(
         @RequestHeader("X-User-Id") UUID userId) {
         return ResponseEntity.ok(SuccessResponse.success(

--- a/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalPopularEventResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalPopularEventResponse.java
@@ -1,11 +1,12 @@
 package com.devticket.event.presentation.dto.internal;
 
 import com.devticket.event.domain.model.Event;
+import java.util.UUID;
 
 public record InternalPopularEventResponse(
-    Long id
+    String id
 ) {
     public static InternalPopularEventResponse from(Event event){
-        return new InternalPopularEventResponse(event.getId());
+        return new InternalPopularEventResponse(event.getEventId().toString());
     }
 }


### PR DESCRIPTION


## 작업 내용
- InternalPopularEventResponse에서 PK(Long id) 대신 eventId(UUID) 반환으로 변경
- AI Service와의 인터페이스 통일 (String id 필드로 UUID 반환)

## 변경 파일
- presentation/dto/internal/InternalPopularEventResponse.java