### PR TITLE
[Event] fix: ES body 에 eventId 필드 추가 — AI 추천 계약(PR #540) 준수

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -412,6 +412,8 @@ public class EventService {
 
             Map<String, Object> doc = new HashMap<>();
             doc.put("id", event.getEventId().toString());
+            // AI 추천 서비스는 _source.eventId 로 추출 (PR #540 계약). _id 는 hit._source 에 포함되지 않으므로 body 에 명시.
+            doc.put("eventId", event.getEventId().toString());
             doc.put("title", event.getTitle());
             doc.put("category", event.getCategory().name());
             doc.put("techStacks", techStackNames);

--- a/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
@@ -21,6 +21,13 @@ public class EventDocument {
     @Id
     private String id;
 
+    /**
+     * AI 추천 서비스는 _source.eventId 로 필드를 추출 (PR #540 계약).
+     * ES _id 는 hit._source 에 포함되지 않으므로 body 에 명시 저장.
+     */
+    @Field(type = FieldType.Keyword)
+    private String eventId;
+
     @Field(type = FieldType.Text)
     private String title;
 
@@ -47,9 +54,10 @@ public class EventDocument {
     private LocalDateTime indexedAt;
 
     @Builder
-    private EventDocument(String id, String title, String category, List<String> techStacks,
+    private EventDocument(String id, String eventId, String title, String category, List<String> techStacks,
         String status, String sellerId, LocalDateTime indexedAt) {
         this.id = id;
+        this.eventId = eventId;
         this.title = title;
         this.category = category;
         this.techStacks = techStacks;
@@ -65,6 +73,7 @@ public class EventDocument {
 
         return EventDocument.builder()
             .id(event.getEventId().toString())
+            .eventId(event.getEventId().toString())
             .title(event.getTitle())
             .category(event.getCategory().name())
             .techStacks(techStackNames)

--- a/event/src/main/resources/elasticsearch/event-mapping.json
+++ b/event/src/main/resources/elasticsearch/event-mapping.json
@@ -1,5 +1,8 @@
 {
   "properties": {
+    "eventId": {
+      "type": "keyword"
+    },
     "title": {
       "type": "text"
     },

--- a/event/src/test/java/com/devticket/event/elasticsearch/EventDocumentTest.java
+++ b/event/src/test/java/com/devticket/event/elasticsearch/EventDocumentTest.java
@@ -40,6 +40,8 @@ class EventDocumentTest {
 
         // then
         assertThat(doc.getId()).isEqualTo(eventId.toString());
+        // AI 추천 서비스 계약 (PR #540) — EventInternalService 재색인 경로에서도 body 에 eventId 포함되어야 함
+        assertThat(doc.getEventId()).isEqualTo(eventId.toString());
         assertThat(doc.getTitle()).isEqualTo("스프링 부트 밋업");
         assertThat(doc.getCategory()).isEqualTo(EventCategory.MEETUP.name());
         assertThat(doc.getStatus()).isEqualTo(EventStatus.ON_SALE.name());

--- a/event/src/test/java/com/devticket/event/elasticsearch/EventSearchFilterTest.java
+++ b/event/src/test/java/com/devticket/event/elasticsearch/EventSearchFilterTest.java
@@ -251,6 +251,7 @@ class EventSearchFilterTest extends ElasticsearchIntegrationTestBase {
 
         Map<String, Object> doc = new HashMap<>();
         doc.put("id", embeddedId);
+        doc.put("eventId", embeddedId);
         doc.put("title", "벡터 검색 이벤트");
         doc.put("category", "MEETUP");
         doc.put("status", "ON_SALE");

--- a/event/src/test/java/com/devticket/event/elasticsearch/EventSyncElasticsearchTest.java
+++ b/event/src/test/java/com/devticket/event/elasticsearch/EventSyncElasticsearchTest.java
@@ -193,6 +193,31 @@ class EventSyncElasticsearchTest extends ElasticsearchIntegrationTestBase {
         assertThat(techStacks).isEmpty();
     }
 
+    // ── AI 계약 (eventId 필드) ────────────────────────────────────────────
+
+    /**
+     * AI 추천 서비스는 _source.eventId 로 필드를 추출 (PR #540 계약).
+     * ES _id 는 hit._source 에 포함되지 않으므로 body 에 eventId 키가 존재해야 함.
+     * 회귀 시 AI reRank 루프에서 NPE 발생.
+     */
+    @Test
+    void sync하면_body_source에_eventId_필드가_저장된다() throws Exception {
+        // given
+        when(openAiEmbeddingClient.embed(anyString())).thenReturn(null);
+        Event event = createEvent(UUID.randomUUID(), "AI 계약 확인 이벤트", EventStatus.ON_SALE);
+
+        // when
+        eventService.syncToElasticsearch(event);
+        elasticsearchOperations.indexOps(EventDocument.class).refresh();
+
+        // then
+        GetResponse<Map> response = esClient.get(g -> g
+            .index("event").id(event.getEventId().toString()), Map.class);
+        assertThat(response.found()).isTrue();
+        assertThat(response.source()).containsKey("eventId");
+        assertThat(response.source().get("eventId")).isEqualTo(event.getEventId().toString());
+    }
+
     // ── indexedAt 형식 ────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
  ## 배경                                                                                                                                                
                                                                                                                                                         
  AI 추천 서비스는 kNN 재정렬 단계에서 `_source.includes("eventId", "embedding")` 로 필드를 추출 (PR #540 계약). 그러나 Event 모듈은 ES body 에 `id`     
  키로만 저장해 AI `candidate.get("eventId").toString()` 에서 NPE 발생 → `/recommendation` 개인화 추천 완전 실패.                                        
                            
  ## 원인

  - `EventService.syncToElasticsearch()` — `doc.put("id", ...)` 만 존재
  - `EventInternalService.syncToElasticsearch()` / `StockStatusChangedListener` — `EventDocument.from()` 경로로 재색인 시에도 body 에 `eventId` 누락

  ## 수정 내용

  | 파일 | 변경 |
  |---|---|
  | `EventService.java` | body 에 `eventId` 키 병행 저장 (기존 `id` 유지) |
  | `EventDocument.java` | `@Field(type=Keyword) eventId` 필드 추가 → 재고 변동 재색인 경로에서도 자동 포함 |
  | `event-mapping.json` | `"eventId": {"type": "keyword"}` 매핑 명시 |
  | 관련 테스트 2종 | 회귀 방지 assertion 추가 (`EventDocumentTest`, `EventSyncElasticsearchTest`) + `EventSearchFilterTest` kNN doc 동반 세팅 |

  ## 로컬 테스트 결과

  타겟 4종 (환경변수 AWS dummy 주입, 로컬 ES 9.2.5 연결):

  | 테스트 | 결과 |
  |---|---|
  | `EventDocumentTest` (단위) | ✅ |
  | `EventSyncElasticsearchTest` (실 ES, 8/8) | ✅ |
  | `EventSearchFilterTest` | ✅ |
  | `EventSearchRepositoryTest` | ✅ |

  **실 ES AI 재현 쿼리 검증**:
  ```bash
  curl -X POST "http://localhost:9200/event/_search" -H 'Content-Type: application/json' \
    -d '{"_source":{"includes":["eventId","embedding"]},"size":1}'
  → _source.eventId 정상 추출 (NPE 원인 제거 end-to-end 증명)

  ▎ 참고: ./gradlew test 전체 실행 시 25 fail 은 기존 파손 (EventControllerTest / RefundStockRestoreServiceTest / EventServiceTest 의 Mock 누락, PR
  ▎ #541·#549 와 동일 패턴) — 본 PR 스코프 밖, 별 PR 처리 예정.

  운영 측 잔여 작업 — 레거시 ES 문서 재색인

  본 PR 은 신규 / 갱신 문서부터 AI 호환 보장. 기존 문서는 아래 스크립트로 dev · staging · prod 각 1회 실행 필요 (idempotent, null 가드 포함):

  POST event/_update_by_query
  {
    "script": {
      "source": "if (ctx._source.eventId == null) { ctx._source.eventId = ctx._source.id != null ? ctx._source.id : ctx._id; }",
      "lang": "painless"
    }
  }

  - 실행 주체: ES / 인프라 담당자 (PO 승인 후)
  - 검증: GET event/_search?size=1 로 _source.eventId 확인

  관련

  - AI PR #540 (인덱스명 통일 + _source.eventId 계약 확정)