### PR TITLE
[Event] feat: AWS S3 이미지 업로드 API 구현

### DIFF
--- a/event/build.gradle
+++ b/event/build.gradle
@@ -56,6 +56,11 @@ dependencies {
     // ShedLock — Outbox 스케줄러 분산 환경 중복 실행 방지
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.16.0'
+
+    // AWS S3
+    implementation platform('software.amazon.awssdk:bom:2.26.12')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:auth'
 }
 
 test {

--- a/event/src/main/java/com/devticket/event/application/S3ImageUploadService.java
+++ b/event/src/main/java/com/devticket/event/application/S3ImageUploadService.java
@@ -1,0 +1,78 @@
+package com.devticket.event.application;
+
+import com.devticket.event.common.exception.BusinessException;
+import com.devticket.event.domain.exception.EventErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3ImageUploadService {
+
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024L;
+    private static final Set<String> ALLOWED_TYPES = Set.of(
+        "image/jpeg", "image/jpg", "image/png", "image/webp"
+    );
+    private static final Map<String, String> EXTENSION_MAP = Map.of(
+        "image/jpeg", "jpg",
+        "image/jpg",  "jpg",
+        "image/png",  "png",
+        "image/webp", "webp"
+    );
+
+    private final S3Client s3Client;
+
+    @Value("${AWS_S3_BUCKET_NAME}")
+    private String bucketName;
+
+    @Value("${AWS_REGION}")
+    private String region;
+
+    public String upload(MultipartFile file) {
+        validateFile(file);
+
+        String contentType = file.getContentType();
+        String extension   = EXTENSION_MAP.get(contentType);
+        String key         = "events/" + UUID.randomUUID() + "." + extension;
+
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(contentType)
+                .contentLength(file.getSize())
+                .build();
+
+            s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
+
+            return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, key);
+
+        } catch (Exception e) {
+            log.error("S3 업로드 실패: bucket={}, key={}, error={}", bucketName, key, e.getMessage(), e);
+            throw new BusinessException(EventErrorCode.IMAGE_UPLOAD_FAILED);
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(EventErrorCode.INVALID_REQUEST);
+        }
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new BusinessException(EventErrorCode.IMAGE_SIZE_EXCEEDED);
+        }
+        if (!ALLOWED_TYPES.contains(file.getContentType())) {
+            throw new BusinessException(EventErrorCode.INVALID_IMAGE_TYPE);
+        }
+    }
+}

--- a/event/src/main/java/com/devticket/event/common/config/S3Config.java
+++ b/event/src/main/java/com/devticket/event/common/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.devticket.event.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${AWS_ACCESS_KEY_ID}")
+    private String accessKey;
+
+    @Value("${AWS_SECRET_ACCESS_KEY}")
+    private String secretKey;
+
+    @Value("${AWS_REGION}")
+    private String region;
+
+    @Value("${AWS_S3_BUCKET_NAME}")
+    private String bucketName;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .build();
+    }
+}

--- a/event/src/main/java/com/devticket/event/common/exception/GlobalExceptionHandler.java
+++ b/event/src/main/java/com/devticket/event/common/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice
@@ -35,6 +36,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse.ofValidation("COMMON_001", e.getBindingResult()));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceeded(MaxUploadSizeExceededException e) {
+        log.warn("MaxUploadSizeExceededException: {}", e.getMessage());
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.of("EVENT_023", "이미지 크기는 최대 5MB입니다.", 400));
     }
 
     /**

--- a/event/src/main/java/com/devticket/event/domain/exception/EventErrorCode.java
+++ b/event/src/main/java/com/devticket/event/domain/exception/EventErrorCode.java
@@ -22,7 +22,10 @@ public enum EventErrorCode implements ErrorCode {
     MAX_QUANTITY_EXCEEDED(400, "EVENT_016", "인당 최대 구매 수량은 총 수량을 초과할 수 없습니다."),
     TOTAL_QUANTITY_BELOW_SOLD(400, "EVENT_017", "총 수량은 이미 판매된 수량 이하로 줄일 수 없습니다."),
     INVALID_STOCK_QUANTITY(400, "EVENT_018", "재고 변경 수량은 1 이상이어야 합니다."),
-    PURCHASE_NOT_ALLOWED(409, "EVENT_019", "현재 구매 불가능한 이벤트입니다.");
+    PURCHASE_NOT_ALLOWED(409, "EVENT_019", "현재 구매 불가능한 이벤트입니다."),
+    IMAGE_UPLOAD_FAILED(500, "EVENT_021", "이미지 업로드에 실패했습니다."),
+    INVALID_IMAGE_TYPE(400, "EVENT_022", "허용되지 않는 이미지 형식입니다. (jpg, jpeg, png, webp만 허용)"),
+    IMAGE_SIZE_EXCEEDED(400, "EVENT_023", "이미지 크기는 최대 5MB입니다.");
 
     private final int status;
     private final String code;

--- a/event/src/main/java/com/devticket/event/presentation/controller/SellerImageUploadController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/SellerImageUploadController.java
@@ -1,0 +1,30 @@
+package com.devticket.event.presentation.controller;
+
+import com.devticket.event.application.S3ImageUploadService;
+import com.devticket.event.common.response.SuccessResponse;
+import com.devticket.event.presentation.dto.ImageUploadResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/seller/images")
+@RequiredArgsConstructor
+public class SellerImageUploadController {
+
+    private final S3ImageUploadService s3ImageUploadService;
+
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public SuccessResponse<ImageUploadResponse> uploadImage(
+        @RequestHeader("X-User-Id") UUID sellerId,
+        @RequestPart("file") MultipartFile file) {
+
+        String imageUrl = s3ImageUploadService.upload(file);
+        return SuccessResponse.success(new ImageUploadResponse(imageUrl));
+    }
+}

--- a/event/src/main/java/com/devticket/event/presentation/dto/ImageUploadResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/ImageUploadResponse.java
@@ -1,0 +1,3 @@
+package com.devticket.event.presentation.dto;
+
+public record ImageUploadResponse(String imageUrl) {}

--- a/event/src/main/resources/application.yml
+++ b/event/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
     datatype:
       datetime:
         write-dates-as-timestamps: false
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 10MB
 
 server:
   port: 8082


### PR DESCRIPTION
## 관련 이슈
- close #542 

## 작업 내용
- 이벤트 이미지를 AWS S3에 업로드하고 S3 URL을 반환하는 API 구현
- 기존 URL 직접 입력 방식을 대체하며, 프론트에서 파일 선택 → 업로드 → URL 획득 → 이벤트 등록 흐름으로 변경

## 변경 사항
- `build.gradle`: AWS SDK v2 BOM 의존성 추가
- `application.yml`: multipart 파일 크기 제한 (파일 5MB / 요청 10MB)
- `S3Config`: @Value로 환경변수 직접 주입, S3Client 빈 등록
- `S3ImageUploadService`: 파일 타입·크기 검증, S3 업로드, URL 반환
- `SellerImageUploadController`: `POST /api/seller/images/upload`
- `EventErrorCode`: EVENT_021~023 에러 코드 추가
- `GlobalExceptionHandler`: MaxUploadSizeExceededException 처리 추가

## 참고 사항
- `.env`에 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_S3_BUCKET_NAME` 4개 환경변수 필요
- 게이트웨이 라우팅에 `/api/seller/images/**` 추가 필요 (gateway 서비스 별도 PR)