### PR TITLE
[Event] fix: ES 재색인 최적화 - 누락 이벤트 동기화 및 종료 이벤트 삭제

### DIFF
--- a/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
+++ b/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
@@ -1,11 +1,16 @@
 package com.devticket.event.common.config;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.devticket.event.application.EventService;
 import com.devticket.event.domain.model.Event;
 import com.devticket.event.infrastructure.persistence.EventRepository;
 import com.devticket.event.infrastructure.search.EventDocument;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -21,6 +26,7 @@ import org.springframework.stereotype.Component;
 public class ElasticsearchIndexInitializer {
 
     private final ElasticsearchOperations elasticsearchOperations;
+    private final ElasticsearchClient esClient;
     private final EventRepository eventRepository;
     private final EventService eventService;
 
@@ -34,16 +40,7 @@ public class ElasticsearchIndexInitializer {
                 log.info("[ES Index] 'event' 인덱스 생성 완료");
                 reindexAllEvents();
             } else {
-                long count = elasticsearchOperations.count(
-                    org.springframework.data.elasticsearch.client.elc.NativeQuery.builder().build(),
-                    EventDocument.class
-                );
-                if (count == 0) {
-                    log.info("[ES Index] 인덱스는 있지만 비어있음 → 재색인 시작");
-                    reindexAllEvents();
-                } else {
-                    log.info("[ES Index] 기존 'event' 인덱스 유지 ({}건)", count);
-                }
+                syncMissingEvents();
             }
 
         } catch (Exception e) {
@@ -52,21 +49,70 @@ public class ElasticsearchIndexInitializer {
         }
     }
 
-    /**
-     * DB의 모든 이벤트를 ES에 재색인.
-     * embedding 포함 저장 (syncToElasticsearch 재사용)
-     */
+    private void syncMissingEvents() {
+        Set<String> dbEventIds = eventRepository.findAllEventIds().stream()
+            .map(UUID::toString)
+            .collect(Collectors.toSet());
+
+        if (dbEventIds.isEmpty()) {
+            log.info("[ES] DB에 이벤트 없음, 동기화 스킵");
+            return;
+        }
+
+        Set<String> esEventIds = getAllEsDocumentIds();
+
+        Set<UUID> missingIds = dbEventIds.stream()
+            .filter(id -> !esEventIds.contains(id))
+            .map(UUID::fromString)
+            .collect(Collectors.toSet());
+
+        if (missingIds.isEmpty()) {
+            log.info("[ES] 모든 이벤트 색인 완료 ({}/{}건)", dbEventIds.size(), dbEventIds.size());
+            return;
+        }
+
+        log.info("[ES] 누락 이벤트 {}건 색인 시작", missingIds.size());
+        List<Event> events = eventRepository.findAllWithDetailsByEventIdIn(new ArrayList<>(missingIds));
+
+        int count = 0;
+        for (Event event : events) {
+            try {
+                eventService.syncToElasticsearch(event);
+                count++;
+            } catch (Exception e) {
+                log.warn("[ES 색인 실패] eventId: {}", event.getEventId(), e);
+            }
+        }
+        log.info("[ES] 누락 색인 완료. {}건", count);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> getAllEsDocumentIds() {
+        try {
+            var response = esClient.search(s -> s
+                    .index("event")
+                    .size(10000)
+                    .source(src -> src.fetch(false))
+                    .query(q -> q.matchAll(m -> m)),
+                Map.class);
+
+            return response.hits().hits().stream()
+                .map(hit -> hit.id())
+                .collect(Collectors.toSet());
+        } catch (Exception e) {
+            log.warn("[ES] 전체 ID 조회 실패 - 전체 재색인으로 폴백", e);
+            return Set.of();
+        }
+    }
+
     private void reindexAllEvents() {
-        List<UUID> allEventIds = eventRepository.findAll().stream()
-            .map(Event::getEventId)
-            .toList();
+        List<UUID> allEventIds = eventRepository.findAllEventIds();
 
         if (allEventIds.isEmpty()) {
             log.info("[ES 재색인] 재색인할 이벤트 없음");
             return;
         }
 
-        // techStacks Fetch Join (LazyInitializationException 방지)
         List<Event> events = eventRepository.findAllWithDetailsByEventIdIn(allEventIds);
 
         int count = 0;

--- a/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
+++ b/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
@@ -2,12 +2,12 @@ package com.devticket.event.common.config;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.devticket.event.application.EventService;
+import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.domain.model.Event;
 import com.devticket.event.infrastructure.persistence.EventRepository;
 import com.devticket.event.infrastructure.search.EventDocument;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -24,6 +24,12 @@ import org.springframework.stereotype.Component;
 @Profile("!test")
 @RequiredArgsConstructor
 public class ElasticsearchIndexInitializer {
+
+    private static final List<EventStatus> ACTIVE_STATUSES =
+        List.of(EventStatus.DRAFT, EventStatus.ON_SALE, EventStatus.SOLD_OUT);
+
+    private static final List<EventStatus> TERMINATED_STATUSES =
+        List.of(EventStatus.SALE_ENDED, EventStatus.CANCELLED, EventStatus.FORCE_CANCELLED);
 
     private final ElasticsearchOperations elasticsearchOperations;
     private final ElasticsearchClient esClient;
@@ -50,40 +56,57 @@ public class ElasticsearchIndexInitializer {
     }
 
     private void syncMissingEvents() {
-        Set<String> dbEventIds = eventRepository.findAllEventIds().stream()
+        Set<String> activeDbIds = eventRepository.findAllEventIdsByStatusIn(ACTIVE_STATUSES).stream()
             .map(UUID::toString)
             .collect(Collectors.toSet());
 
-        if (dbEventIds.isEmpty()) {
-            log.info("[ES] DB에 이벤트 없음, 동기화 스킵");
-            return;
-        }
+        Set<String> terminatedDbIds = eventRepository.findAllEventIdsByStatusIn(TERMINATED_STATUSES).stream()
+            .map(UUID::toString)
+            .collect(Collectors.toSet());
 
-        Set<String> esEventIds = getAllEsDocumentIds();
+        Set<String> esIds = getAllEsDocumentIds();
 
-        Set<UUID> missingIds = dbEventIds.stream()
-            .filter(id -> !esEventIds.contains(id))
+        // 누락된 활성 이벤트 색인
+        Set<UUID> missingIds = activeDbIds.stream()
+            .filter(id -> !esIds.contains(id))
             .map(UUID::fromString)
             .collect(Collectors.toSet());
 
-        if (missingIds.isEmpty()) {
-            log.info("[ES] 모든 이벤트 색인 완료 ({}/{}건)", dbEventIds.size(), dbEventIds.size());
-            return;
-        }
-
-        log.info("[ES] 누락 이벤트 {}건 색인 시작", missingIds.size());
-        List<Event> events = eventRepository.findAllWithDetailsByEventIdIn(new ArrayList<>(missingIds));
-
-        int count = 0;
-        for (Event event : events) {
-            try {
-                eventService.syncToElasticsearch(event);
-                count++;
-            } catch (Exception e) {
-                log.warn("[ES 색인 실패] eventId: {}", event.getEventId(), e);
+        if (!missingIds.isEmpty()) {
+            log.info("[ES] 누락 이벤트 {}건 색인 시작", missingIds.size());
+            List<Event> events = eventRepository.findAllWithDetailsByEventIdIn(new ArrayList<>(missingIds));
+            int count = 0;
+            for (Event event : events) {
+                try {
+                    eventService.syncToElasticsearch(event);
+                    count++;
+                } catch (Exception e) {
+                    log.warn("[ES 색인 실패] eventId: {}", event.getEventId(), e);
+                }
             }
+            log.info("[ES] 누락 색인 완료. {}건", count);
+        } else {
+            log.info("[ES] 활성 이벤트 모두 색인됨 ({}건)", activeDbIds.size());
         }
-        log.info("[ES] 누락 색인 완료. {}건", count);
+
+        // ES에 남아있는 종료 이벤트 삭제
+        Set<String> staleEsIds = terminatedDbIds.stream()
+            .filter(esIds::contains)
+            .collect(Collectors.toSet());
+
+        if (!staleEsIds.isEmpty()) {
+            log.info("[ES] 종료 이벤트 {}건 인덱스에서 삭제 시작", staleEsIds.size());
+            int deleted = 0;
+            for (String id : staleEsIds) {
+                try {
+                    esClient.delete(d -> d.index("event").id(id));
+                    deleted++;
+                } catch (Exception e) {
+                    log.warn("[ES 삭제 실패] eventId: {}", id, e);
+                }
+            }
+            log.info("[ES] 종료 이벤트 삭제 완료. {}건", deleted);
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -94,19 +117,19 @@ public class ElasticsearchIndexInitializer {
                     .size(10000)
                     .source(src -> src.fetch(false))
                     .query(q -> q.matchAll(m -> m)),
-                Map.class);
+                java.util.Map.class);
 
             return response.hits().hits().stream()
                 .map(hit -> hit.id())
                 .collect(Collectors.toSet());
         } catch (Exception e) {
-            log.warn("[ES] 전체 ID 조회 실패 - 전체 재색인으로 폴백", e);
+            log.warn("[ES] 전체 ID 조회 실패 - 동기화 스킵", e);
             return Set.of();
         }
     }
 
     private void reindexAllEvents() {
-        List<UUID> allEventIds = eventRepository.findAllEventIds();
+        List<UUID> allEventIds = eventRepository.findAllEventIdsByStatusIn(ACTIVE_STATUSES);
 
         if (allEventIds.isEmpty()) {
             log.info("[ES 재색인] 재색인할 이벤트 없음");
@@ -124,7 +147,6 @@ public class ElasticsearchIndexInitializer {
                 log.warn("[ES 재색인 실패] eventId: {}", event.getEventId(), e);
             }
         }
-
         log.info("[ES 재색인] 완료. 총 {}건", count);
     }
 }

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
@@ -33,8 +33,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
         Pageable pageable
     );
 
-    @Query("SELECT e.eventId FROM Event e")
-    List<UUID> findAllEventIds();
+    @Query("SELECT e.eventId FROM Event e WHERE e.status IN :statuses")
+    List<UUID> findAllEventIdsByStatusIn(@Param("statuses") List<EventStatus> statuses);
 
     // 외부 API
     List<Event> findAllByEventIdIn(List<UUID> eventIds);

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
@@ -33,6 +33,9 @@ public interface EventRepository extends JpaRepository<Event, Long> {
         Pageable pageable
     );
 
+    @Query("SELECT e.eventId FROM Event e")
+    List<UUID> findAllEventIds();
+
     // 외부 API
     List<Event> findAllByEventIdIn(List<UUID> eventIds);
 


### PR DESCRIPTION
## 관련 이슈
- close #571 

## 작업 내용
- 서버 재시작 시 DB와 ES의 ID를 비교해 누락된 활성 이벤트만 색인
- 이미 색인된 이벤트는 OpenAI 임베딩 API 호출을 건너뛰어 재시작 시간 단축
- 종료 상태 이벤트는 색인 대상에서 제외하고 ES에 잔존 시 삭제하여 인덱스 정합성 유지

## 변경 사항
- `EventRepository`: `findAllEventIdsByStatusIn()` 추가 — 상태 기반 eventId 프로젝션
- `ElasticsearchIndexInitializer`:
  - `syncMissingEvents()` 추가 — 활성 이벤트 누락분 색인 + 종료 이벤트 ES 삭제
  - `getAllEsDocumentIds()` 추가 — esClient 직접 사용, source:false로 dense_vector 로딩 방지
  - `reindexAllEvents()` — 활성 이벤트만 색인하도록 변경


## 참고 사항
- 인덱스 자체가 없을 경우 기존과 동일하게 활성 이벤트 전체 재색인 수행
- `getAllEsDocumentIds()` 실패 시 빈 Set 반환 → 동기화 스킵으로 안전하게 처리
- 종료 이벤트 제외로 ES 문서 수 감소 → 10,000건 제한 초과 가능성 완화