### PR TITLE
[Payment] fix: OutboxRepositoryTest CI 환경 H2 나노초 정밀도 문제 수정

### DIFF
--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxRepositoryTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.persistence.EntityManager;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -88,7 +89,7 @@ class OutboxRepositoryTest {
         @Test
         void nextRetryAt이_현재와_동일하면_스킵된다() {
             // `<` 연산자라서 경계값은 배제 — 다음 틱에서 픽업됨
-            Instant now = Instant.now();
+            Instant now = Instant.now().truncatedTo(ChronoUnit.MICROS);
             Outbox saved = saveWithNextRetryAt(now);
 
             List<Outbox> result = outboxRepository.findPendingToPublish(


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- CI 환경에서만 실패하던 `OutboxRepositoryTest` 수정

## 변경 사항
- `OutboxRepositoryTest.java`
  - `nextRetryAt이_현재와_동일하면_스킵된다()` 테스트의 `Instant.now()` 에 `truncatedTo(ChronoUnit.MICROS)` 적용
  - `saveWithNextRetryAt()` 내부 JPQL UPDATE 파라미터에 동일하게 적용

## 원인
로컬(PostgreSQL)과 CI(H2 in-memory)의 `Instant` 저장 정밀도 차이로 발생

| 환경 | 저장 정밀도 |
|---|---|
| PostgreSQL | 마이크로초(6자리) |
| H2 | 나노초(9자리) → 내부 변환 시 값이 미묘하게 달라짐 |

H2가 나노초를 저장하는 과정에서 값을 변환하여 `nextRetryAt < :now` 조건이 `true`가 되어 경계값이 결과에 포함되는 문제

## 테스트
- [x] 단위 테스트 통과
- 비즈니스 로직(`<` 경계값 배제) 의도 그대로 유지됨

## 참고 사항
- 프로덕션 코드 변경 없음, 테스트 코드만 수정
- `OutboxRepository.findPendingToPublish()` 쿼리 자체는 변경 없음