### PR TITLE
[Event] feat: order.cancelled Consumer 추가 — 결제 전 주문 취소 재고 복구

### DIFF
--- a/event/src/main/java/com/devticket/event/application/OrderCancelledService.java
+++ b/event/src/main/java/com/devticket/event/application/OrderCancelledService.java
@@ -1,0 +1,83 @@
+package com.devticket.event.application;
+
+import com.devticket.event.common.messaging.event.OrderCancelledEvent;
+import com.devticket.event.domain.enums.EventStatus;
+import com.devticket.event.domain.model.Event;
+import com.devticket.event.infrastructure.persistence.EventRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderCancelledService {
+    private final EventRepository eventRepository;
+    private final MessageDeduplicationService deduplicationService;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void restoreStockForOrderCancelled(UUID messageId, String topic, String payload) {
+        // Step 1. Dedup 체크
+        if (deduplicationService.isDuplicate(messageId)) {
+            return;
+        }
+
+        OrderCancelledEvent event = deserializeOrderCancelled(payload);
+        // eventId 정렬 → 비관적 락 조회 (데드락 방지)
+        List<UUID> sortedEventIds = event.orderItems().stream()
+            .map(OrderCancelledEvent.OrderItem::eventId)
+            .distinct()
+            .sorted()
+            .toList();
+
+        Map<UUID, Event> eventMap = eventRepository.findAllByEventIdInWithLock(sortedEventIds)
+            .stream()
+            .collect(Collectors.toMap(Event::getEventId, e -> e));
+
+        // 정렬된 순서로 처리
+        List<OrderCancelledEvent.OrderItem> sortedItems = event.orderItems().stream()
+            .sorted(Comparator.comparing(OrderCancelledEvent.OrderItem::eventId))
+            .toList();
+
+        for (OrderCancelledEvent.OrderItem item : sortedItems) {
+            Event targetEvent = eventMap.get(item.eventId());
+            if (targetEvent == null) {
+                throw new IllegalStateException(
+                    "Event not found for stock restore: eventId=" + item.eventId()
+                        + ", orderId=" + event.orderId());
+            }
+
+            // Step 2. EventStatus 검증 — CANCELLED/FORCE_CANCELLED면 정책적 스킵
+            if (targetEvent.getStatus() == EventStatus.CANCELLED
+                || targetEvent.getStatus() == EventStatus.FORCE_CANCELLED) {
+                log.warn("[정책적 스킵] order.cancelled 재고 복구 생략 — eventId={}, status={}, orderId={}",
+                    item.eventId(), targetEvent.getStatus(), event.orderId());
+                continue;
+            }
+
+            // Step 3. 비즈니스 로직 — 재고 복구
+            targetEvent.restoreStock(item.quantity());
+            log.info("[재고 복구] eventId={}, quantity={}, orderId={}, remaining={}",
+                item.eventId(), item.quantity(), event.orderId(), targetEvent.getRemainingQuantity());
+        }
+
+        // Step 4. Dedup 기록 (같은 트랜잭션)
+        deduplicationService.markProcessed(messageId, topic);
+    }
+
+    private OrderCancelledEvent deserializeOrderCancelled(String payload) {
+        try {
+            return objectMapper.readValue(payload, OrderCancelledEvent.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("OrderCancelledEvent 역직렬화 실패", e);
+        }
+    }
+}

--- a/event/src/main/java/com/devticket/event/common/messaging/KafkaTopics.java
+++ b/event/src/main/java/com/devticket/event/common/messaging/KafkaTopics.java
@@ -5,6 +5,7 @@ public final class KafkaTopics {
     private KafkaTopics() {}
 
     // Event 서비스가 소비하는 토픽
+    public static final String ORDER_CANCELLED = "order.cancelled";
     public static final String PAYMENT_FAILED = "payment.failed";
     public static final String REFUND_COMPLETED = "refund.completed";
     public static final String REFUND_STOCK_RESTORE = "refund.stock.restore";

--- a/event/src/main/java/com/devticket/event/common/messaging/event/OrderCancelledEvent.java
+++ b/event/src/main/java/com/devticket/event/common/messaging/event/OrderCancelledEvent.java
@@ -1,0 +1,15 @@
+package com.devticket.event.common.messaging.event;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderCancelledEvent(
+    UUID orderId,
+    UUID userId,
+    List<OrderItem> orderItems,
+    String reason,
+    Instant timestamp
+) {
+    public record OrderItem(UUID eventId, int quantity) {}
+}

--- a/event/src/main/java/com/devticket/event/presentation/consumer/OrderCancelledConsumer.java
+++ b/event/src/main/java/com/devticket/event/presentation/consumer/OrderCancelledConsumer.java
@@ -1,0 +1,64 @@
+package com.devticket.event.presentation.consumer;
+
+import com.devticket.event.application.MessageDeduplicationService;
+import com.devticket.event.application.OrderCancelledService;
+import com.devticket.event.common.messaging.KafkaTopics;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderCancelledConsumer {
+
+    private final OrderCancelledService orderCancelledService;
+    private final MessageDeduplicationService deduplicationService;
+
+    @KafkaListener(
+        topics = KafkaTopics.ORDER_CANCELLED,
+        groupId = "event-order.cancelled"
+    )
+    public void consume(ConsumerRecord<String, String> record, Acknowledgment ack) {
+        UUID messageId = extractMessageId(record.headers());
+        log.info("[order.cancelled 수신] messageId={}, key={}", messageId, record.key());
+
+        try {
+            orderCancelledService.restoreStockForOrderCancelled(
+                messageId, record.topic(), record.value());
+        } catch (ObjectOptimisticLockingFailureException e) {
+            // @Version 충돌: 트랜잭션 롤백됨 (restoreStock + markProcessed 모두 롤백)
+            // 다른 스레드가 동일 메시지를 이미 처리했을 수 있으므로 dedup 재확인
+            if (deduplicationService.isDuplicate(messageId)) {
+                log.info("[order.cancelled @Version 충돌 → 이미 처리됨, 스킵] messageId={}", messageId);
+            } else {
+                log.warn("[order.cancelled @Version 충돌 → 재시도] messageId={}", messageId);
+                throw e;
+            }
+        } catch (DataIntegrityViolationException e) {
+            log.warn("[order.cancelled dedup] UNIQUE 충돌로 스킵 — messageId={}", messageId);
+        } catch (Exception e) {
+            log.error("[order.cancelled 처리 실패] messageId={}", messageId, e);
+            throw e;
+        }
+
+        ack.acknowledge();
+    }
+
+    private UUID extractMessageId(Headers headers) {
+        Header header = headers.lastHeader("X-Message-Id");
+        if (header == null) {
+            throw new IllegalStateException("Kafka 헤더에 X-Message-Id가 없습니다");
+        }
+        return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8));
+    }
+}

--- a/event/src/test/java/com/devticket/event/application/OrderCancelledServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/OrderCancelledServiceTest.java
@@ -1,0 +1,206 @@
+package com.devticket.event.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.devticket.event.common.config.JacksonConfig;
+import com.devticket.event.domain.enums.EventCategory;
+import com.devticket.event.domain.enums.EventStatus;
+import com.devticket.event.domain.model.Event;
+import com.devticket.event.domain.repository.ProcessedMessageRepository;
+import com.devticket.event.infrastructure.persistence.EventRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import({OrderCancelledService.class, MessageDeduplicationService.class, JacksonConfig.class})
+class OrderCancelledServiceTest {
+
+    @Autowired
+    private OrderCancelledService orderCancelledService;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private ProcessedMessageRepository processedMessageRepository;
+
+    private Event testEvent;
+    private UUID eventId;
+
+    @BeforeEach
+    void setUp() {
+        processedMessageRepository.deleteAll();
+
+        testEvent = Event.create(
+            UUID.randomUUID(), "테스트 이벤트", "설명", "서울",
+            LocalDateTime.now().plusDays(15),
+            LocalDateTime.now().minusDays(1),
+            LocalDateTime.now().plusDays(10),
+            10000, 100, 5, EventCategory.CONFERENCE
+        );
+        ReflectionTestUtils.setField(testEvent, "remainingQuantity", 95);
+        testEvent = eventRepository.saveAndFlush(testEvent);
+        eventId = testEvent.getEventId();
+    }
+
+    private String buildPayload(UUID orderId, UUID targetEventId, int quantity) {
+        return """
+            {"orderId":"%s","userId":"%s","orderItems":[{"eventId":"%s","quantity":%d}],"reason":"만료","timestamp":"2026-04-24T10:00:00Z"}
+            """.formatted(orderId, UUID.randomUUID(), targetEventId, quantity).trim();
+    }
+
+    @Nested
+    @DisplayName("Happy Path")
+    class HappyPath {
+
+        @Test
+        @DisplayName("order.cancelled 수신 시 재고를 복구한다")
+        void restoreStock_success() {
+            UUID messageId = UUID.randomUUID();
+            String payload = buildPayload(UUID.randomUUID(), eventId, 5);
+
+            orderCancelledService.restoreStockForOrderCancelled(messageId, "order.cancelled", payload);
+
+            Event updated = eventRepository.findByEventId(eventId).orElseThrow();
+            assertThat(updated.getRemainingQuantity()).isEqualTo(100);
+            assertThat(processedMessageRepository.existsByMessageId(messageId.toString())).isTrue();
+        }
+
+        @Test
+        @DisplayName("다중 이벤트 재고를 한 트랜잭션에서 벌크 복구한다")
+        void restoreStock_bulk() {
+            Event event2 = Event.create(
+                UUID.randomUUID(), "이벤트2", "설명", "부산",
+                LocalDateTime.now().plusDays(15),
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(10),
+                10000, 50, 3, EventCategory.HACKATHON
+            );
+            ReflectionTestUtils.setField(event2, "remainingQuantity", 47);
+            event2 = eventRepository.saveAndFlush(event2);
+            UUID eventId2 = event2.getEventId();
+
+            UUID messageId = UUID.randomUUID();
+            String payload = """
+                {"orderId":"%s","userId":"%s","orderItems":[{"eventId":"%s","quantity":5},{"eventId":"%s","quantity":3}],"reason":"만료","timestamp":"2026-04-24T10:00:00Z"}
+                """.formatted(UUID.randomUUID(), UUID.randomUUID(), eventId, eventId2).trim();
+
+            orderCancelledService.restoreStockForOrderCancelled(messageId, "order.cancelled", payload);
+
+            assertThat(eventRepository.findByEventId(eventId).orElseThrow().getRemainingQuantity()).isEqualTo(100);
+            assertThat(eventRepository.findByEventId(eventId2).orElseThrow().getRemainingQuantity()).isEqualTo(50);
+        }
+
+        @Test
+        @DisplayName("SOLD_OUT 상태에서 재고 복구 시 ON_SALE로 전환된다")
+        void restoreStock_soldOutToOnSale() {
+            ReflectionTestUtils.setField(testEvent, "remainingQuantity", 0);
+            ReflectionTestUtils.setField(testEvent, "status", EventStatus.SOLD_OUT);
+            eventRepository.saveAndFlush(testEvent);
+
+            UUID messageId = UUID.randomUUID();
+            String payload = buildPayload(UUID.randomUUID(), eventId, 5);
+
+            orderCancelledService.restoreStockForOrderCancelled(messageId, "order.cancelled", payload);
+
+            Event updated = eventRepository.findByEventId(eventId).orElseThrow();
+            assertThat(updated.getRemainingQuantity()).isEqualTo(5);
+            assertThat(updated.getStatus()).isEqualTo(EventStatus.ON_SALE);
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 — Dedup")
+    class Idempotency {
+
+        @Test
+        @DisplayName("동일 messageId 재처리 시 재고가 이중 복구되지 않는다")
+        void dedup_skipsDuplicate() {
+            UUID messageId = UUID.randomUUID();
+            String payload = buildPayload(UUID.randomUUID(), eventId, 5);
+
+            orderCancelledService.restoreStockForOrderCancelled(messageId, "order.cancelled", payload);
+            orderCancelledService.restoreStockForOrderCancelled(messageId, "order.cancelled", payload);
+
+            Event updated = eventRepository.findByEventId(eventId).orElseThrow();
+            assertThat(updated.getRemainingQuantity()).isEqualTo(100);
+        }
+    }
+
+    @Nested
+    @DisplayName("정책적 스킵")
+    class PolicySkip {
+
+        @Test
+        @DisplayName("FORCE_CANCELLED 이벤트는 재고 복구를 스킵한다")
+        void skip_forceCancelled() {
+            ReflectionTestUtils.setField(testEvent, "status", EventStatus.FORCE_CANCELLED);
+            eventRepository.saveAndFlush(testEvent);
+
+            UUID messageId = UUID.randomUUID();
+            String payload = buildPayload(UUID.randomUUID(), eventId, 5);
+
+            orderCancelledService.restoreStockForOrderCancelled(messageId, "order.cancelled", payload);
+
+            Event updated = eventRepository.findByEventId(eventId).orElseThrow();
+            assertThat(updated.getRemainingQuantity()).isEqualTo(95);
+            assertThat(processedMessageRepository.existsByMessageId(messageId.toString())).isTrue();
+        }
+
+        @Test
+        @DisplayName("CANCELLED 이벤트는 재고 복구를 스킵한다")
+        void skip_cancelled() {
+            ReflectionTestUtils.setField(testEvent, "status", EventStatus.CANCELLED);
+            eventRepository.saveAndFlush(testEvent);
+
+            UUID messageId = UUID.randomUUID();
+            String payload = buildPayload(UUID.randomUUID(), eventId, 5);
+
+            orderCancelledService.restoreStockForOrderCancelled(messageId, "order.cancelled", payload);
+
+            Event updated = eventRepository.findByEventId(eventId).orElseThrow();
+            assertThat(updated.getRemainingQuantity()).isEqualTo(95);
+        }
+    }
+
+    @Nested
+    @DisplayName("에러 케이스")
+    class ErrorCases {
+
+        @Test
+        @DisplayName("존재하지 않는 eventId면 예외를 던진다")
+        void throwsOnMissingEvent() {
+            UUID messageId = UUID.randomUUID();
+            String payload = buildPayload(UUID.randomUUID(), UUID.randomUUID(), 5);
+
+            assertThatThrownBy(() ->
+                orderCancelledService.restoreStockForOrderCancelled(messageId, "order.cancelled", payload)
+            ).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Event not found");
+        }
+
+        @Test
+        @DisplayName("잘못된 JSON payload면 예외를 던진다")
+        void throwsOnInvalidPayload() {
+            UUID messageId = UUID.randomUUID();
+
+            assertThatThrownBy(() ->
+                orderCancelledService.restoreStockForOrderCancelled(messageId, "order.cancelled", "invalid json")
+            ).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("역직렬화 실패");
+        }
+    }
+}

--- a/event/src/test/java/com/devticket/event/integration/OrderCancelledKafkaIntegrationTest.java
+++ b/event/src/test/java/com/devticket/event/integration/OrderCancelledKafkaIntegrationTest.java
@@ -1,0 +1,249 @@
+package com.devticket.event.integration;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.devticket.event.common.config.ElasticsearchIndexInitializer;
+import com.devticket.event.common.messaging.KafkaTopics;
+import com.devticket.event.common.messaging.event.OrderCancelledEvent;
+import com.devticket.event.common.outbox.OutboxScheduler;
+import com.devticket.event.domain.enums.EventCategory;
+import com.devticket.event.domain.enums.EventStatus;
+import com.devticket.event.domain.model.Event;
+import com.devticket.event.domain.repository.ProcessedMessageRepository;
+import com.devticket.event.infrastructure.client.MemberClient;
+import com.devticket.event.infrastructure.client.OpenAiEmbeddingClient;
+import com.devticket.event.infrastructure.persistence.EventRepository;
+import com.devticket.event.infrastructure.search.EventSearchRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * 주문 취소 재고 복구 Kafka E2E 통합 테스트
+ *
+ * <p>EmbeddedKafka → OrderCancelledConsumer → OrderCancelledService → DB 전체 흐름 검증
+ *
+ * <p>외부 의존성(ES, MemberClient, OpenAI, OutboxScheduler)은 Mock으로 대체.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(
+    partitions = 1,
+    topics = {"order.cancelled"}
+)
+@TestPropertySource(properties = {
+    "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+    "spring.kafka.listener.ack-mode=manual",
+    "spring.kafka.consumer.enable-auto-commit=false",
+    "spring.kafka.consumer.auto-offset-reset=earliest"
+})
+class OrderCancelledKafkaIntegrationTest {
+
+    @Autowired private KafkaTemplate<String, String> kafkaTemplate;
+    @Autowired private EventRepository eventRepository;
+    @Autowired private ProcessedMessageRepository processedMessageRepository;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private EventSearchRepository eventSearchRepository;
+    @MockitoBean private MemberClient memberClient;
+    @MockitoBean private OpenAiEmbeddingClient openAiEmbeddingClient;
+    @MockitoBean private OutboxScheduler outboxScheduler;
+    @MockitoBean private ElasticsearchIndexInitializer elasticsearchIndexInitializer;
+
+    @BeforeEach
+    void setUp() {
+        processedMessageRepository.deleteAll();
+        eventRepository.deleteAll();
+    }
+
+    // =========================================================================
+    // 테스트 1: E2E — order.cancelled 수신 시 재고 복구 성공
+    //
+    // 공격: order.cancelled Kafka 메시지 수신
+    // 방어: findAllByEventIdInWithLock 비관적 락 → restoreStock → markProcessed
+    // 검증: remainingQuantity 증가 + processed_message 1건
+    // =========================================================================
+    @Test
+    @DisplayName("order.cancelled 수신 시 재고가 복구되고 processed_message가 저장된다")
+    void order_cancelled_수신시_재고_복구_및_processedMessage_저장() throws Exception {
+        // given
+        Event event = saveEvent(95, 100, EventStatus.ON_SALE);
+        UUID messageId = UUID.randomUUID();
+
+        // when
+        sendOrderCancelled(messageId, event.getEventId(), 5);
+
+        // then
+        await().atMost(10, SECONDS).untilAsserted(() -> {
+            Event saved = eventRepository.findByEventId(event.getEventId()).orElseThrow();
+            assertThat(saved.getRemainingQuantity()).isEqualTo(100);
+        });
+
+        assertThat(processedMessageRepository.existsByMessageId(messageId.toString())).isTrue();
+    }
+
+    // =========================================================================
+    // 테스트 2: E2E — SOLD_OUT 상태에서 재고 복구 시 ON_SALE로 전이
+    //
+    // 검증: remainingQuantity > 0 + status = ON_SALE
+    // =========================================================================
+    @Test
+    @DisplayName("SOLD_OUT 이벤트에 order.cancelled 수신 시 재고 복구 후 ON_SALE로 전이된다")
+    void SOLD_OUT_이벤트_order_cancelled_수신시_ON_SALE_전이() throws Exception {
+        // given
+        Event event = saveEvent(0, 100, EventStatus.SOLD_OUT);
+        UUID messageId = UUID.randomUUID();
+
+        // when
+        sendOrderCancelled(messageId, event.getEventId(), 3);
+
+        // then
+        await().atMost(10, SECONDS).untilAsserted(() -> {
+            Event saved = eventRepository.findByEventId(event.getEventId()).orElseThrow();
+            assertThat(saved.getRemainingQuantity()).isEqualTo(3);
+            assertThat(saved.getStatus()).isEqualTo(EventStatus.ON_SALE);
+        });
+    }
+
+    // =========================================================================
+    // 테스트 3: E2E — 동일 messageId로 두 번 전송 시 재고 1회만 복구
+    //
+    // 공격: 같은 X-Message-Id로 order.cancelled 메시지를 두 번 전송
+    // 방어: isDuplicate() → 첫 번째 처리 후 두 번째는 dedup 스킵
+    // 검증: 재고 1회만 복구 + processed_message 1건
+    // =========================================================================
+    @Test
+    @DisplayName("동일 X-Message-Id로 두 번 전송 시 재고는 1회만 복구된다")
+    void 동일_messageId_두번_전송__재고_1회만_복구() throws Exception {
+        // given
+        Event event = saveEvent(90, 100, EventStatus.ON_SALE);
+        UUID messageId = UUID.randomUUID();
+
+        // when — 첫 번째 전송
+        sendOrderCancelled(messageId, event.getEventId(), 5);
+
+        await().atMost(10, SECONDS).untilAsserted(() ->
+            assertThat(processedMessageRepository.existsByMessageId(messageId.toString())).isTrue()
+        );
+
+        // 두 번째 전송 — 같은 messageId
+        sendOrderCancelled(messageId, event.getEventId(), 5);
+
+        Thread.sleep(2000);
+
+        // then — 1회만 복구 (90 + 5 = 95, 이중 복구 시 100)
+        assertThat(eventRepository.findByEventId(event.getEventId()).orElseThrow()
+            .getRemainingQuantity()).isEqualTo(95);
+        assertThat(processedMessageRepository.count()).isEqualTo(1);
+    }
+
+    // =========================================================================
+    // 테스트 4: E2E — FORCE_CANCELLED 이벤트는 재고 복구 스킵
+    //
+    // 검증: remainingQuantity 불변 + processed_message는 저장됨 (처리 완료로 기록)
+    // =========================================================================
+    @Test
+    @DisplayName("FORCE_CANCELLED 이벤트에 order.cancelled 수신 시 재고 복구를 스킵한다")
+    void FORCE_CANCELLED_이벤트_order_cancelled_수신시_재고_복구_스킵() throws Exception {
+        // given
+        Event event = saveEvent(95, 100, EventStatus.FORCE_CANCELLED);
+        UUID messageId = UUID.randomUUID();
+
+        // when
+        sendOrderCancelled(messageId, event.getEventId(), 5);
+
+        // then — processed_message 저장 대기 (스킵이지만 처리 완료 기록됨)
+        await().atMost(10, SECONDS).untilAsserted(() ->
+            assertThat(processedMessageRepository.existsByMessageId(messageId.toString())).isTrue()
+        );
+
+        assertThat(eventRepository.findByEventId(event.getEventId()).orElseThrow()
+            .getRemainingQuantity()).isEqualTo(95);
+    }
+
+    // =========================================================================
+    // 테스트 5: E2E — X-Message-Id 헤더 누락 시 DB 상태 변화 없음
+    //
+    // 공격: X-Message-Id 헤더 없이 order.cancelled 전송
+    // 현재 동작: IllegalStateException → 에러 핸들러가 재시도 후 스킵
+    // 검증: DB 상태 변화 없음
+    // =========================================================================
+    @Test
+    @DisplayName("X-Message-Id 헤더 없이 order.cancelled 수신 시 DB 상태 변화 없이 스킵된다")
+    void X_Message_Id_헤더_누락시_DB_상태_변화_없음() throws Exception {
+        // given
+        Event event = saveEvent(95, 100, EventStatus.ON_SALE);
+        String payload = buildPayload(UUID.randomUUID(), event.getEventId(), 5);
+        ProducerRecord<String, String> record = new ProducerRecord<>(
+            KafkaTopics.ORDER_CANCELLED, null, UUID.randomUUID().toString(), payload
+        );
+        // X-Message-Id 헤더를 의도적으로 추가하지 않음
+
+        // when
+        kafkaTemplate.send(record).get(5, TimeUnit.SECONDS);
+
+        Thread.sleep(3000);
+
+        // then
+        assertThat(processedMessageRepository.count()).isEqualTo(0);
+        assertThat(eventRepository.findByEventId(event.getEventId()).orElseThrow()
+            .getRemainingQuantity()).isEqualTo(95);
+    }
+
+    // =========================================================================
+    // 픽스처 / 헬퍼
+    // =========================================================================
+
+    private Event saveEvent(int remainingQuantity, int totalQuantity, EventStatus status) {
+        Event event = Event.create(
+            UUID.randomUUID(), "테스트 이벤트", "설명", "서울",
+            LocalDateTime.now().plusDays(10),
+            LocalDateTime.now().minusDays(1),
+            LocalDateTime.now().plusDays(5),
+            50000, totalQuantity, 10, EventCategory.MEETUP
+        );
+        ReflectionTestUtils.setField(event, "remainingQuantity", remainingQuantity);
+        ReflectionTestUtils.setField(event, "status", status);
+        return eventRepository.save(event);
+    }
+
+    private void sendOrderCancelled(UUID messageId, UUID eventId, int quantity) throws Exception {
+        String payload = buildPayload(UUID.randomUUID(), eventId, quantity);
+        ProducerRecord<String, String> record = new ProducerRecord<>(
+            KafkaTopics.ORDER_CANCELLED, null, UUID.randomUUID().toString(), payload
+        );
+        record.headers().add("X-Message-Id", messageId.toString().getBytes(StandardCharsets.UTF_8));
+        kafkaTemplate.send(record).get(5, TimeUnit.SECONDS);
+    }
+
+    private String buildPayload(UUID orderId, UUID eventId, int quantity) {
+        OrderCancelledEvent event = new OrderCancelledEvent(
+            orderId, UUID.randomUUID(),
+            List.of(new OrderCancelledEvent.OrderItem(eventId, quantity)),
+            "만료", Instant.now()
+        );
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (Exception e) {
+            throw new RuntimeException("직렬화 실패", e);
+        }
+    }
+}

--- a/event/src/test/java/com/devticket/event/presentation/consumer/OrderCancelledConsumerTest.java
+++ b/event/src/test/java/com/devticket/event/presentation/consumer/OrderCancelledConsumerTest.java
@@ -1,0 +1,168 @@
+package com.devticket.event.presentation.consumer;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.devticket.event.application.MessageDeduplicationService;
+import com.devticket.event.application.OrderCancelledService;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+@ExtendWith(MockitoExtension.class)
+class OrderCancelledConsumerTest {
+
+    @InjectMocks
+    private OrderCancelledConsumer consumer;
+
+    @Mock
+    private OrderCancelledService orderCancelledService;
+
+    @Mock
+    private MessageDeduplicationService deduplicationService;
+
+    @Mock
+    private Acknowledgment ack;
+
+    private ConsumerRecord<String, String> createRecord(UUID messageId, String payload) {
+        RecordHeaders headers = new RecordHeaders();
+        headers.add("X-Message-Id", messageId.toString().getBytes(StandardCharsets.UTF_8));
+        return new ConsumerRecord<>("order.cancelled", 0, 0L, 0L,
+            TimestampType.CREATE_TIME, 0, payload.length(), null, payload,
+            headers, Optional.empty());
+    }
+
+    @Nested
+    @DisplayName("정상 처리")
+    class NormalProcessing {
+
+        @Test
+        @DisplayName("메시지 처리 성공 시 ACK한다")
+        void success_thenAck() {
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record = createRecord(messageId, "{}");
+            doNothing().when(orderCancelledService)
+                .restoreStockForOrderCancelled(any(), any(), any());
+
+            consumer.consume(record, ack);
+
+            verify(orderCancelledService).restoreStockForOrderCancelled(
+                eq(messageId), eq("order.cancelled"), eq("{}"));
+            verify(ack).acknowledge();
+        }
+    }
+
+    @Nested
+    @DisplayName("헤더 누락")
+    class MissingHeader {
+
+        @Test
+        @DisplayName("X-Message-Id 헤더가 없으면 예외를 던진다")
+        void noHeader_throwsException() {
+            RecordHeaders headers = new RecordHeaders();
+            ConsumerRecord<String, String> record = new ConsumerRecord<>(
+                "order.cancelled", 0, 0L, 0L, TimestampType.CREATE_TIME,
+                0, 2, null, "{}", headers, Optional.empty());
+
+            assertThatThrownBy(() -> consumer.consume(record, ack))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("X-Message-Id");
+
+            verify(ack, never()).acknowledge();
+        }
+    }
+
+    @Nested
+    @DisplayName("OptimisticLockException 처리")
+    class OptimisticLockHandling {
+
+        @Test
+        @DisplayName("@Version 충돌 + 이미 처리됨 → 스킵 + ACK")
+        void optimisticLock_alreadyProcessed_thenSkip() {
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record = createRecord(messageId, "{}");
+
+            doThrow(new ObjectOptimisticLockingFailureException("Event", messageId))
+                .when(orderCancelledService).restoreStockForOrderCancelled(any(), any(), any());
+            given(deduplicationService.isDuplicate(messageId)).willReturn(true);
+
+            consumer.consume(record, ack);
+
+            verify(ack).acknowledge();
+        }
+
+        @Test
+        @DisplayName("@Version 충돌 + 아직 미처리 → rethrow (재시도)")
+        void optimisticLock_notProcessed_thenRethrow() {
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record = createRecord(messageId, "{}");
+
+            doThrow(new ObjectOptimisticLockingFailureException("Event", messageId))
+                .when(orderCancelledService).restoreStockForOrderCancelled(any(), any(), any());
+            given(deduplicationService.isDuplicate(messageId)).willReturn(false);
+
+            assertThatThrownBy(() -> consumer.consume(record, ack))
+                .isInstanceOf(ObjectOptimisticLockingFailureException.class);
+
+            verify(ack, never()).acknowledge();
+        }
+    }
+
+    @Nested
+    @DisplayName("DataIntegrityViolation 처리")
+    class UniqueConstraintHandling {
+
+        @Test
+        @DisplayName("UNIQUE 충돌 → 스킵 + ACK")
+        void uniqueViolation_thenSkip() {
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record = createRecord(messageId, "{}");
+
+            doThrow(new DataIntegrityViolationException("unique constraint"))
+                .when(orderCancelledService).restoreStockForOrderCancelled(any(), any(), any());
+
+            consumer.consume(record, ack);
+
+            verify(ack).acknowledge();
+        }
+    }
+
+    @Nested
+    @DisplayName("기타 예외")
+    class OtherExceptions {
+
+        @Test
+        @DisplayName("예상치 못한 예외 → rethrow (재시도) + ACK 안 함")
+        void unexpectedException_thenRethrow() {
+            UUID messageId = UUID.randomUUID();
+            ConsumerRecord<String, String> record = createRecord(messageId, "{}");
+
+            doThrow(new RuntimeException("unexpected"))
+                .when(orderCancelledService).restoreStockForOrderCancelled(any(), any(), any());
+
+            assertThatThrownBy(() -> consumer.consume(record, ack))
+                .isInstanceOf(RuntimeException.class);
+
+            verify(ack, never()).acknowledge();
+        }
+    }
+}


### PR DESCRIPTION
#503 

## 배경

Commerce 서비스가 결제 전 주문 만료(타임아웃) 시 재고 복구 트리거 토픽을 `payment.failed` → `order.cancelled`로 변경함에 따라, Event 서비스에 `order.cancelled` 소비 경로를 신규 구현합니다.

기존 `payment.failed`는 **결제 실패** 시나리오 전용으로 유지되며, 결제 전 취소는 별도 토픽으로 분리됩니다.

## 변경 사항

### 신규 파일

| 파일 | 설명 |
|------|------|
| `common/messaging/event/OrderCancelledEvent.java` | `order.cancelled` 페이로드 DTO |
| `application/OrderCancelledService.java` | 재고 복구 비즈니스 로직 |
| `presentation/consumer/OrderCancelledConsumer.java` | Kafka 컨슈머 |

### 수정 파일

| 파일 | 변경 내용 |
|------|-----------|
| `common/messaging/KafkaTopics.java` | `ORDER_CANCELLED = "order.cancelled"` 상수 추가 |

### 신규 테스트 파일

| 파일 | 설명 |
|------|------|
| `test/.../application/OrderCancelledServiceTest.java` | 서비스 단위 테스트 (`@DataJpaTest`) |
| `test/.../consumer/OrderCancelledConsumerTest.java` | 컨슈머 단위 테스트 (Mockito) |
| `test/.../integration/OrderCancelledKafkaIntegrationTest.java` | E2E 통합 테스트 (EmbeddedKafka) |

## 구현 상세

### 처리 흐름

```
Kafka: order.cancelled
    → OrderCancelledConsumer.consume()
        → OrderCancelledService.restoreStockForOrderCancelled()
```

### OrderCancelledService

`StockRestoreService.restoreStockForPaymentFailed`와 동일한 처리 흐름을 따릅니다.

1. **Dedup 체크** — `MessageDeduplicationService.isDuplicate(messageId)`
2. **비관적 락 조회** — 데드락 방지를 위해 eventId 정렬 후 `findAllByEventIdInWithLock()`
3. **정책적 스킵** — 이벤트 상태가 `CANCELLED` / `FORCE_CANCELLED`이면 재고 복구 생략
4. **재고 복구** — `event.restoreStock(quantity)`
5. **Dedup 기록** — `markProcessed(messageId, topic)` (같은 트랜잭션)

`payment.failed` 로직과 처리 대상 DTO만 다르고 구조가 동일하여 `StockRestoreService`에 합치지 않고 별도 서비스로 분리했습니다.

### OrderCancelledConsumer 예외 처리

| 예외 | 처리 |
|------|------|
| `ObjectOptimisticLockingFailureException` | dedup 재확인 → 이미 처리됐으면 스킵, 아니면 rethrow |
| `DataIntegrityViolationException` | UNIQUE 충돌 → 스킵 |
| 그 외 | rethrow → Kafka 재전달 |

ACK는 정상 처리 또는 dedup 스킵 후에만 전송합니다.

## 테스트

### 신규 테스트 파일

| 파일 | 종류 | 설명 |
|------|------|------|
| `OrderCancelledServiceTest.java` | `@DataJpaTest` | 서비스 단위 테스트 |
| `OrderCancelledConsumerTest.java` | Mockito | 컨슈머 단위 테스트 |
| `OrderCancelledKafkaIntegrationTest.java` | `@SpringBootTest` + EmbeddedKafka | E2E 통합 테스트 |

### `OrderCancelledServiceTest` 케이스

| 케이스 | 검증 |
|--------|------|
| 재고 복구 성공 | remainingQuantity 증가 + processed_message 저장 |
| 다중 이벤트 벌크 복구 | 두 이벤트 모두 복구 |
| SOLD_OUT → ON_SALE 전이 | 재고 복구 후 상태 전이 |
| 동일 messageId 재처리 | 재고 이중 복구 없음 |
| FORCE_CANCELLED 정책 스킵 | 재고 불변, processed_message는 저장 |
| CANCELLED 정책 스킵 | 재고 불변 |
| 존재하지 않는 eventId | `IllegalStateException` |
| 잘못된 JSON payload | `IllegalArgumentException` |

### `OrderCancelledConsumerTest` 케이스

| 케이스 | 검증 |
|--------|------|
| 정상 처리 | ACK 전송, 서비스 메서드 호출 |
| X-Message-Id 헤더 누락 | `IllegalStateException`, ACK 없음 |
| @Version 충돌 + 이미 처리됨 | 스킵 + ACK |
| @Version 충돌 + 미처리 | rethrow, ACK 없음 |
| UNIQUE 충돌 | 스킵 + ACK |
| 기타 예외 | rethrow, ACK 없음 |

### `OrderCancelledKafkaIntegrationTest` 케이스

`PaymentFailedKafkaIntegrationTest`와 동일한 5개 시나리오를 `order.cancelled` 토픽으로 검증합니다.

| 케이스 | 검증 |
|--------|------|
| 재고 복구 성공 | remainingQuantity 증가 + processed_message 저장 |
| SOLD_OUT → ON_SALE 전이 | 상태 전이 확인 |
| 동일 messageId 두 번 전송 | 재고 1회만 복구 |
| FORCE_CANCELLED 정책 스킵 | 재고 불변, processed_message 저장 |
| X-Message-Id 헤더 누락 | DB 상태 변화 없음 |