### PR TITLE
[Gateway] fix: 이벤트 이미지 업로드 경로 라우팅 추가

### DIFF
--- a/apigateway/src/main/resources/application-prod.yml
+++ b/apigateway/src/main/resources/application-prod.yml
@@ -15,7 +15,7 @@ spring:
             - id: event-service
               uri: http://event:8082
               predicates:
-                - Path=/api/events, /api/events/**, /api/seller/events, /api/seller/events/**
+                - Path=/api/events, /api/events/**, /api/seller/events, /api/seller/events/**, /api/seller/images/**
             - id: payment-service
               uri: http://payment:8084
               predicates:

--- a/apigateway/src/main/resources/application.yml
+++ b/apigateway/src/main/resources/application.yml
@@ -41,7 +41,7 @@ spring:
             - id: event-service
               uri: http://localhost:8082
               predicates:
-                - Path=/api/events, /api/events/**, /api/seller/events, /api/seller/events/**
+                - Path=/api/events, /api/events/**, /api/seller/events, /api/seller/events/**, /api/seller/images/**
 
             - id: payment-service
               uri: http://localhost:8084


### PR DESCRIPTION
## 관련 이슈
- close #544 

## 작업 내용
- 이벤트 서비스에 추가된 `POST /api/seller/images/upload` API가
  게이트웨이 라우팅 미등록으로 502 에러 발생하던 문제 수정
- `/api/seller/images/**` 경로를 event-service로 라우팅하도록 추가

## 변경 사항
- `application.yml`: event-service 라우팅 predicates에 `/api/seller/images/**` 추가
- `application-prod.yml`: 동일하게 반영