### PR TITLE
[Log] feat: AI recentVector 조회 엔드포인트 추가 — GET /internal/logs/actions (#555)

### DIFF
--- a/fastify-log/.env.example
+++ b/fastify-log/.env.example
@@ -13,6 +13,6 @@ KAFKA_TOPIC_ACTION_LOG=action.log
 KAFKA_TOPIC_PAYMENT_COMPLETED=payment.completed
 
 # ===== Server =====
-PORT=8085
+PORT=8086
 NODE_ENV=development
 LOG_LEVEL=info

--- a/fastify-log/sql/V1__create_action_log.sql
+++ b/fastify-log/sql/V1__create_action_log.sql
@@ -29,4 +29,6 @@ COMMENT ON COLUMN log.action_log.event_id           IS '이벤트 외부 식별�
 COMMENT ON COLUMN log.action_log.action_type        IS 'VIEW|DETAIL_VIEW|CART_ADD|CART_REMOVE|PURCHASE|DWELL_TIME|REFUND';
 COMMENT ON COLUMN log.action_log.dwell_time_seconds IS 'DWELL_TIME 시 체류 시간(초)';
 COMMENT ON COLUMN log.action_log.quantity           IS 'PURCHASE, CART_ADD 시 수량';
-COMMENT ON COLUMN log.action_log.total_amount       IS 'PURCHASE, REFUND 시 금액';
+COMMENT ON COLUMN log.action_log.total_amount       IS 'PURCHASE, REFUND 시 금액 (PURCHASE 다건 주문은 NULL — SUM 부풀림 방지. 정확한 매출은 Payment.payment.total_amount 집계)';
+COMMENT ON COLUMN log.action_log.created_at         IS '이벤트 발생 시각 (Kafka 메시지 timestamp 저장, AI 시퀀스 분석 기준) — 수신 시각 아님';
+COMMENT ON COLUMN log.action_log.updated_at         IS '현재 미사용 — action_log는 append-only 로그 특성상 UPDATE 없음. 향후 확장 여지로 보존';

--- a/fastify-log/sql/V2__add_user_created_index.sql
+++ b/fastify-log/sql/V2__add_user_created_index.sql
@@ -1,0 +1,12 @@
+-- DevTicket Log Module — action_log 복합 인덱스 추가
+-- 목적: AI 조회 엔드포인트(GET /internal/logs/actions) 쿼리 최적화
+--       user_id 기준 시간범위 역순 조회 (user별 recentVector 갱신 배치)
+-- 참조: docs/actionLog.md §5.5
+-- 실행 주체: 수동 DDL (ShedLock 테이블 실행 절차와 동일)
+-- 주의: CONCURRENTLY 옵션 — 운영 중 테이블 쓰기 락 회피. 트랜잭션 블록 내 실행 금지.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_action_log_user_created
+  ON log.action_log (user_id, created_at DESC);
+
+COMMENT ON INDEX log.idx_action_log_user_created
+  IS 'AI 조회 엔드포인트용 — user별 created_at 역순 조회 (docs/actionLog.md §5.5)';

--- a/fastify-log/src/index.ts
+++ b/fastify-log/src/index.ts
@@ -5,6 +5,7 @@ import { closeDatabase } from './config/database';
 import { disconnectConsumer } from './config/kafka';
 import { startActionLogConsumer } from './consumer/action-log.consumer';
 import { healthRoutes } from './route/health.route';
+import { internalLogRoutes } from './route/internal-log.route';
 import { logger } from './util/logger';
 
 async function main(): Promise<void> {
@@ -12,6 +13,7 @@ async function main(): Promise<void> {
 
   // 라우트 등록
   await app.register(healthRoutes);
+  await app.register(internalLogRoutes);
 
   // Kafka consumer 시작
   try {

--- a/fastify-log/src/repository/action-log.repository.ts
+++ b/fastify-log/src/repository/action-log.repository.ts
@@ -1,5 +1,6 @@
 import { pool } from '../config/database';
 import { ActionLog } from '../model/action-log.model';
+import { ActionType } from '../model/action-type.enum';
 
 const COLUMN_COUNT = 9;
 
@@ -16,6 +17,27 @@ const INSERT_ACTION_LOG_PREFIX = `
      dwell_time_seconds, quantity, total_amount, created_at)
   VALUES
 `;
+
+// AI recentVector 배치 조회 — (user_id, created_at DESC) 복합 인덱스 활용 (V2)
+// WHERE event_id IS NOT NULL: VIEW 중 eventId null row는 분석 대상 외 선제 제외
+const FIND_RECENT_ACTIONS = `
+  SELECT event_id AS "eventId",
+         action_type AS "actionType",
+         dwell_time_seconds AS "dwellTimeSeconds"
+  FROM log.action_log
+  WHERE user_id = $1
+    AND action_type = ANY($2::text[])
+    AND created_at >= NOW() - ($3::int || ' days')::INTERVAL
+    AND event_id IS NOT NULL
+  ORDER BY created_at DESC
+  LIMIT $4
+`;
+
+export interface RecentActionRow {
+  eventId: string;
+  actionType: ActionType;
+  dwellTimeSeconds: number | null;
+}
 
 export async function insertActionLog(log: ActionLog): Promise<void> {
   await pool.query(INSERT_ACTION_LOG, toParams(log));
@@ -55,7 +77,18 @@ function toParams(log: ActionLog): unknown[] {
   ];
 }
 
+export async function findRecentActions(
+  userId: string,
+  actionTypes: string[],
+  days: number,
+  limit: number,
+): Promise<RecentActionRow[]> {
+  const res = await pool.query(FIND_RECENT_ACTIONS, [userId, actionTypes, days, limit]);
+  return res.rows as RecentActionRow[];
+}
+
 export const actionLogRepository = {
   insertActionLog,
   insertActionLogs,
+  findRecentActions,
 };

--- a/fastify-log/src/route/internal-log.route.ts
+++ b/fastify-log/src/route/internal-log.route.ts
@@ -1,0 +1,85 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import { ActionType, isValidActionType } from '../model/action-type.enum';
+import { actionLogService } from '../service/action-log.service';
+
+const INTERNAL_SERVICE_ALLOWLIST = new Set(['ai']);
+
+const DEFAULT_DAYS = 7;
+
+interface RecentLogsQuery {
+  userId: string;
+  days?: number;
+  actionTypes: string;
+}
+
+const recentLogsSchema = {
+  querystring: {
+    type: 'object',
+    required: ['userId', 'actionTypes'],
+    properties: {
+      userId: {
+        type: 'string',
+        pattern:
+          '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',
+      },
+      days: { type: 'integer', minimum: 1, maximum: 30, default: DEFAULT_DAYS },
+      actionTypes: { type: 'string', minLength: 1 },
+    },
+  },
+} as const;
+
+function parseActionTypes(raw: string): ActionType[] | null {
+  const tokens = raw
+    .split(',')
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+  if (tokens.length === 0) return null;
+  const validated: ActionType[] = [];
+  for (const t of tokens) {
+    if (!isValidActionType(t)) return null;
+    validated.push(t);
+  }
+  return validated;
+}
+
+export async function internalLogRoutes(app: FastifyInstance): Promise<void> {
+  app.addHook('onRequest', async (request: FastifyRequest, reply: FastifyReply) => {
+    const header = request.headers['x-internal-service'];
+    const value = Array.isArray(header) ? header[0] : header;
+    if (!value) {
+      return reply.status(401).send({
+        statusCode: 401,
+        error: 'Unauthorized',
+        message: 'X-Internal-Service 헤더가 필요합니다.',
+      });
+    }
+    if (!INTERNAL_SERVICE_ALLOWLIST.has(value)) {
+      return reply.status(403).send({
+        statusCode: 403,
+        error: 'Forbidden',
+        message: 'X-Internal-Service 값이 허용 목록에 없습니다.',
+      });
+    }
+  });
+
+  app.get<{ Querystring: RecentLogsQuery }>(
+    '/internal/logs/actions',
+    { schema: recentLogsSchema },
+    async (request, reply) => {
+      const { userId, days = DEFAULT_DAYS, actionTypes: rawActionTypes } = request.query;
+      const actionTypes = parseActionTypes(rawActionTypes);
+      if (!actionTypes) {
+        return reply.status(400).send({
+          statusCode: 400,
+          error: 'Bad Request',
+          message:
+            'actionTypes는 CSV 형식의 ActionType enum 값이어야 합니다. 예: VIEW,DETAIL_VIEW,DWELL_TIME',
+        });
+      }
+
+      const logs = await actionLogService.getRecentLogs(userId, days, actionTypes);
+      return reply.status(200).send({ userId, logs });
+    },
+  );
+}

--- a/fastify-log/src/service/action-log.service.ts
+++ b/fastify-log/src/service/action-log.service.ts
@@ -1,6 +1,13 @@
 import { ActionLog, ActionLogMessage } from '../model/action-log.model';
 import { ActionType, isValidActionType } from '../model/action-type.enum';
-import { actionLogRepository } from '../repository/action-log.repository';
+import {
+  actionLogRepository,
+  RecentActionRow,
+} from '../repository/action-log.repository';
+
+// AI recentVector 배치 응답 상한 — docs/actionLog.md §5.5
+// 폭증 방지 + AI 측 파싱 부담 관리. 튜닝은 실측 후 조정.
+const RECENT_LOGS_LIMIT = 5000;
 
 export async function save(raw: unknown): Promise<void> {
   const message = validateAndParse(raw);
@@ -48,6 +55,15 @@ function toActionLog(message: ActionLogMessage): ActionLog {
   };
 }
 
+export async function getRecentLogs(
+  userId: string,
+  days: number,
+  actionTypes: ActionType[],
+): Promise<RecentActionRow[]> {
+  return actionLogRepository.findRecentActions(userId, actionTypes, days, RECENT_LOGS_LIMIT);
+}
+
 export const actionLogService = {
   save,
+  getRecentLogs,
 };

--- a/fastify-log/test/integration/internal-log.route.db.test.ts
+++ b/fastify-log/test/integration/internal-log.route.db.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import type { Pool } from 'pg';
+
+/**
+ * Internal log route → 실제 Postgres 통합 테스트.
+ * RUN_DB_TESTS=1 환경변수가 세팅된 경우에만 실행. 기본은 skip.
+ *
+ * 실행 예:
+ *   RUN_DB_TESTS=1 npx vitest run test/integration/internal-log.route.db.test.ts
+ *
+ * 접속 정보 (docker devticket-postgres): localhost:5433, devticket/devticket/devticket
+ */
+
+const runDbTests = process.env.RUN_DB_TESTS === '1';
+
+if (runDbTests) {
+  process.env.DB_HOST ??= process.env.TEST_DB_HOST ?? 'localhost';
+  process.env.DB_PORT ??= process.env.TEST_DB_PORT ?? '5433';
+  process.env.DB_NAME ??= process.env.TEST_DB_NAME ?? 'devticket';
+  process.env.DB_USER ??= process.env.TEST_DB_USER ?? 'devticket';
+  process.env.DB_PASSWORD ??= process.env.TEST_DB_PASSWORD ?? 'devticket';
+  process.env.DB_SCHEMA ??= 'log';
+  process.env.KAFKA_BROKERS ??= 'localhost:9093';
+}
+
+const describeIfDb = runDbTests ? describe : describe.skip;
+
+const USER_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const OTHER_USER_UUID = '660e8400-e29b-41d4-a716-446655440000';
+const EVENT_A = '11111111-1111-4111-8111-111111111111';
+const EVENT_B = '22222222-2222-4222-8222-222222222222';
+
+const AI_HEADER = { 'x-internal-service': 'ai' };
+
+describeIfDb('InternalLogRoutes (실 Postgres)', () => {
+  let pool: Pool;
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const db = await import('../../src/config/database');
+    pool = db.pool;
+
+    // V1 스키마 idempotent 적용
+    const v1 = readFileSync(
+      resolve(__dirname, '../../sql/V1__create_action_log.sql'),
+      'utf-8',
+    );
+    await pool.query('CREATE SCHEMA IF NOT EXISTS log');
+    await pool.query('DROP TABLE IF EXISTS log.action_log CASCADE');
+    await pool.query(v1);
+
+    const { internalLogRoutes } = await import('../../src/route/internal-log.route');
+    const Fastify = (await import('fastify')).default;
+    app = Fastify({ logger: false });
+    await app.register(internalLogRoutes);
+    await app.ready();
+  }, 20000);
+
+  afterEach(async () => {
+    await pool.query('TRUNCATE log.action_log RESTART IDENTITY');
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.query('DROP TABLE IF EXISTS log.action_log CASCADE');
+    await pool.end();
+  });
+
+  interface SeedRow {
+    userId: string;
+    eventId: string | null;
+    actionType: string;
+    dwellTimeSeconds?: number | null;
+    createdAt?: string;
+  }
+
+  async function seed(rows: SeedRow[]): Promise<void> {
+    for (const r of rows) {
+      await pool.query(
+        `INSERT INTO log.action_log
+           (user_id, event_id, action_type, dwell_time_seconds, created_at)
+         VALUES ($1, $2, $3, $4, COALESCE($5::timestamptz, NOW()))`,
+        [
+          r.userId,
+          r.eventId,
+          r.actionType,
+          r.dwellTimeSeconds ?? null,
+          r.createdAt ?? null,
+        ],
+      );
+    }
+  }
+
+  it('매칭되는 로그 반환', async () => {
+    await seed([
+      { userId: USER_UUID, eventId: EVENT_A, actionType: 'VIEW' },
+      {
+        userId: USER_UUID,
+        eventId: EVENT_B,
+        actionType: 'DWELL_TIME',
+        dwellTimeSeconds: 30,
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW,DWELL_TIME`,
+      headers: AI_HEADER,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.userId).toBe(USER_UUID);
+    expect(body.logs).toHaveLength(2);
+  });
+
+  it('다른 userId 로그 반환 안 함', async () => {
+    await seed([{ userId: OTHER_USER_UUID, eventId: EVENT_A, actionType: 'VIEW' }]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW`,
+      headers: AI_HEADER,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().logs).toEqual([]);
+  });
+
+  it('event_id=null row는 제외 (VIEW 중 목록 조회성)', async () => {
+    await seed([
+      { userId: USER_UUID, eventId: null, actionType: 'VIEW' },
+      { userId: USER_UUID, eventId: EVENT_A, actionType: 'VIEW' },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW`,
+      headers: AI_HEADER,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.logs).toHaveLength(1);
+    expect(body.logs[0].eventId).toBe(EVENT_A);
+  });
+
+  it('created_at DESC 정렬', async () => {
+    await seed([
+      {
+        userId: USER_UUID,
+        eventId: EVENT_A,
+        actionType: 'VIEW',
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+      {
+        userId: USER_UUID,
+        eventId: EVENT_B,
+        actionType: 'VIEW',
+        createdAt: '2026-04-01T00:00:00Z',
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW`,
+      headers: AI_HEADER,
+    });
+
+    const logs = res.json().logs;
+    expect(logs[0].eventId).toBe(EVENT_B);
+    expect(logs[1].eventId).toBe(EVENT_A);
+  });
+
+  it('days 범위 밖 (40일 전) 로그 제외', async () => {
+    const fortyDaysAgo = new Date(
+      Date.now() - 40 * 24 * 3600 * 1000,
+    ).toISOString();
+    await seed([
+      {
+        userId: USER_UUID,
+        eventId: EVENT_A,
+        actionType: 'VIEW',
+        createdAt: fortyDaysAgo,
+      },
+      { userId: USER_UUID, eventId: EVENT_B, actionType: 'VIEW' },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/internal/logs/actions?userId=${USER_UUID}&days=7&actionTypes=VIEW`,
+      headers: AI_HEADER,
+    });
+
+    const logs = res.json().logs;
+    expect(logs).toHaveLength(1);
+    expect(logs[0].eventId).toBe(EVENT_B);
+  });
+});

--- a/fastify-log/test/integration/internal-log.route.db.test.ts
+++ b/fastify-log/test/integration/internal-log.route.db.test.ts
@@ -149,18 +149,23 @@ describeIfDb('InternalLogRoutes (실 Postgres)', () => {
   });
 
   it('created_at DESC 정렬', async () => {
+    // 상대 시간 기반 — 실행 시점에 독립적 (days=7 기본 범위 내 보장)
+    const now = Date.now();
+    const threeHoursAgo = new Date(now - 3 * 60 * 60 * 1000).toISOString();
+    const oneHourAgo = new Date(now - 60 * 60 * 1000).toISOString();
+
     await seed([
       {
         userId: USER_UUID,
         eventId: EVENT_A,
         actionType: 'VIEW',
-        createdAt: '2026-01-01T00:00:00Z',
+        createdAt: threeHoursAgo,
       },
       {
         userId: USER_UUID,
         eventId: EVENT_B,
         actionType: 'VIEW',
-        createdAt: '2026-04-01T00:00:00Z',
+        createdAt: oneHourAgo,
       },
     ]);
 
@@ -174,6 +179,72 @@ describeIfDb('InternalLogRoutes (실 Postgres)', () => {
     expect(logs[0].eventId).toBe(EVENT_B);
     expect(logs[1].eventId).toBe(EVENT_A);
   });
+
+  it('응답 필드 완전성 — eventId/actionType/dwellTimeSeconds 3개만 (추가 필드 유출 없음)', async () => {
+    // 상대 시간 기반 — 실행 시점에 독립적 (days=7 기본 범위 내 보장)
+    const now = Date.now();
+    const threeHoursAgo = new Date(now - 3 * 60 * 60 * 1000).toISOString();
+    const oneHourAgo = new Date(now - 60 * 60 * 1000).toISOString();
+
+    await seed([
+      {
+        userId: USER_UUID,
+        eventId: EVENT_A,
+        actionType: 'VIEW',
+        createdAt: threeHoursAgo,
+      },
+      {
+        userId: USER_UUID,
+        eventId: EVENT_B,
+        actionType: 'DWELL_TIME',
+        dwellTimeSeconds: 30,
+        createdAt: oneHourAgo,
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW,DWELL_TIME`,
+      headers: AI_HEADER,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    // 각 log 객체는 정확히 3개 필드만 — search_keyword, quantity, total_amount 등 DB 원본 누출 없어야 함
+    for (const log of body.logs) {
+      expect(Object.keys(log).sort()).toEqual([
+        'actionType',
+        'dwellTimeSeconds',
+        'eventId',
+      ]);
+    }
+
+    // DESC 정렬 + 필드 정확 매칭
+    expect(body.logs).toEqual([
+      { eventId: EVENT_B, actionType: 'DWELL_TIME', dwellTimeSeconds: 30 },
+      { eventId: EVENT_A, actionType: 'VIEW', dwellTimeSeconds: null },
+    ]);
+  });
+
+  it('LIMIT 5000 — 10001건 삽입 시 최신 5000건만 반환', async () => {
+    // generate_series로 단일 쿼리 대량 삽입 — beforeEach TRUNCATE로 격리됨
+    await pool.query(
+      `INSERT INTO log.action_log (user_id, event_id, action_type, created_at)
+       SELECT $1::uuid, $2::uuid, 'VIEW', NOW() - (s || ' seconds')::INTERVAL
+       FROM generate_series(1, 10001) AS s`,
+      [USER_UUID, EVENT_A],
+    );
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/internal/logs/actions?userId=${USER_UUID}&days=1&actionTypes=VIEW`,
+      headers: AI_HEADER,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().logs).toHaveLength(5000);
+  }, 30000);
 
   it('days 범위 밖 (40일 전) 로그 제외', async () => {
     const fortyDaysAgo = new Date(

--- a/fastify-log/test/unit/internal-log.route.test.ts
+++ b/fastify-log/test/unit/internal-log.route.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+
+const { mockGetRecentLogs } = vi.hoisted(() => ({
+  mockGetRecentLogs: vi.fn(),
+}));
+
+vi.mock('../../src/service/action-log.service', () => ({
+  actionLogService: {
+    save: vi.fn(),
+    getRecentLogs: mockGetRecentLogs,
+  },
+}));
+
+vi.mock('../../src/config/database', () => ({
+  pool: { query: vi.fn() },
+}));
+
+import { internalLogRoutes } from '../../src/route/internal-log.route';
+
+const USER_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(internalLogRoutes);
+  return app;
+}
+
+describe('InternalLogRoutes — GET /internal/logs/actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ========== X-Internal-Service 헤더 가드 ==========
+
+  describe('X-Internal-Service 헤더 가드', () => {
+    it('헤더 누락 → 401', async () => {
+      // given
+      const app = await buildApp();
+
+      // when
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW`,
+      });
+
+      // then
+      expect(res.statusCode).toBe(401);
+      expect(res.json()).toMatchObject({ statusCode: 401, error: 'Unauthorized' });
+      expect(mockGetRecentLogs).not.toHaveBeenCalled();
+    });
+
+    it('allowlist 외 값 → 403', async () => {
+      // given
+      const app = await buildApp();
+
+      // when
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW`,
+        headers: { 'x-internal-service': 'attacker' },
+      });
+
+      // then
+      expect(res.statusCode).toBe(403);
+      expect(res.json()).toMatchObject({ statusCode: 403, error: 'Forbidden' });
+      expect(mockGetRecentLogs).not.toHaveBeenCalled();
+    });
+
+    it('allowlist 값 (ai) → 통과', async () => {
+      // given
+      mockGetRecentLogs.mockResolvedValueOnce([]);
+      const app = await buildApp();
+
+      // when
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW`,
+        headers: { 'x-internal-service': 'ai' },
+      });
+
+      // then
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  // ========== 쿼리 파라미터 validation ==========
+
+  describe('쿼리 파라미터 validation', () => {
+    const ok = { 'x-internal-service': 'ai' };
+
+    it('userId 미UUID → 400', async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/internal/logs/actions?userId=not-a-uuid&actionTypes=VIEW',
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(400);
+      expect(mockGetRecentLogs).not.toHaveBeenCalled();
+    });
+
+    it('userId 누락 → 400', async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/internal/logs/actions?actionTypes=VIEW',
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('actionTypes 누락 → 400', async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}`,
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('days 상한 초과 (31) → 400', async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&days=31&actionTypes=VIEW`,
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('days 하한 미만 (0) → 400', async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&days=0&actionTypes=VIEW`,
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('days 누락 → 기본 7 사용', async () => {
+      mockGetRecentLogs.mockResolvedValueOnce([]);
+      const app = await buildApp();
+      await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW`,
+        headers: ok,
+      });
+      expect(mockGetRecentLogs).toHaveBeenCalledWith(USER_UUID, 7, ['VIEW']);
+    });
+
+    it('actionTypes 무효 토큰 포함 (UNKNOWN) → 400', async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW,UNKNOWN`,
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().message).toContain('actionTypes');
+      expect(mockGetRecentLogs).not.toHaveBeenCalled();
+    });
+
+    it('actionTypes CSV 공백 트림', async () => {
+      mockGetRecentLogs.mockResolvedValueOnce([]);
+      const app = await buildApp();
+      await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW,%20DETAIL_VIEW`,
+        headers: ok,
+      });
+      expect(mockGetRecentLogs).toHaveBeenCalledWith(
+        USER_UUID,
+        7,
+        ['VIEW', 'DETAIL_VIEW'],
+      );
+    });
+
+    it('URL 인코딩된 actionTypes (VIEW%2CDETAIL_VIEW) → 자동 디코딩', async () => {
+      mockGetRecentLogs.mockResolvedValueOnce([]);
+      const app = await buildApp();
+      await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW%2CDETAIL_VIEW`,
+        headers: ok,
+      });
+      expect(mockGetRecentLogs).toHaveBeenCalledWith(
+        USER_UUID,
+        7,
+        ['VIEW', 'DETAIL_VIEW'],
+      );
+    });
+
+    it('actionTypes가 comma 단독 → 400 (빈 토큰만)', async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=%2C`,
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('소문자 actionType → 400', async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=view`,
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  // ========== 정상 응답 ==========
+
+  describe('정상 응답', () => {
+    const ok = { 'x-internal-service': 'ai' };
+
+    it('로그 존재 → 200 + logs 배열 + service 호출 인자 확인', async () => {
+      // given
+      mockGetRecentLogs.mockResolvedValueOnce([
+        {
+          eventId: '11111111-1111-4111-8111-111111111111',
+          actionType: 'VIEW',
+          dwellTimeSeconds: null,
+        },
+        {
+          eventId: '22222222-2222-4222-8222-222222222222',
+          actionType: 'DWELL_TIME',
+          dwellTimeSeconds: 45,
+        },
+      ]);
+      const app = await buildApp();
+
+      // when
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&days=7&actionTypes=VIEW,DWELL_TIME`,
+        headers: ok,
+      });
+
+      // then
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({
+        userId: USER_UUID,
+        logs: [
+          {
+            eventId: '11111111-1111-4111-8111-111111111111',
+            actionType: 'VIEW',
+            dwellTimeSeconds: null,
+          },
+          {
+            eventId: '22222222-2222-4222-8222-222222222222',
+            actionType: 'DWELL_TIME',
+            dwellTimeSeconds: 45,
+          },
+        ],
+      });
+      expect(mockGetRecentLogs).toHaveBeenCalledWith(
+        USER_UUID,
+        7,
+        ['VIEW', 'DWELL_TIME'],
+      );
+    });
+
+    it('로그 없음 → 200 + 빈 배열 (404 아님)', async () => {
+      mockGetRecentLogs.mockResolvedValueOnce([]);
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW`,
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ userId: USER_UUID, logs: [] });
+    });
+  });
+});

--- a/fastify-log/test/unit/internal-log.route.test.ts
+++ b/fastify-log/test/unit/internal-log.route.test.ts
@@ -14,14 +14,25 @@ vi.mock('../../src/service/action-log.service', () => ({
 
 vi.mock('../../src/config/database', () => ({
   pool: { query: vi.fn() },
+  pingDatabase: vi.fn().mockResolvedValue(true),
+  closeDatabase: vi.fn(),
 }));
 
 import { internalLogRoutes } from '../../src/route/internal-log.route';
+import { healthRoutes } from '../../src/route/health.route';
 
 const USER_UUID = '550e8400-e29b-41d4-a716-446655440000';
 
 async function buildApp(): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
+  await app.register(internalLogRoutes);
+  return app;
+}
+
+// index.ts와 동일한 등록 순서 — health + internal 두 라우트 공존 회귀 검증용
+async function buildAppWithHealth(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(healthRoutes);
   await app.register(internalLogRoutes);
   return app;
 }
@@ -276,6 +287,129 @@ describe('InternalLogRoutes — GET /internal/logs/actions', () => {
       });
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ userId: USER_UUID, logs: [] });
+    });
+  });
+
+  // ========== Fastify encapsulation 회귀 방지 ==========
+
+  describe('Fastify encapsulation 회귀 방지', () => {
+    it('/health는 internal-log의 onRequest hook 영향 없음', async () => {
+      // given
+      const app = await buildAppWithHealth();
+
+      // when — X-Internal-Service 헤더 없이 요청
+      const res = await app.inject({ method: 'GET', url: '/health' });
+
+      // then
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ status: 'ok' });
+    });
+
+    it('/ready는 internal-log의 onRequest hook 영향 없음', async () => {
+      const app = await buildAppWithHealth();
+      const res = await app.inject({ method: 'GET', url: '/ready' });
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  // ========== 보안 엄격성 ==========
+
+  describe('X-Internal-Service 값 엄격 매칭', () => {
+    it('대문자 AI → 403 — allowlist는 정확한 문자열 매칭', async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW`,
+        headers: { 'x-internal-service': 'AI' },
+      });
+      expect(res.statusCode).toBe(403);
+      expect(mockGetRecentLogs).not.toHaveBeenCalled();
+    });
+  });
+
+  // ========== 에러 전파 ==========
+
+  describe('에러 전파', () => {
+    const ok = { 'x-internal-service': 'ai' };
+
+    it('service throw → 500 (Fastify 기본 핸들러)', async () => {
+      mockGetRecentLogs.mockRejectedValueOnce(new Error('DB connection lost'));
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW`,
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(500);
+    });
+  });
+
+  // ========== 경계값 ==========
+
+  describe('days 경계값', () => {
+    const ok = { 'x-internal-service': 'ai' };
+
+    it.each([1, 30])('days=%i 경계값 정상 통과', async (days) => {
+      mockGetRecentLogs.mockResolvedValueOnce([]);
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&days=${days}&actionTypes=VIEW`,
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(mockGetRecentLogs).toHaveBeenCalledWith(USER_UUID, days, ['VIEW']);
+    });
+  });
+
+  // ========== actionTypes 엣지 케이스 ==========
+
+  describe('actionTypes 엣지 케이스', () => {
+    const ok = { 'x-internal-service': 'ai' };
+
+    it('중복 토큰 (VIEW,VIEW,VIEW) — 현 구현은 그대로 전달', async () => {
+      mockGetRecentLogs.mockResolvedValueOnce([]);
+      const app = await buildApp();
+      await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=VIEW,VIEW,VIEW`,
+        headers: ok,
+      });
+      expect(mockGetRecentLogs).toHaveBeenCalledWith(
+        USER_UUID,
+        7,
+        ['VIEW', 'VIEW', 'VIEW'],
+      );
+    });
+
+    it('빈 문자열 (actionTypes=) → 400 (schema minLength 방어선)', async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=`,
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it.each([
+      'VIEW',
+      'DETAIL_VIEW',
+      'CART_ADD',
+      'CART_REMOVE',
+      'PURCHASE',
+      'DWELL_TIME',
+      'REFUND',
+    ])('ActionType 전수 통과 — %s', async (actionType) => {
+      mockGetRecentLogs.mockResolvedValueOnce([]);
+      const app = await buildApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: `/internal/logs/actions?userId=${USER_UUID}&actionTypes=${actionType}`,
+        headers: ok,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(mockGetRecentLogs).toHaveBeenCalledWith(USER_UUID, 7, [actionType]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **신규 엔드포인트**: `GET /internal/logs/actions` — AI 추천 모듈의 최근 사용자 행동 로그 조회용 Internal API
- **V2 인덱스**: `(user_id, created_at DESC)` 복합 인덱스 추가 (`CONCURRENTLY + IF NOT EXISTS`)
- **V1 COMMENT 보강**: `total_amount` / `created_at` / `updated_at` 컬럼 의도 명시 (DDL 변경 없음)
- **테스트**: 단위 31 + 통합 7 = 총 38건

Closes #555

## 변경 상세

### Route (`internal-log.route.ts` 신규)
- Fastify JSON Schema validation (days: 1~30, actionTypes: CSV)
- `X-Internal-Service` 헤더 가드 (onRequest hook, allowlist: `ai`) — 대문자 매칭 엄격 (`AI` → 403)
- 응답 필드: `eventId` / `actionType` / `dwellTimeSeconds` 3개만 노출 (DB 원본 컬럼 유출 차단)

### Service
- `getRecentLogs(userId, days, actionTypes)` — LIMIT 5000 상한, `ActionType` enum 검증

### Repository
- `findRecentActions` — `WHERE event_id IS NOT NULL` / `ORDER BY created_at DESC` / `LIMIT 5000`

### SQL
- `V2__add_user_created_index.sql` 신규: `(user_id, created_at DESC)` 복합 인덱스
- `V1__create_action_log.sql` COMMENT 업데이트:
  - `total_amount`: PURCHASE 다건 주문 시 NULL (SUM 부풀림 방지, 정확 매출은 `Payment.payment.total_amount` 집계)
  - `created_at`: Kafka 메시지 timestamp 저장 (수신 시각 아님, AI 시퀀스 분석 기준)
  - `updated_at`: append-only 특성상 미사용 (확장 여지 보존)

### 설정
- `.env.example` PORT `8085` → `8086` (설계값 정합)

## Test plan

- [x] 단위 테스트 31건 passed
  - validation 400/401/403, null eventId skip, URL 인코딩
  - Fastify encapsulation 회귀 (health/ready hook 영향 X)
  - service throw → 500, days 경계 1/30
  - ActionType enum 7종 전수 (VIEW/DETAIL_VIEW/CART_ADD/CART_REMOVE/PURCHASE/DWELL_TIME/REFUND)
  - 응답 필드 완전성 / actionTypes 중복 토큰 / 빈 문자열
- [x] 통합 테스트 7건 passed (`RUN_DB_TESTS=1`)
  - 실 DB seed + LIMIT 5000 (10001건 → 5000건)
  - 응답 필드 완전성 toEqual 정확 매칭
  - 시간 의존성 제거: `Date.now()` 기반 상대 시간 seed (실행 시점 독립)
- [x] 커밋 구성: feat + test 2-commit (테스트 2건 squash 완료)
- [ ] 리뷰어: 운영 DB에 V2 인덱스 생성 수동 실행 여부 확인