### PR TITLE
[Payment] fix: 티켓 단건 환불이 OrderItem 전체 금액으로 환불되던 버그 수정

### DIFF
--- a/payment/src/main/java/com/devticket/payment/payment/application/dto/PgPaymentCancelCommand.java
+++ b/payment/src/main/java/com/devticket/payment/payment/application/dto/PgPaymentCancelCommand.java
@@ -3,6 +3,11 @@ package com.devticket.payment.payment.application.dto;
 public record PgPaymentCancelCommand(
     String paymentKey,
     int cancelAmount,
-    String cancelReason
+    String cancelReason,
+    String idempotencyKey
 ) {
+    // 편의 생성자 — 기존 호출부 호환 (idempotencyKey 없이)
+    public PgPaymentCancelCommand(String paymentKey, int cancelAmount, String cancelReason) {
+        this(paymentKey, cancelAmount, cancelReason, null);
+    }
 }

--- a/payment/src/main/java/com/devticket/payment/payment/infrastructure/external/PgPaymentClient.java
+++ b/payment/src/main/java/com/devticket/payment/payment/infrastructure/external/PgPaymentClient.java
@@ -222,6 +222,11 @@ public class PgPaymentClient {
         try {
             TossPaymentCancelResponse response = restClient.post()
                 .uri(CANCEL_PATH, command.paymentKey())
+                .headers(headers -> {
+                    if (command.idempotencyKey() != null && !command.idempotencyKey().isBlank()) {
+                        headers.set("Idempotency-Key", command.idempotencyKey());
+                    }
+                })
                 .body(request)
                 .retrieve()
                 .body(TossPaymentCancelResponse.class);

--- a/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
@@ -58,8 +58,7 @@ public class RefundSagaOrchestrator {
     private final WalletService walletService;
 
     /**
-     * Saga 진입점 — refund.requested 수신 또는 ticket.issue-failed 수신 시 호출.
-     * SagaState 생성 + refund.order.cancel 발행.
+     * Saga 진입점 — refund.requested 수신 또는 ticket.issue-failed 수신 시 호출. SagaState 생성 + refund.order.cancel 발행.
      */
     @Transactional
     public void start(RefundRequestedEvent event) {
@@ -84,9 +83,9 @@ public class RefundSagaOrchestrator {
         );
         outboxService.save(
             event.refundId().toString(),
-            KafkaTopics.REFUND_ORDER_CANCEL,
-            KafkaTopics.REFUND_ORDER_CANCEL,
             event.orderId().toString(),
+            KafkaTopics.REFUND_ORDER_CANCEL,
+            KafkaTopics.REFUND_ORDER_CANCEL,
             cancelEvent
         );
 
@@ -122,9 +121,9 @@ public class RefundSagaOrchestrator {
         );
         outboxService.save(
             event.refundId().toString(),
-            KafkaTopics.REFUND_TICKET_CANCEL,
-            KafkaTopics.REFUND_TICKET_CANCEL,
             event.orderId().toString(),
+            KafkaTopics.REFUND_TICKET_CANCEL,
+            KafkaTopics.REFUND_TICKET_CANCEL,
             next
         );
 
@@ -164,7 +163,7 @@ public class RefundSagaOrchestrator {
             return;
         }
 
-        // (1) cancelledTicketIds → ticketIds 로 필드명 변경
+        // (1) 원본 ticketIds 보존 — RefundTicket 테이블이 비어있고 이벤트에 ticketIds 가 있으면 upsert
         List<RefundTicket> existing = refundTicketRepository.findByRefundId(event.refundId());
         if (existing.isEmpty() && event.ticketIds() != null && !event.ticketIds().isEmpty()) {
             List<RefundTicket> rts = event.ticketIds().stream()
@@ -173,41 +172,47 @@ public class RefundSagaOrchestrator {
             refundTicketRepository.saveAll(rts);
         }
 
-        // (2) quantity 계산 — 우선순위: event.quantity > event.ticketIds.size > RefundTicket > ledger.remainingTickets
-        // whole-order 환불에서 Commerce 가 빈 ticketIds 를 보내도 재고가 0 으로 복구되지 않도록 보정.
-        int quantity;
-        if (event.quantity() > 0) {
-            quantity = event.quantity();
-        } else if (event.ticketIds() != null && !event.ticketIds().isEmpty()) {
-            quantity = event.ticketIds().size();
-        } else if (!existing.isEmpty()) {
-            quantity = existing.size();
+        // (2) items 정규화 — Commerce 가 (eventId, quantity) 배열을 묶어 보내므로 그대로 사용.
+        // 단 items 가 비어 있으면(마이그레이션·폴백) ledger.remainingTickets 기준으로 최소 1건을 추정.
+        List<RefundStockRestoreEvent.Item> stockItems;
+        if (event.items() != null && !event.items().isEmpty()) {
+            stockItems = event.items().stream()
+                .map(i -> new RefundStockRestoreEvent.Item(i.eventId(), i.quantity()))
+                .toList();
         } else {
-            quantity = orderRefundRepository.findByOrderId(event.orderId())
-                .map(OrderRefund::getRemainingTickets)
-                .orElse(0);
+            int fallbackQty = !existing.isEmpty()
+                ? existing.size()
+                : orderRefundRepository.findByOrderId(event.orderId())
+                    .map(OrderRefund::getRemainingTickets)
+                    .orElse(0);
+            stockItems = List.of(new RefundStockRestoreEvent.Item(null, fallbackQty));
         }
 
         state.advance(SagaStep.STOCK_RESTORING);
         sagaStateRepository.save(state);
 
-        // (3) RefundStockRestoreEvent 를 items 리스트 구조로 발행
+        // (3) partitionKey — 단일 이벤트면 eventId, 다중이면 orderId 로 고정해 순서 보장.
+        String partitionKey = stockItems.size() == 1 && stockItems.get(0).eventId() != null
+            ? stockItems.get(0).eventId().toString()
+            : event.orderId().toString();
+
         RefundStockRestoreEvent next = new RefundStockRestoreEvent(
             event.refundId(),
             event.orderId(),
-            List.of(new RefundStockRestoreEvent.Item(event.eventId(), quantity)),
+            stockItems,
             Instant.now()
         );
+
         outboxService.save(
             event.refundId().toString(),
+            partitionKey,
             KafkaTopics.REFUND_STOCK_RESTORE,
             KafkaTopics.REFUND_STOCK_RESTORE,
-            event.eventId() != null ? event.eventId().toString() : event.orderId().toString(),
             next
         );
 
-        log.info("[Saga] ticket.done → stock.restore 발행 — refundId={}, eventId={}, quantity={}",
-            event.refundId(), event.eventId(), quantity);
+        log.info("[Saga] ticket.done → stock.restore 발행 — refundId={}, items={}",
+            event.refundId(), stockItems);
     }
 
     @Transactional
@@ -233,9 +238,9 @@ public class RefundSagaOrchestrator {
         );
         outboxService.save(
             event.refundId().toString(),
-            KafkaTopics.REFUND_ORDER_COMPENSATE,
-            KafkaTopics.REFUND_ORDER_COMPENSATE,
             event.orderId().toString(),
+            KafkaTopics.REFUND_ORDER_COMPENSATE,
+            KafkaTopics.REFUND_ORDER_COMPENSATE,
             comp
         );
 
@@ -285,9 +290,9 @@ public class RefundSagaOrchestrator {
         );
         outboxService.save(
             event.refundId().toString(),
-            KafkaTopics.REFUND_TICKET_COMPENSATE,
-            KafkaTopics.REFUND_TICKET_COMPENSATE,
             event.orderId().toString(),
+            KafkaTopics.REFUND_TICKET_COMPENSATE,
+            KafkaTopics.REFUND_TICKET_COMPENSATE,
             ticketComp
         );
 
@@ -328,7 +333,8 @@ public class RefundSagaOrchestrator {
             case PG -> {
                 state.advance(SagaStep.PG_CANCELLING);
                 sagaStateRepository.save(state);
-                completedAt = executePgCancel(payment, refund.getRefundAmount(), completedAt);
+                completedAt = executePgCancel(payment, refund.getRefundAmount(),
+                    refund.getRefundId().toString(), completedAt);
             }
             case WALLET -> {
                 state.advance(SagaStep.WALLET_RESTORING);
@@ -347,7 +353,8 @@ public class RefundSagaOrchestrator {
                     : 0;
                 int pgPortion = refund.getRefundAmount() - walletPortion;
 
-                log.info("[Saga] WALLET_PG 분배 — refundId={}, total={}, walletPortion={}, pgPortion={} (원결제 wallet={}/pg={}/total={})",
+                log.info(
+                    "[Saga] WALLET_PG 분배 — refundId={}, total={}, walletPortion={}, pgPortion={} (원결제 wallet={}/pg={}/total={})",
                     refund.getRefundId(), refund.getRefundAmount(),
                     walletPortion, pgPortion,
                     walletOriginal, payment.getPgAmount(), totalPaid);
@@ -356,7 +363,8 @@ public class RefundSagaOrchestrator {
                 if (pgPortion > 0) {
                     state.advance(SagaStep.PG_CANCELLING);
                     sagaStateRepository.save(state);
-                    completedAt = executePgCancel(payment, pgPortion, completedAt);
+                    completedAt = executePgCancel(payment, pgPortion,
+                        refund.getRefundId().toString() + "-pg", completedAt);
                 }
 
                 // Wallet 복구 — walletPortion 만
@@ -397,9 +405,9 @@ public class RefundSagaOrchestrator {
 
         outboxService.save(
             refund.getRefundId().toString(),
-            KafkaTopics.REFUND_COMPLETED,
-            KafkaTopics.REFUND_COMPLETED,
             refund.getOrderId().toString(),
+            KafkaTopics.REFUND_COMPLETED,
+            KafkaTopics.REFUND_COMPLETED,
             completed
         );
 
@@ -407,20 +415,21 @@ public class RefundSagaOrchestrator {
             refund.getRefundId(), method, refund.getRefundAmount());
     }
 
-    private LocalDateTime executePgCancel(Payment payment, int amount, LocalDateTime fallback) {
+    private LocalDateTime executePgCancel(Payment payment, int amount, String idempotencyKey,
+        LocalDateTime fallback) {
         if (payment.getPaymentKey() == null || amount <= 0) {
             return fallback;
         }
         try {
             PgPaymentCancelResult result = pgPaymentClient.cancelPartial(
-                new PgPaymentCancelCommand(payment.getPaymentKey(), amount, "refund-saga")
+                new PgPaymentCancelCommand(payment.getPaymentKey(), amount, "refund-saga", idempotencyKey)
             );
             return result.canceledAt() != null
                 ? OffsetDateTime.parse(result.canceledAt()).toLocalDateTime()
                 : fallback;
         } catch (Exception e) {
-            log.error("[Saga] PG 취소 실패 — paymentKey={}, amount={}",
-                payment.getPaymentKey(), amount, e);
+            log.error("[Saga] PG 취소 실패 — paymentKey={}, amount={}, idemKey={}",
+                payment.getPaymentKey(), amount, idempotencyKey, e);
             throw new RefundException(RefundErrorCode.PG_REFUND_FAILED);
         }
     }

--- a/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
@@ -182,9 +182,11 @@ public class RefundSagaOrchestrator {
         } else {
             int fallbackQty = !existing.isEmpty()
                 ? existing.size()
-                : orderRefundRepository.findByOrderId(event.orderId())
-                    .map(OrderRefund::getRemainingTickets)
-                    .orElse(0);
+                : (event.ticketIds() != null && !event.ticketIds().isEmpty())
+                    ? event.ticketIds().size()
+                    : orderRefundRepository.findByOrderId(event.orderId())
+                        .map(OrderRefund::getRemainingTickets)
+                        .orElse(0);
             stockItems = List.of(new RefundStockRestoreEvent.Item(null, fallbackQty));
         }
 
@@ -304,9 +306,9 @@ public class RefundSagaOrchestrator {
         );
         outboxService.save(
             event.refundId().toString(),
-            KafkaTopics.REFUND_ORDER_COMPENSATE,
-            KafkaTopics.REFUND_ORDER_COMPENSATE,
             event.orderId().toString(),
+            KafkaTopics.REFUND_ORDER_COMPENSATE,
+            KafkaTopics.REFUND_ORDER_COMPENSATE,
             orderComp
         );
 

--- a/payment/src/main/java/com/devticket/payment/refund/application/saga/event/RefundTicketDoneEvent.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/saga/event/RefundTicketDoneEvent.java
@@ -8,7 +8,8 @@ public record RefundTicketDoneEvent(
     UUID refundId,
     UUID orderId,
     List<UUID> ticketIds,
-    UUID eventId,
-    int quantity,
+    List<Item> items,
     Instant timestamp
-) {}
+) {
+    public record Item(UUID eventId, int quantity) {}
+}

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
@@ -159,9 +159,9 @@ public class RefundServiceImpl implements RefundService {
         );
         outboxService.save(
             refund.getRefundId().toString(),
-            KafkaTopics.REFUND_REQUESTED,
-            KafkaTopics.REFUND_REQUESTED,
             orderItem.orderId().toString(),
+            KafkaTopics.REFUND_REQUESTED,
+            KafkaTopics.REFUND_REQUESTED,
             requested
         );
 
@@ -248,9 +248,9 @@ public class RefundServiceImpl implements RefundService {
         );
         outboxService.save(
             refund.getRefundId().toString(),
-            KafkaTopics.REFUND_REQUESTED,
-            KafkaTopics.REFUND_REQUESTED,
             orderId.toString(),
+            KafkaTopics.REFUND_REQUESTED,
+            KafkaTopics.REFUND_REQUESTED,
             requested
         );
 

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/TicketIssueFailedHandler.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/TicketIssueFailedHandler.java
@@ -96,9 +96,9 @@ public class TicketIssueFailedHandler {
 
         outboxService.save(
             refund.getRefundId().toString(),
-            KafkaTopics.REFUND_REQUESTED,
-            KafkaTopics.REFUND_REQUESTED,
             event.orderId().toString(),
+            KafkaTopics.REFUND_REQUESTED,
+            KafkaTopics.REFUND_REQUESTED,
             requested
         );
 

--- a/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
@@ -235,6 +235,38 @@ class RefundSagaOrchestratorTest {
                 any()
             );
         }
+
+        @Test
+        @DisplayName("items 비어있으면 ticketIds 개수를 폴백 수량으로 사용")
+        void items_비어있으면_ticketIds_개수_폴백() {
+            given(sagaStateRepository.findByRefundId(refundId))
+                .willReturn(Optional.of(state(SagaStep.TICKET_CANCELLING)));
+            given(refundTicketRepository.findByRefundId(refundId)).willReturn(List.of());
+
+            RefundTicketDoneEvent event = new RefundTicketDoneEvent(
+                refundId, orderId,
+                List.of(UUID.randomUUID()),
+                List.of(),
+                Instant.now()
+            );
+
+            orchestrator.onTicketDone(event);
+
+            ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+            verify(outboxService).save(
+                eq(refundId.toString()),
+                eq(orderId.toString()),
+                eq(KafkaTopics.REFUND_STOCK_RESTORE),
+                eq(KafkaTopics.REFUND_STOCK_RESTORE),
+                captor.capture()
+            );
+
+            RefundStockRestoreEvent published = (RefundStockRestoreEvent) captor.getValue();
+            assertThat(published.items()).hasSize(1);
+            assertThat(published.items().get(0).eventId()).isNull();
+            assertThat(published.items().get(0).quantity()).isEqualTo(1);
+            verify(orderRefundRepository, never()).findByOrderId(orderId);
+        }
     }
 
     @Nested

--- a/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 
 import com.devticket.payment.common.messaging.KafkaTopics;
 import com.devticket.payment.common.outbox.OutboxService;
+import com.devticket.payment.payment.application.dto.PgPaymentCancelCommand;
 import com.devticket.payment.payment.application.dto.PgPaymentCancelResult;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.model.Payment;
@@ -20,6 +21,7 @@ import com.devticket.payment.refund.application.saga.event.RefundOrderFailedEven
 import com.devticket.payment.refund.application.saga.event.RefundRequestedEvent;
 import com.devticket.payment.refund.application.saga.event.RefundStockDoneEvent;
 import com.devticket.payment.refund.application.saga.event.RefundStockFailedEvent;
+import com.devticket.payment.refund.application.saga.event.RefundStockRestoreEvent;
 import com.devticket.payment.refund.application.saga.event.RefundTicketDoneEvent;
 import com.devticket.payment.refund.application.saga.event.RefundTicketFailedEvent;
 import com.devticket.payment.refund.domain.enums.OrderRefundStatus;
@@ -43,6 +45,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -50,16 +53,25 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class RefundSagaOrchestratorTest {
 
-    @Mock SagaStateRepository sagaStateRepository;
-    @Mock RefundRepository refundRepository;
-    @Mock OrderRefundRepository orderRefundRepository;
-    @Mock RefundTicketRepository refundTicketRepository;
-    @Mock PaymentRepository paymentRepository;
-    @Mock OutboxService outboxService;
-    @Mock PgPaymentClient pgPaymentClient;
-    @Mock WalletService walletService;
+    @Mock
+    SagaStateRepository sagaStateRepository;
+    @Mock
+    RefundRepository refundRepository;
+    @Mock
+    OrderRefundRepository orderRefundRepository;
+    @Mock
+    RefundTicketRepository refundTicketRepository;
+    @Mock
+    PaymentRepository paymentRepository;
+    @Mock
+    OutboxService outboxService;
+    @Mock
+    PgPaymentClient pgPaymentClient;
+    @Mock
+    WalletService walletService;
 
-    @InjectMocks RefundSagaOrchestrator orchestrator;
+    @InjectMocks
+    RefundSagaOrchestrator orchestrator;
 
     private UUID refundId;
     private UUID orderId;
@@ -100,9 +112,9 @@ class RefundSagaOrchestratorTest {
             verify(sagaStateRepository).save(any(SagaState.class));
             verify(outboxService).save(
                 eq(refundId.toString()),
-                eq(KafkaTopics.REFUND_ORDER_CANCEL),
-                eq(KafkaTopics.REFUND_ORDER_CANCEL),
                 eq(orderId.toString()),
+                eq(KafkaTopics.REFUND_ORDER_CANCEL),
+                eq(KafkaTopics.REFUND_ORDER_CANCEL),
                 any()
             );
         }
@@ -137,9 +149,9 @@ class RefundSagaOrchestratorTest {
 
             verify(outboxService).save(
                 eq(refundId.toString()),
-                eq(KafkaTopics.REFUND_TICKET_CANCEL),
-                eq(KafkaTopics.REFUND_TICKET_CANCEL),
                 eq(orderId.toString()),
+                eq(KafkaTopics.REFUND_TICKET_CANCEL),
+                eq(KafkaTopics.REFUND_TICKET_CANCEL),
                 any()
             );
         }
@@ -153,6 +165,75 @@ class RefundSagaOrchestratorTest {
             orchestrator.onOrderDone(new RefundOrderDoneEvent(refundId, orderId, Instant.now()));
 
             verify(outboxService, never()).save(any(), any(), any(), any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("onTicketDone — items 전파")
+    class OnTicketDoneTest {
+
+        @Test
+        @DisplayName("다중 이벤트 items — stock.restore 도 동일한 items 로 1건 발행")
+        void 다중_이벤트_items_전파() {
+            given(sagaStateRepository.findByRefundId(refundId))
+                .willReturn(Optional.of(state(SagaStep.TICKET_CANCELLING)));
+            given(refundTicketRepository.findByRefundId(refundId)).willReturn(List.of());
+
+            UUID eventA = UUID.randomUUID();
+            UUID eventB = UUID.randomUUID();
+            RefundTicketDoneEvent event = new RefundTicketDoneEvent(
+                refundId, orderId,
+                List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()),
+                List.of(
+                    new RefundTicketDoneEvent.Item(eventA, 2),
+                    new RefundTicketDoneEvent.Item(eventB, 1)
+                ),
+                Instant.now()
+            );
+
+            orchestrator.onTicketDone(event);
+
+            ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+            verify(outboxService).save(
+                eq(refundId.toString()),
+                eq(orderId.toString()),
+                eq(KafkaTopics.REFUND_STOCK_RESTORE),
+                eq(KafkaTopics.REFUND_STOCK_RESTORE),
+                captor.capture()
+            );
+            RefundStockRestoreEvent published = (RefundStockRestoreEvent) captor.getValue();
+            assertThat(published.items()).hasSize(2);
+            assertThat(published.items())
+                .extracting(RefundStockRestoreEvent.Item::eventId)
+                .containsExactlyInAnyOrder(eventA, eventB);
+            assertThat(published.items())
+                .extracting(RefundStockRestoreEvent.Item::quantity)
+                .containsExactlyInAnyOrder(2, 1);
+        }
+
+        @Test
+        @DisplayName("단일 이벤트 — partitionKey=eventId 로 발행")
+        void 단일_이벤트_partitionKey_eventId() {
+            given(sagaStateRepository.findByRefundId(refundId))
+                .willReturn(Optional.of(state(SagaStep.TICKET_CANCELLING)));
+            given(refundTicketRepository.findByRefundId(refundId)).willReturn(List.of());
+
+            UUID eventA = UUID.randomUUID();
+            RefundTicketDoneEvent event = new RefundTicketDoneEvent(
+                refundId, orderId, List.of(UUID.randomUUID()),
+                List.of(new RefundTicketDoneEvent.Item(eventA, 1)),
+                Instant.now()
+            );
+
+            orchestrator.onTicketDone(event);
+
+            verify(outboxService).save(
+                eq(refundId.toString()),
+                eq(eventA.toString()),
+                eq(KafkaTopics.REFUND_STOCK_RESTORE),
+                eq(KafkaTopics.REFUND_STOCK_RESTORE),
+                any()
+            );
         }
     }
 
@@ -193,9 +274,9 @@ class RefundSagaOrchestratorTest {
             assertThat(st.getStatus()).isEqualTo(SagaStatus.COMPENSATING);
             verify(outboxService).save(
                 eq(refundId.toString()),
-                eq(KafkaTopics.REFUND_ORDER_COMPENSATE),
-                eq(KafkaTopics.REFUND_ORDER_COMPENSATE),
                 eq(orderId.toString()),
+                eq(KafkaTopics.REFUND_ORDER_COMPENSATE),
+                eq(KafkaTopics.REFUND_ORDER_COMPENSATE),
                 any()
             );
         }
@@ -218,9 +299,11 @@ class RefundSagaOrchestratorTest {
 
             assertThat(st.getStatus()).isEqualTo(SagaStatus.COMPENSATING);
             verify(outboxService).save(
-                any(), eq(KafkaTopics.REFUND_TICKET_COMPENSATE), any(), any(), any());
+                any(), any(), eq(KafkaTopics.REFUND_TICKET_COMPENSATE),
+                eq(KafkaTopics.REFUND_TICKET_COMPENSATE), any());
             verify(outboxService).save(
-                any(), eq(KafkaTopics.REFUND_ORDER_COMPENSATE), any(), any(), any());
+                any(), any(), eq(KafkaTopics.REFUND_ORDER_COMPENSATE),
+                eq(KafkaTopics.REFUND_ORDER_COMPENSATE), any());
         }
     }
 
@@ -247,13 +330,14 @@ class RefundSagaOrchestratorTest {
             verify(walletService).restoreBalance(eq(userId), eq(10_000), any(UUID.class), eq(orderId));
             verify(pgPaymentClient, never()).cancelPartial(any());
             verify(outboxService).save(
-                any(), eq(KafkaTopics.REFUND_COMPLETED), any(), any(), any());
+                any(), any(), eq(KafkaTopics.REFUND_COMPLETED),
+                eq(KafkaTopics.REFUND_COMPLETED), any());
             assertThat(st.getStatus()).isEqualTo(SagaStatus.COMPLETED);
             assertThat(ledger.getRefundedAmount()).isEqualTo(10_000);
         }
 
         @Test
-        @DisplayName("PG — pgPaymentClient.cancelPartial 호출 + refund.completed 발행")
+        @DisplayName("PG — pgPaymentClient.cancelPartial 호출 + refund.completed 발행 + Idempotency-Key=refundId")
         void PG_분기() {
             SagaState st = SagaState.create(refundId, orderId, PaymentMethod.PG, SagaStep.STOCK_RESTORING);
             given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.of(st));
@@ -270,14 +354,17 @@ class RefundSagaOrchestratorTest {
 
             orchestrator.onStockDone(new RefundStockDoneEvent(refundId, orderId, Instant.now()));
 
-            verify(pgPaymentClient, atLeastOnce()).cancelPartial(any());
+            ArgumentCaptor<PgPaymentCancelCommand> cmd = ArgumentCaptor.forClass(PgPaymentCancelCommand.class);
+            verify(pgPaymentClient, atLeastOnce()).cancelPartial(cmd.capture());
+            assertThat(cmd.getValue().idempotencyKey()).isEqualTo(refund.getRefundId().toString());
             verify(walletService, never()).restoreBalance(any(), anyInt(), any(), any());
-            verify(outboxService).save(any(), eq(KafkaTopics.REFUND_COMPLETED), any(), any(), any());
+            verify(outboxService).save(any(), any(), eq(KafkaTopics.REFUND_COMPLETED),
+                eq(KafkaTopics.REFUND_COMPLETED), any());
             assertThat(st.getStatus()).isEqualTo(SagaStatus.COMPLETED);
         }
 
         @Test
-        @DisplayName("WALLET_PG — PG 취소 + Wallet 복구 둘 다 호출")
+        @DisplayName("WALLET_PG — PG 취소(Idempotency-Key=refundId-pg) + Wallet 복구 둘 다 호출")
         void WALLET_PG_분기() {
             SagaState st = SagaState.create(refundId, orderId, PaymentMethod.WALLET_PG, SagaStep.STOCK_RESTORING);
             given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.of(st));
@@ -294,9 +381,157 @@ class RefundSagaOrchestratorTest {
 
             orchestrator.onStockDone(new RefundStockDoneEvent(refundId, orderId, Instant.now()));
 
-            verify(pgPaymentClient, atLeastOnce()).cancelPartial(any());
+            ArgumentCaptor<PgPaymentCancelCommand> cmd = ArgumentCaptor.forClass(PgPaymentCancelCommand.class);
+            verify(pgPaymentClient, atLeastOnce()).cancelPartial(cmd.capture());
+            assertThat(cmd.getValue().idempotencyKey())
+                .isEqualTo(refund.getRefundId().toString() + "-pg");
             verify(walletService).restoreBalance(eq(userId), anyInt(), any(UUID.class), eq(orderId));
             assertThat(st.getStatus()).isEqualTo(SagaStatus.COMPLETED);
+        }
+    }
+
+    @Nested
+    @DisplayName("WALLET_PG 분할 정밀도 — pgPortion + walletPortion == refundAmount 항등")
+    class WalletPgPrecision {
+
+        @Test
+        @DisplayName("균등 분할 — total=10000, wallet=3000, pg=7000, refund=10000 → wallet=3000, pg=7000")
+        void 전액_환불_균등_분할() {
+            assertSplit(10_000, 3_000, 7_000, 10_000, 3_000, 7_000);
+        }
+
+        @Test
+        @DisplayName("정수 나눗셈 오차 — refund=7777 → wallet=2333, pg=5444 (합=7777)")
+        void 정수_나눗셈_오차_없음() {
+            // (7777 * 3000) / 10000 = 23_331_000 / 10000 = 2333 (int)
+            // pg = 7777 - 2333 = 5444
+            assertSplit(10_000, 3_000, 7_000, 7_777, 2_333, 5_444);
+        }
+
+        @Test
+        @DisplayName("1원 부분환불 — refund=1 → wallet=0 (비율 0.3 절삭), pg=1 (wallet 호출 안 됨)")
+        void 최소금액_환불() {
+            // 0원 분기는 호출 스킵되는 걸 검증
+            SagaState st = SagaState.create(refundId, orderId, PaymentMethod.WALLET_PG, SagaStep.STOCK_RESTORING);
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.of(st));
+            Refund refund = refundWith(1);
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.of(refund));
+            Payment payment = walletPgPayment(10_000, 3_000, 7_000);
+            given(paymentRepository.findByPaymentId(any())).willReturn(Optional.of(payment));
+            given(orderRefundRepository.findByOrderId(orderId))
+                .willReturn(Optional.of(ledgerWith(10_000, 1)));
+            given(refundTicketRepository.findByRefundId(any()))
+                .willReturn(List.of(RefundTicket.of(UUID.randomUUID(), UUID.randomUUID())));
+            given(pgPaymentClient.cancelPartial(any()))
+                .willReturn(new PgPaymentCancelResult("pk", 1, 1, "2025-04-01T12:00:00+09:00"));
+
+            orchestrator.onStockDone(new RefundStockDoneEvent(refundId, orderId, Instant.now()));
+
+            ArgumentCaptor<PgPaymentCancelCommand> cmd = ArgumentCaptor.forClass(PgPaymentCancelCommand.class);
+            verify(pgPaymentClient).cancelPartial(cmd.capture());
+            assertThat(cmd.getValue().cancelAmount()).isEqualTo(1);
+            // walletPortion=0 이므로 walletService 호출 없음
+            verify(walletService, never()).restoreBalance(any(), anyInt(), any(), any());
+        }
+
+        @Test
+        @DisplayName("wallet=0 원결제 — refund 전액 PG 처리, walletService 호출 안 됨")
+        void wallet_0_전액_PG() {
+            SagaState st = SagaState.create(refundId, orderId, PaymentMethod.WALLET_PG, SagaStep.STOCK_RESTORING);
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.of(st));
+            Refund refund = refundWith(5_000);
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.of(refund));
+            Payment payment = walletPgPayment(10_000, 0, 10_000); // wallet=0 인 WALLET_PG
+            given(paymentRepository.findByPaymentId(any())).willReturn(Optional.of(payment));
+            given(orderRefundRepository.findByOrderId(orderId))
+                .willReturn(Optional.of(ledgerWith(10_000, 1)));
+            given(refundTicketRepository.findByRefundId(any()))
+                .willReturn(List.of(RefundTicket.of(UUID.randomUUID(), UUID.randomUUID())));
+            given(pgPaymentClient.cancelPartial(any()))
+                .willReturn(new PgPaymentCancelResult("pk", 5_000, 5_000, "2025-04-01T12:00:00+09:00"));
+
+            orchestrator.onStockDone(new RefundStockDoneEvent(refundId, orderId, Instant.now()));
+
+            ArgumentCaptor<PgPaymentCancelCommand> cmd = ArgumentCaptor.forClass(PgPaymentCancelCommand.class);
+            verify(pgPaymentClient).cancelPartial(cmd.capture());
+            assertThat(cmd.getValue().cancelAmount()).isEqualTo(5_000);
+            verify(walletService, never()).restoreBalance(any(), anyInt(), any(), any());
+        }
+
+        @Test
+        @DisplayName("pg=0 원결제 — refund 전액 Wallet 복구, pgPaymentClient 호출 안 됨")
+        void pg_0_전액_Wallet() {
+            SagaState st = SagaState.create(refundId, orderId, PaymentMethod.WALLET_PG, SagaStep.STOCK_RESTORING);
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.of(st));
+            Refund refund = refundWith(5_000);
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.of(refund));
+            Payment payment = walletPgPayment(10_000, 10_000, 0); // pg=0 인 WALLET_PG
+            given(paymentRepository.findByPaymentId(any())).willReturn(Optional.of(payment));
+            given(orderRefundRepository.findByOrderId(orderId))
+                .willReturn(Optional.of(ledgerWith(10_000, 1)));
+            given(refundTicketRepository.findByRefundId(any()))
+                .willReturn(List.of(RefundTicket.of(UUID.randomUUID(), UUID.randomUUID())));
+
+            orchestrator.onStockDone(new RefundStockDoneEvent(refundId, orderId, Instant.now()));
+
+            verify(walletService).restoreBalance(eq(userId), eq(5_000), any(UUID.class), eq(orderId));
+            verify(pgPaymentClient, never()).cancelPartial(any());
+        }
+
+        @Test
+        @DisplayName("부분 환불 누적 — wallet/pg 각각 합이 refundAmount 와 동일")
+        void 부분환불_누적시_합계_일치() {
+            // 30_000 결제 (wallet=9_000/30%, pg=21_000/70%), 세 번 부분환불 (10_000, 10_000, 10_000)
+            int[] sums = {0, 0}; // [walletSum, pgSum]
+            for (int i = 0; i < 3; i++) {
+                int[] portions = splitAmountsFor(30_000, 9_000, 10_000);
+                sums[0] += portions[0];
+                sums[1] += portions[1];
+            }
+            // 누적 wallet = 3000 * 3 = 9000, 누적 pg = 7000 * 3 = 21_000, 합 = 30_000
+            assertThat(sums[0]).isEqualTo(9_000);
+            assertThat(sums[1]).isEqualTo(21_000);
+            assertThat(sums[0] + sums[1]).isEqualTo(30_000);
+        }
+
+        private void assertSplit(int total, int walletOriginal, int pgOriginal,
+            int refundAmount, int expectedWallet, int expectedPg) {
+            SagaState st = SagaState.create(refundId, orderId, PaymentMethod.WALLET_PG, SagaStep.STOCK_RESTORING);
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.of(st));
+            Refund refund = refundWith(refundAmount);
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.of(refund));
+            Payment payment = walletPgPayment(total, walletOriginal, pgOriginal);
+            given(paymentRepository.findByPaymentId(any())).willReturn(Optional.of(payment));
+            given(orderRefundRepository.findByOrderId(orderId))
+                .willReturn(Optional.of(ledgerWith(total, 1)));
+            given(refundTicketRepository.findByRefundId(any()))
+                .willReturn(List.of(RefundTicket.of(UUID.randomUUID(), UUID.randomUUID())));
+            given(pgPaymentClient.cancelPartial(any()))
+                .willReturn(new PgPaymentCancelResult("pk", expectedPg, expectedPg, "2025-04-01T12:00:00+09:00"));
+
+            orchestrator.onStockDone(new RefundStockDoneEvent(refundId, orderId, Instant.now()));
+
+            if (expectedPg > 0) {
+                ArgumentCaptor<PgPaymentCancelCommand> cmd = ArgumentCaptor.forClass(PgPaymentCancelCommand.class);
+                verify(pgPaymentClient).cancelPartial(cmd.capture());
+                assertThat(cmd.getValue().cancelAmount()).isEqualTo(expectedPg);
+            } else {
+                verify(pgPaymentClient, never()).cancelPartial(any());
+            }
+            if (expectedWallet > 0) {
+                verify(walletService).restoreBalance(eq(userId), eq(expectedWallet), any(UUID.class), eq(orderId));
+            } else {
+                verify(walletService, never()).restoreBalance(any(), anyInt(), any(), any());
+            }
+            assertThat(expectedWallet + expectedPg)
+                .as("wallet + pg 합은 refundAmount 와 항등")
+                .isEqualTo(refundAmount);
+        }
+
+        private int[] splitAmountsFor(int total, int walletOriginal, int refundAmount) {
+            int walletPortion = total > 0 ? (int) ((long) refundAmount * walletOriginal / total) : 0;
+            int pgPortion = refundAmount - walletPortion;
+            return new int[]{walletPortion, pgPortion};
         }
     }
 
@@ -324,5 +559,19 @@ class RefundSagaOrchestratorTest {
         Payment payment = Payment.create(orderId, userId, PaymentMethod.WALLET_PG, 10_000, 3_000, 7_000);
         payment.approve("pk-test");
         return payment;
+    }
+
+    private Refund refundWith(int amount) {
+        return Refund.create(orderId, paymentId, userId, amount, 100);
+    }
+
+    private Payment walletPgPayment(int total, int walletAmount, int pgAmount) {
+        Payment payment = Payment.create(orderId, userId, PaymentMethod.WALLET_PG, total, walletAmount, pgAmount);
+        payment.approve("pk-test");
+        return payment;
+    }
+
+    private OrderRefund ledgerWith(int totalAmount, int totalTickets) {
+        return OrderRefund.create(orderId, userId, paymentId, PaymentMethod.WALLET_PG, totalAmount, totalTickets);
     }
 }

--- a/payment/src/test/java/com/devticket/payment/refund/application/service/RefundServiceImplSagaTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/application/service/RefundServiceImplSagaTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.devticket.payment.common.messaging.KafkaTopics;
@@ -36,8 +37,10 @@ import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -45,15 +48,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class RefundServiceImplSagaTest {
 
-    @Mock CommerceInternalClient commerceInternalClient;
-    @Mock EventInternalClient eventInternalClient;
-    @Mock PaymentRepository paymentRepository;
-    @Mock RefundRepository refundRepository;
-    @Mock OrderRefundRepository orderRefundRepository;
-    @Mock RefundTicketRepository refundTicketRepository;
-    @Mock OutboxService outboxService;
+    @Mock
+    CommerceInternalClient commerceInternalClient;
+    @Mock
+    EventInternalClient eventInternalClient;
+    @Mock
+    PaymentRepository paymentRepository;
+    @Mock
+    RefundRepository refundRepository;
+    @Mock
+    OrderRefundRepository orderRefundRepository;
+    @Mock
+    RefundTicketRepository refundTicketRepository;
+    @Mock
+    OutboxService outboxService;
 
-    @InjectMocks RefundServiceImpl service;
+    @InjectMocks
+    RefundServiceImpl service;
 
     private UUID userId;
     private UUID orderId;
@@ -90,7 +101,8 @@ class RefundServiceImplSagaTest {
                 List.of(new InternalOrderInfoResponse.OrderItem(eventId, 1)))
         );
 
-        PgRefundResponse resp = service.refundPgTicket(userId, ticketId.toString(), new PgRefundRequest("change-of-mind"));
+        PgRefundResponse resp = service.refundPgTicket(userId, ticketId.toString(),
+            new PgRefundRequest("change-of-mind"));
 
         assertThat(resp.refundStatus()).isEqualTo("REQUESTED");
         verify(orderRefundRepository).save(any(OrderRefund.class));
@@ -98,9 +110,9 @@ class RefundServiceImplSagaTest {
         verify(refundTicketRepository).save(any(RefundTicket.class));
         verify(outboxService).save(
             anyString(),
-            eq(KafkaTopics.REFUND_REQUESTED),
-            eq(KafkaTopics.REFUND_REQUESTED),
             eq(orderId.toString()),
+            eq(KafkaTopics.REFUND_REQUESTED),
+            eq(KafkaTopics.REFUND_REQUESTED),
             any(RefundRequestedEvent.class)
         );
     }
@@ -164,9 +176,9 @@ class RefundServiceImplSagaTest {
         assertThat(resp.refundStatus()).isEqualTo("REQUESTED");
         verify(outboxService).save(
             anyString(),
-            eq(KafkaTopics.REFUND_REQUESTED),
-            eq(KafkaTopics.REFUND_REQUESTED),
             eq(orderId.toString()),
+            eq(KafkaTopics.REFUND_REQUESTED),
+            eq(KafkaTopics.REFUND_REQUESTED),
             any(RefundRequestedEvent.class)
         );
     }
@@ -205,13 +217,213 @@ class RefundServiceImplSagaTest {
         return p;
     }
 
+    private Payment walletPgPayment(int total, int walletAmount, int pgAmount) {
+        Payment p = Payment.create(orderId, userId, PaymentMethod.WALLET_PG, total, walletAmount, pgAmount);
+        p.approve("pk-test");
+        return p;
+    }
+
     private InternalEventInfoResponse futureEvent(int daysAhead) {
+        return futureEventFor(eventId, daysAhead);
+    }
+
+    private InternalEventInfoResponse futureEventFor(UUID eid, int daysAhead) {
         LocalDateTime eventDate = LocalDateTime.now().plusDays(daysAhead);
         return new InternalEventInfoResponse(
-            eventId, UUID.randomUUID(), "Test Event", 10_000, "ON_SALE",
+            eid, UUID.randomUUID(), "Test Event", 10_000, "ON_SALE",
             "MUSIC", 100, 1, 50,
             eventDate.toString(), LocalDateTime.now().minusDays(1).toString(),
             eventDate.toString()
         );
+    }
+
+    private InternalEventInfoResponse futureEventOwnedBy(UUID eid, UUID sellerId, int daysAhead) {
+        LocalDateTime eventDate = LocalDateTime.now().plusDays(daysAhead);
+        return new InternalEventInfoResponse(
+            eid, sellerId, "Test Event", 10_000, "ON_SALE",
+            "MUSIC", 100, 1, 50,
+            eventDate.toString(), LocalDateTime.now().minusDays(1).toString(),
+            eventDate.toString()
+        );
+    }
+
+    // ======================== 엣지 케이스 — 다중 이벤트 주문 ========================
+
+    @Nested
+    @DisplayName("다중 이벤트 주문 시나리오")
+    class MultiEventOrder {
+
+        @Test
+        @DisplayName("단건 환불 — ledger.totalTickets 는 주문 전체 티켓 수 합산")
+        void 단건환불_ledger_totalTickets_합산() {
+            UUID eventA = eventId;
+            UUID eventB = UUID.randomUUID();
+            Payment payment = pgPayment(50_000);
+            InternalOrderItemInfoResponse orderItem = new InternalOrderItemInfoResponse(
+                UUID.randomUUID(), orderId, userId, eventA, 10_000);
+
+            given(commerceInternalClient.getOrderItemInfoByTicketId(anyString())).willReturn(orderItem);
+            given(eventInternalClient.getEventInfo(eventA)).willReturn(futureEventFor(eventA, 30));
+            given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
+            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+            // inferOrderTotalTickets 가 commerce 로부터 다중 이벤트 전체 수량 합 조회
+            given(commerceInternalClient.getOrderInfo(orderId)).willReturn(
+                new InternalOrderInfoResponse(
+                    orderId, userId, "ORD-1", 50_000, "PAID",
+                    LocalDateTime.now().toString(),
+                    List.of(
+                        new InternalOrderInfoResponse.OrderItem(eventA, 2),
+                        new InternalOrderInfoResponse.OrderItem(eventB, 3)
+                    )
+                )
+            );
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(inv -> inv.getArgument(0));
+            given(refundRepository.save(any(Refund.class))).willAnswer(inv -> inv.getArgument(0));
+
+            service.refundPgTicket(userId, ticketId.toString(), new PgRefundRequest("partial"));
+
+            ArgumentCaptor<OrderRefund> ledgerCaptor = ArgumentCaptor.forClass(OrderRefund.class);
+            verify(orderRefundRepository).save(ledgerCaptor.capture());
+            assertThat(ledgerCaptor.getValue().getTotalTickets()).isEqualTo(5); // 2 + 3
+            assertThat(ledgerCaptor.getValue().getTotalAmount()).isEqualTo(50_000);
+        }
+
+        @Test
+        @DisplayName("단건 환불 → 주문 전체 환불 순차 — 부분환불 ledger 의 remainingAmount 만 재청구")
+        void 단건환불_후_전체환불_순차() {
+            UUID eventA = eventId;
+            UUID eventB = UUID.randomUUID();
+            Payment payment = pgPayment(50_000);
+
+            // 기존 ledger (단건 환불이 완료된 상태로 PARTIAL)
+            OrderRefund ledger = OrderRefund.create(orderId, userId, payment.getPaymentId(),
+                PaymentMethod.PG, 50_000, 5);
+            ledger.applyRefund(10_000, 1); // 1장 환불 완료
+            assertThat(ledger.getStatus()).isEqualTo(OrderRefundStatus.PARTIAL);
+            assertThat(ledger.getRemainingAmount()).isEqualTo(40_000);
+
+            InternalOrderInfoResponse orderInfo = new InternalOrderInfoResponse(
+                orderId, userId, "ORD-1", 50_000, "PAID",
+                LocalDateTime.now().toString(),
+                List.of(
+                    new InternalOrderInfoResponse.OrderItem(eventA, 2),
+                    new InternalOrderInfoResponse.OrderItem(eventB, 3)
+                )
+            );
+            given(commerceInternalClient.getOrderInfo(orderId)).willReturn(orderInfo);
+            given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
+            given(eventInternalClient.getEventInfo(eventA)).willReturn(futureEventFor(eventA, 30));
+            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.of(ledger));
+            given(refundRepository.save(any(Refund.class))).willAnswer(inv -> inv.getArgument(0));
+
+            OrderRefundResponse resp = service.refundOrder(userId, orderId, "reason");
+
+            // remainingAmount=40_000 * 100% = 40_000 (이미 환불된 10_000 제외)
+            assertThat(resp.refundAmount()).isEqualTo(40_000);
+            assertThat(resp.refundStatus()).isEqualTo("REQUESTED");
+        }
+
+        @Test
+        @DisplayName("오더 전체 환불 — 다중 이벤트 주문에서 첫 이벤트 기준 refundRate 적용")
+        void 오더전체환불_다중이벤트_refundRate_첫이벤트기준() {
+            UUID eventA = eventId;
+            UUID eventB = UUID.randomUUID();
+            Payment payment = pgPayment(50_000);
+            InternalOrderInfoResponse orderInfo = new InternalOrderInfoResponse(
+                orderId, userId, "ORD-1", 50_000, "PAID",
+                LocalDateTime.now().toString(),
+                List.of(
+                    new InternalOrderInfoResponse.OrderItem(eventA, 2),
+                    new InternalOrderInfoResponse.OrderItem(eventB, 3)
+                )
+            );
+
+            given(commerceInternalClient.getOrderInfo(orderId)).willReturn(orderInfo);
+            given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
+            // 첫 이벤트 기준 — 30일 전이면 100%
+            given(eventInternalClient.getEventInfo(eventA)).willReturn(futureEventFor(eventA, 30));
+            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(inv -> inv.getArgument(0));
+            given(refundRepository.save(any(Refund.class))).willAnswer(inv -> inv.getArgument(0));
+
+            OrderRefundResponse resp = service.refundOrder(userId, orderId, "cancel-all");
+
+            assertThat(resp.refundAmount()).isEqualTo(50_000);
+            assertThat(resp.refundRate()).isEqualTo(100);
+            // eventB 는 조회되지 않아야 함 (첫 이벤트 기준 정책)
+            verify(eventInternalClient, never()).getEventInfo(eventB);
+        }
+
+        @Test
+        @DisplayName("오더 전체 환불 — WALLET_PG 복합결제도 remainingAmount 기반으로 요청")
+        void 오더전체환불_WALLET_PG_remainingAmount() {
+            Payment payment = walletPgPayment(50_000, 20_000, 30_000);
+            InternalOrderInfoResponse orderInfo = new InternalOrderInfoResponse(
+                orderId, userId, "ORD-1", 50_000, "PAID",
+                LocalDateTime.now().toString(),
+                List.of(new InternalOrderInfoResponse.OrderItem(eventId, 5))
+            );
+
+            given(commerceInternalClient.getOrderInfo(orderId)).willReturn(orderInfo);
+            given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
+            given(eventInternalClient.getEventInfo(eventId)).willReturn(futureEvent(30));
+
+            // 이미 10_000 환불된 PARTIAL ledger
+            OrderRefund ledger = OrderRefund.create(orderId, userId, payment.getPaymentId(),
+                PaymentMethod.WALLET_PG, 50_000, 5);
+            ledger.applyRefund(10_000, 1);
+            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.of(ledger));
+            given(refundRepository.save(any(Refund.class))).willAnswer(inv -> inv.getArgument(0));
+
+            OrderRefundResponse resp = service.refundOrder(userId, orderId, "full-cancel");
+
+            // remainingAmount=40_000
+            assertThat(resp.refundAmount()).isEqualTo(40_000);
+            assertThat(resp.paymentMethod()).isEqualTo("WALLET_PG");
+        }
+    }
+
+    // ======================== 엣지 케이스 — Seller / Admin 강제취소 ========================
+
+    @Nested
+    @DisplayName("Seller/Admin 이벤트 강제취소")
+    class SellerAdminCancel {
+
+        @Test
+        @DisplayName("cancelSellerEvent — 소유권 일치 시 Event 서비스 forceCancel 호출")
+        void seller_소유권_일치() {
+            UUID sellerId = UUID.randomUUID();
+            given(eventInternalClient.getEventInfo(eventId))
+                .willReturn(futureEventOwnedBy(eventId, sellerId, 30));
+
+            service.cancelSellerEvent(sellerId, eventId, "sold-out");
+
+            verify(eventInternalClient).forceCancel(eventId, "sold-out");
+        }
+
+        @Test
+        @DisplayName("cancelSellerEvent — 소유권 불일치 시 예외 + forceCancel 호출 없음")
+        void seller_소유권_불일치_예외() {
+            UUID sellerId = UUID.randomUUID();
+            UUID actualOwner = UUID.randomUUID();
+            given(eventInternalClient.getEventInfo(eventId))
+                .willReturn(futureEventOwnedBy(eventId, actualOwner, 30));
+
+            assertThatThrownBy(() -> service.cancelSellerEvent(sellerId, eventId, "reason"))
+                .isInstanceOf(RefundException.class);
+            verify(eventInternalClient, never()).forceCancel(any(), any());
+        }
+
+        @Test
+        @DisplayName("cancelAdminEvent — 소유권 검증 없이 forceCancel 호출 (Seller 경로와 동일 내부 API)")
+        void admin_소유권검증_없이_통과() {
+            UUID adminId = UUID.randomUUID();
+
+            service.cancelAdminEvent(adminId, eventId, "policy-violation");
+
+            verify(eventInternalClient).forceCancel(eventId, "policy-violation");
+            // admin 은 이벤트 소유권을 조회하지 않는다
+            verify(eventInternalClient, never()).getEventInfo(any());
+        }
     }
 }

--- a/payment/src/test/java/com/devticket/payment/refund/integration/RefundSagaIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/integration/RefundSagaIntegrationTest.java
@@ -9,8 +9,6 @@ import com.devticket.payment.common.outbox.OutboxService;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
-import com.devticket.payment.wallet.domain.model.Wallet;
-import com.devticket.payment.wallet.domain.repository.WalletRepository;
 import com.devticket.payment.refund.application.saga.event.RefundOrderDoneEvent;
 import com.devticket.payment.refund.application.saga.event.RefundRequestedEvent;
 import com.devticket.payment.refund.application.saga.event.RefundStockDoneEvent;
@@ -25,6 +23,8 @@ import com.devticket.payment.refund.domain.repository.RefundRepository;
 import com.devticket.payment.refund.domain.repository.SagaStateRepository;
 import com.devticket.payment.refund.domain.saga.SagaStatus;
 import com.devticket.payment.refund.domain.saga.SagaStep;
+import com.devticket.payment.wallet.domain.model.Wallet;
+import com.devticket.payment.wallet.domain.repository.WalletRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
@@ -48,12 +48,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Refund Saga E2E 통합 테스트 —
- * Payment Orchestrator + Outbox + Kafka + Mock Commerce/Event Consumer 연동 검증.
- *
- * Commerce/Event 서비스가 없으므로 같은 컨테이너 내부에서 Mock @KafkaListener 가
- * refund.order.cancel / refund.ticket.cancel / refund.stock.restore 수신 시
- * 대응하는 done / failed 이벤트를 Outbox 로 회신한다.
+ * Refund Saga E2E 통합 테스트 — Payment Orchestrator + Outbox + Kafka + Mock Commerce/Event Consumer 연동 검증.
+ * <p>
+ * Commerce/Event 서비스가 없으므로 같은 컨테이너 내부에서 Mock @KafkaListener 가 refund.order.cancel / refund.ticket.cancel /
+ * refund.stock.restore 수신 시 대응하는 done / failed 이벤트를 Outbox 로 회신한다.
  */
 @SpringBootTest
 @ActiveProfiles("test")
@@ -71,15 +69,24 @@ import org.springframework.transaction.annotation.Transactional;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class RefundSagaIntegrationTest {
 
-    @Autowired PaymentRepository paymentRepository;
-    @Autowired RefundRepository refundRepository;
-    @Autowired OrderRefundRepository orderRefundRepository;
-    @Autowired SagaStateRepository sagaStateRepository;
-    @Autowired OutboxRepository outboxRepository;
-    @Autowired OutboxService outboxService;
-    @Autowired ObjectMapper objectMapper;
-    @Autowired MockSagaPartner mockPartner;
-    @Autowired WalletRepository walletRepository;
+    @Autowired
+    PaymentRepository paymentRepository;
+    @Autowired
+    RefundRepository refundRepository;
+    @Autowired
+    OrderRefundRepository orderRefundRepository;
+    @Autowired
+    SagaStateRepository sagaStateRepository;
+    @Autowired
+    OutboxRepository outboxRepository;
+    @Autowired
+    OutboxService outboxService;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    MockSagaPartner mockPartner;
+    @Autowired
+    WalletRepository walletRepository;
 
     @BeforeEach
     void setUp() {
@@ -194,6 +201,7 @@ class RefundSagaIntegrationTest {
     // =====================================================================
     @TestConfiguration
     static class MockSagaPartnerConfig {
+
         @Bean
         MockSagaPartner mockSagaPartner(OutboxService outboxService, ObjectMapper objectMapper) {
             return new MockSagaPartner(outboxService, objectMapper);
@@ -225,9 +233,9 @@ class RefundSagaIntegrationTest {
 
             outboxService.save(
                 refundId.toString(),
-                KafkaTopics.REFUND_ORDER_DONE,
-                KafkaTopics.REFUND_ORDER_DONE,
                 orderId.toString(),
+                KafkaTopics.REFUND_ORDER_DONE,
+                KafkaTopics.REFUND_ORDER_DONE,
                 new RefundOrderDoneEvent(refundId, orderId, Instant.now())
             );
         }
@@ -242,20 +250,22 @@ class RefundSagaIntegrationTest {
             if (failOnTicketCancel.get()) {
                 outboxService.save(
                     refundId.toString(),
-                    KafkaTopics.REFUND_TICKET_FAILED,
-                    KafkaTopics.REFUND_TICKET_FAILED,
                     orderId.toString(),
+                    KafkaTopics.REFUND_TICKET_FAILED,
+                    KafkaTopics.REFUND_TICKET_FAILED,
                     new RefundTicketFailedEvent(refundId, orderId, "mock-fail", Instant.now())
                 );
                 return;
             }
             outboxService.save(
                 refundId.toString(),
-                KafkaTopics.REFUND_TICKET_DONE,
-                KafkaTopics.REFUND_TICKET_DONE,
                 orderId.toString(),
+                KafkaTopics.REFUND_TICKET_DONE,
+                KafkaTopics.REFUND_TICKET_DONE,
                 new RefundTicketDoneEvent(refundId, orderId,
-                    List.of(UUID.randomUUID()), UUID.randomUUID(), 1, Instant.now())
+                    List.of(UUID.randomUUID()),
+                    List.of(new RefundTicketDoneEvent.Item(UUID.randomUUID(), 1)),
+                    Instant.now())
             );
         }
 
@@ -267,9 +277,9 @@ class RefundSagaIntegrationTest {
             UUID orderId = UUID.fromString(payload.get("orderId").asText());
             outboxService.save(
                 refundId.toString(),
-                KafkaTopics.REFUND_STOCK_DONE,
-                KafkaTopics.REFUND_STOCK_DONE,
                 orderId.toString(),
+                KafkaTopics.REFUND_STOCK_DONE,
+                KafkaTopics.REFUND_STOCK_DONE,
                 new RefundStockDoneEvent(refundId, orderId, Instant.now())
             );
         }

--- a/payment/src/test/java/com/devticket/payment/refund/integration/RefundSagaIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/integration/RefundSagaIntegrationTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import com.devticket.payment.common.messaging.KafkaTopics;
-import com.devticket.payment.common.outbox.OutboxRepository;
 import com.devticket.payment.common.outbox.OutboxService;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.model.Payment;
@@ -12,8 +11,11 @@ import com.devticket.payment.payment.domain.repository.PaymentRepository;
 import com.devticket.payment.refund.application.saga.event.RefundOrderDoneEvent;
 import com.devticket.payment.refund.application.saga.event.RefundRequestedEvent;
 import com.devticket.payment.refund.application.saga.event.RefundStockDoneEvent;
+import com.devticket.payment.refund.application.saga.event.RefundStockRestoreEvent;
+import com.devticket.payment.refund.application.saga.event.RefundTicketCancelEvent;
 import com.devticket.payment.refund.application.saga.event.RefundTicketDoneEvent;
 import com.devticket.payment.refund.application.saga.event.RefundTicketFailedEvent;
+import com.devticket.payment.refund.application.saga.event.RefundOrderCancelEvent;
 import com.devticket.payment.refund.domain.enums.OrderRefundStatus;
 import com.devticket.payment.refund.domain.model.OrderRefund;
 import com.devticket.payment.refund.domain.model.Refund;
@@ -25,7 +27,6 @@ import com.devticket.payment.refund.domain.saga.SagaStatus;
 import com.devticket.payment.refund.domain.saga.SagaStep;
 import com.devticket.payment.wallet.domain.model.Wallet;
 import com.devticket.payment.wallet.domain.repository.WalletRepository;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.time.Instant;
@@ -45,7 +46,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Refund Saga E2E 통합 테스트 — Payment Orchestrator + Outbox + Kafka + Mock Commerce/Event Consumer 연동 검증.
@@ -78,15 +79,13 @@ class RefundSagaIntegrationTest {
     @Autowired
     SagaStateRepository sagaStateRepository;
     @Autowired
-    OutboxRepository outboxRepository;
-    @Autowired
     OutboxService outboxService;
-    @Autowired
-    ObjectMapper objectMapper;
     @Autowired
     MockSagaPartner mockPartner;
     @Autowired
     WalletRepository walletRepository;
+    @Autowired
+    TransactionTemplate transactionTemplate;
 
     @BeforeEach
     void setUp() {
@@ -126,8 +125,12 @@ class RefundSagaIntegrationTest {
             Instant.now()
         );
 
-        publishOutbox(KafkaTopics.REFUND_REQUESTED, refund.getRefundId().toString(),
-            payment.getOrderId().toString(), requested);
+        publishOutbox(
+            refund.getRefundId().toString(),
+            payment.getOrderId().toString(),
+            KafkaTopics.REFUND_REQUESTED,
+            requested
+        );
 
         await().atMost(Duration.ofSeconds(90)).untilAsserted(() -> {
             SagaState state = sagaStateRepository.findByRefundId(refund.getRefundId()).orElse(null);
@@ -167,8 +170,12 @@ class RefundSagaIntegrationTest {
             List.of(UUID.randomUUID()), payment.getAmount(), 100, false,
             "integration-test", Instant.now()
         );
-        publishOutbox(KafkaTopics.REFUND_REQUESTED, refund.getRefundId().toString(),
-            payment.getOrderId().toString(), requested);
+        publishOutbox(
+            refund.getRefundId().toString(),
+            payment.getOrderId().toString(),
+            KafkaTopics.REFUND_REQUESTED,
+            requested
+        );
 
         await().atMost(Duration.ofSeconds(60)).untilAsserted(() -> {
             SagaState state = sagaStateRepository.findByRefundId(refund.getRefundId()).orElse(null);
@@ -179,9 +186,10 @@ class RefundSagaIntegrationTest {
 
     // ---------- helpers ----------
 
-    @Transactional
-    protected void publishOutbox(String topic, String aggregateId, String partitionKey, Object payload) {
-        outboxService.save(aggregateId, topic, topic, partitionKey, payload);
+    protected void publishOutbox(String aggregateId, String partitionKey, String topic, Object payload) {
+        transactionTemplate.executeWithoutResult(status ->
+            outboxService.save(aggregateId, partitionKey, topic, topic, payload)
+        );
     }
 
     private Payment createAndSavePgPayment() {
@@ -203,8 +211,12 @@ class RefundSagaIntegrationTest {
     static class MockSagaPartnerConfig {
 
         @Bean
-        MockSagaPartner mockSagaPartner(OutboxService outboxService, ObjectMapper objectMapper) {
-            return new MockSagaPartner(outboxService, objectMapper);
+        MockSagaPartner mockSagaPartner(
+            OutboxService outboxService,
+            ObjectMapper objectMapper,
+            TransactionTemplate transactionTemplate
+        ) {
+            return new MockSagaPartner(outboxService, objectMapper, transactionTemplate);
         }
     }
 
@@ -214,74 +226,97 @@ class RefundSagaIntegrationTest {
 
         private final OutboxService outboxService;
         private final ObjectMapper objectMapper;
+        private final TransactionTemplate transactionTemplate;
 
-        MockSagaPartner(OutboxService outboxService, ObjectMapper objectMapper) {
+        MockSagaPartner(
+            OutboxService outboxService,
+            ObjectMapper objectMapper,
+            TransactionTemplate transactionTemplate
+        ) {
             this.outboxService = outboxService;
             this.objectMapper = objectMapper;
+            this.transactionTemplate = transactionTemplate;
         }
 
         void reset() {
             failOnTicketCancel.set(false);
         }
 
-        @KafkaListener(topics = KafkaTopics.REFUND_ORDER_CANCEL, groupId = "mock-partner-order-cancel")
-        void onOrderCancel(ConsumerRecord<String, String> record) throws Exception {
-            JsonNode node = objectMapper.readTree(record.value());
-            JsonNode payload = objectMapper.readTree(node.get("payload").asText());
-            UUID refundId = UUID.fromString(payload.get("refundId").asText());
-            UUID orderId = UUID.fromString(payload.get("orderId").asText());
+        @KafkaListener(
+            topics = KafkaTopics.REFUND_ORDER_CANCEL,
+            groupId = "mock-partner-order-cancel",
+            properties = "auto.offset.reset=earliest"
+        )
+        public void onOrderCancel(ConsumerRecord<String, String> record) throws Exception {
+            RefundOrderCancelEvent event = extractPayload(record, RefundOrderCancelEvent.class);
 
-            outboxService.save(
-                refundId.toString(),
-                orderId.toString(),
+            savePartnerOutbox(
+                event.refundId(),
+                event.orderId(),
                 KafkaTopics.REFUND_ORDER_DONE,
-                KafkaTopics.REFUND_ORDER_DONE,
-                new RefundOrderDoneEvent(refundId, orderId, Instant.now())
+                new RefundOrderDoneEvent(event.refundId(), event.orderId(), Instant.now())
             );
         }
 
-        @KafkaListener(topics = KafkaTopics.REFUND_TICKET_CANCEL, groupId = "mock-partner-ticket-cancel")
-        void onTicketCancel(ConsumerRecord<String, String> record) throws Exception {
-            JsonNode node = objectMapper.readTree(record.value());
-            JsonNode payload = objectMapper.readTree(node.get("payload").asText());
-            UUID refundId = UUID.fromString(payload.get("refundId").asText());
-            UUID orderId = UUID.fromString(payload.get("orderId").asText());
+        @KafkaListener(
+            topics = KafkaTopics.REFUND_TICKET_CANCEL,
+            groupId = "mock-partner-ticket-cancel",
+            properties = "auto.offset.reset=earliest"
+        )
+        public void onTicketCancel(ConsumerRecord<String, String> record) throws Exception {
+            RefundTicketCancelEvent event = extractPayload(record, RefundTicketCancelEvent.class);
 
             if (failOnTicketCancel.get()) {
-                outboxService.save(
-                    refundId.toString(),
-                    orderId.toString(),
+                savePartnerOutbox(
+                    event.refundId(),
+                    event.orderId(),
                     KafkaTopics.REFUND_TICKET_FAILED,
-                    KafkaTopics.REFUND_TICKET_FAILED,
-                    new RefundTicketFailedEvent(refundId, orderId, "mock-fail", Instant.now())
+                    new RefundTicketFailedEvent(event.refundId(), event.orderId(), "mock-fail", Instant.now())
                 );
                 return;
             }
-            outboxService.save(
-                refundId.toString(),
-                orderId.toString(),
+            savePartnerOutbox(
+                event.refundId(),
+                event.orderId(),
                 KafkaTopics.REFUND_TICKET_DONE,
-                KafkaTopics.REFUND_TICKET_DONE,
-                new RefundTicketDoneEvent(refundId, orderId,
+                new RefundTicketDoneEvent(event.refundId(), event.orderId(),
                     List.of(UUID.randomUUID()),
                     List.of(new RefundTicketDoneEvent.Item(UUID.randomUUID(), 1)),
                     Instant.now())
             );
         }
 
-        @KafkaListener(topics = KafkaTopics.REFUND_STOCK_RESTORE, groupId = "mock-partner-stock-restore")
-        void onStockRestore(ConsumerRecord<String, String> record) throws Exception {
-            JsonNode node = objectMapper.readTree(record.value());
-            JsonNode payload = objectMapper.readTree(node.get("payload").asText());
-            UUID refundId = UUID.fromString(payload.get("refundId").asText());
-            UUID orderId = UUID.fromString(payload.get("orderId").asText());
-            outboxService.save(
-                refundId.toString(),
-                orderId.toString(),
+        @KafkaListener(
+            topics = KafkaTopics.REFUND_STOCK_RESTORE,
+            groupId = "mock-partner-stock-restore",
+            properties = "auto.offset.reset=earliest"
+        )
+        public void onStockRestore(ConsumerRecord<String, String> record) throws Exception {
+            RefundStockRestoreEvent event = extractPayload(record, RefundStockRestoreEvent.class);
+            savePartnerOutbox(
+                event.refundId(),
+                event.orderId(),
                 KafkaTopics.REFUND_STOCK_DONE,
-                KafkaTopics.REFUND_STOCK_DONE,
-                new RefundStockDoneEvent(refundId, orderId, Instant.now())
+                new RefundStockDoneEvent(event.refundId(), event.orderId(), Instant.now())
             );
+        }
+
+        private void savePartnerOutbox(UUID refundId, UUID orderId, String topic, Object payload) {
+            transactionTemplate.executeWithoutResult(status ->
+                outboxService.save(
+                    refundId.toString(),
+                    orderId.toString(),
+                    topic,
+                    topic,
+                    payload
+                )
+            );
+        }
+
+        private <T> T extractPayload(ConsumerRecord<String, String> record, Class<T> payloadType) throws Exception {
+            String rootJson = record.value();
+            String payloadJson = objectMapper.readTree(rootJson).get("payload").asText();
+            return objectMapper.readValue(payloadJson, payloadType);
         }
     }
 }


### PR DESCRIPTION
- 환불 주요 시나리오·복합결제 엣지케이스 테스트 보강
- PG 부분 환불을 Idempotency-Key 로 멱등 보장
- 다중 이벤트 주문도 stock 복구를 누락 없이 처리
- refund Outbox save 의 partitionKey/topic 인자 순서 교정

