### PR TITLE
[Admin] cleanup: 식별자 오타 Settelment → Settlement 정정

### DIFF
--- a/admin/src/main/java/com/devticket/admin/application/service/AdminSettlementService.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/AdminSettlementService.java
@@ -1,10 +1,10 @@
 package com.devticket.admin.application.service;
 
 import com.devticket.admin.presentation.dto.req.AdminSettlementSearchRequest;
-import com.devticket.admin.presentation.dto.res.AdminSettelmentListResponse;
+import com.devticket.admin.presentation.dto.res.AdminSettlementListResponse;
 import java.util.UUID;
 
 public interface AdminSettlementService {
-    AdminSettelmentListResponse getSettlementList(AdminSettlementSearchRequest condition);
+    AdminSettlementListResponse getSettlementList(AdminSettlementSearchRequest condition);
     void runSettlement(UUID adminId);
 }

--- a/admin/src/main/java/com/devticket/admin/application/service/AdminSettlementServiceImpl.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/AdminSettlementServiceImpl.java
@@ -7,7 +7,7 @@ import com.devticket.admin.domain.repository.AdminActionRepository;
 import com.devticket.admin.infrastructure.external.client.SettlementInternalClient;
 import com.devticket.admin.infrastructure.external.dto.res.InternalSettlementPageResponse;
 import com.devticket.admin.presentation.dto.req.AdminSettlementSearchRequest;
-import com.devticket.admin.presentation.dto.res.AdminSettelmentListResponse;
+import com.devticket.admin.presentation.dto.res.AdminSettlementListResponse;
 import com.devticket.admin.presentation.dto.res.SettlementResponse;
 import java.util.List;
 import java.util.UUID;
@@ -24,7 +24,7 @@ public class AdminSettlementServiceImpl implements AdminSettlementService {
     private final AdminActionRepository adminActionRepository;
 
     @Override
-    public AdminSettelmentListResponse getSettlementList(AdminSettlementSearchRequest condition) {
+    public AdminSettlementListResponse getSettlementList(AdminSettlementSearchRequest condition) {
         InternalSettlementPageResponse page = settlementInternalClient.getSettlements(condition);
         List<SettlementResponse> content = page.content().stream()
             .map(s -> new SettlementResponse(
@@ -32,7 +32,7 @@ public class AdminSettlementServiceImpl implements AdminSettlementService {
                 s.totalSalesAmount(), s.totalRefundAmount(), s.totalFeeAmount(),
                 s.finalSettlementAmount(), s.status(), s.settledAt()))
             .toList();
-        return new AdminSettelmentListResponse(content, page.page(), page.size(), page.totalElements(), page.totalPages());
+        return new AdminSettlementListResponse(content, page.page(), page.size(), page.totalElements(), page.totalPages());
     }
 
     @Transactional

--- a/admin/src/main/java/com/devticket/admin/presentation/controller/AdminSettlementController.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/controller/AdminSettlementController.java
@@ -2,7 +2,7 @@ package com.devticket.admin.presentation.controller;
 
 import com.devticket.admin.application.service.AdminSettlementService;
 import com.devticket.admin.presentation.dto.req.AdminSettlementSearchRequest;
-import com.devticket.admin.presentation.dto.res.AdminSettelmentListResponse;
+import com.devticket.admin.presentation.dto.res.AdminSettlementListResponse;
 import com.devticket.admin.presentation.dto.res.SettlementResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -30,7 +30,7 @@ public class AdminSettlementController {
     @ApiResponse(responseCode = "200", description = "정산 목록 조회 성공")
     @ApiResponse(responseCode = "403", description = "접근 권한 없음 (COMMON_005)")
     @GetMapping("/settlements")
-    public AdminSettelmentListResponse getAdminSettlementList(
+    public AdminSettlementListResponse getAdminSettlementList(
         @ModelAttribute @Valid AdminSettlementSearchRequest condition) {
         return adminSettlementService.getSettlementList(condition);
     }

--- a/admin/src/main/java/com/devticket/admin/presentation/dto/res/AdminSettlementListResponse.java
+++ b/admin/src/main/java/com/devticket/admin/presentation/dto/res/AdminSettlementListResponse.java
@@ -3,7 +3,7 @@ package com.devticket.admin.presentation.dto.res;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record AdminSettelmentListResponse(
+public record AdminSettlementListResponse(
 
     @Schema(description = "정산 목록 (SettlementResponse 재사용)", example = "json List 형태")
     List<SettlementResponse> content,

--- a/admin/src/test/java/com/devticket/admin/service/AdminSettlementServiceImplTest.java
+++ b/admin/src/test/java/com/devticket/admin/service/AdminSettlementServiceImplTest.java
@@ -13,7 +13,7 @@ import com.devticket.admin.infrastructure.external.client.SettlementInternalClie
 import com.devticket.admin.infrastructure.external.dto.res.InternalSettlementPageResponse;
 import com.devticket.admin.infrastructure.external.dto.res.InternalSettlementResponse;
 import com.devticket.admin.presentation.dto.req.AdminSettlementSearchRequest;
-import com.devticket.admin.presentation.dto.res.AdminSettelmentListResponse;
+import com.devticket.admin.presentation.dto.res.AdminSettlementListResponse;
 import com.devticket.admin.presentation.dto.res.SettlementResponse;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -62,7 +62,7 @@ class AdminSettlementServiceImplTest {
             given(settlementInternalClient.getSettlements(condition)).willReturn(page);
 
             // when
-            AdminSettelmentListResponse response = adminSettlementService.getSettlementList(condition);
+            AdminSettlementListResponse response = adminSettlementService.getSettlementList(condition);
 
             // then
             assertThat(response.page()).isEqualTo(0);
@@ -95,7 +95,7 @@ class AdminSettlementServiceImplTest {
                 .willReturn(new InternalSettlementPageResponse(List.of(), 0, 20, 0L, 0));
 
             // when
-            AdminSettelmentListResponse response = adminSettlementService.getSettlementList(condition);
+            AdminSettlementListResponse response = adminSettlementService.getSettlementList(condition);
 
             // then
             assertThat(response.content()).isEmpty();


### PR DESCRIPTION
## Summary
- DTO 클래스 `AdminSettelmentListResponse` → `AdminSettlementListResponse` rename (오타 정정)
- 참조 4개 파일(Service 인터페이스/구현체, Controller, Test) import 및 타입 사용처 갱신
- HTTP 경로/응답 JSON 키 변동 없음 — 외부 계약 무영향, OpenAPI 컴포넌트명만 변경

## Background
문서·코드 sync 감사 중 식별자 오타 발견. 정상 단어는 `Settlement`(8자)이나 코드는 `Settelment`(9자)로 'e'가 'l' 앞에 잘못 위치. 동일 모듈에 정상 표기(`AdminSettlementService`, `AdminSettlementController`)와 오타 표기가 혼재해 가독성·검색성 저해.

## 변경 파일
- `src/main/java/com/devticket/admin/presentation/dto/res/AdminSettelmentListResponse.java` → `AdminSettlementListResponse.java` (rename, 93% 유사도)
- `src/main/java/com/devticket/admin/application/service/AdminSettlementService.java` (import + 반환 타입)
- `src/main/java/com/devticket/admin/application/service/AdminSettlementServiceImpl.java` (import + 반환 타입 + new 호출)
- `src/main/java/com/devticket/admin/presentation/controller/AdminSettlementController.java` (import + 반환 타입)
- `src/test/java/com/devticket/admin/service/AdminSettlementServiceImplTest.java` (import + 변수 선언 2건)

## 영향 범위
- BE: admin 모듈만 영향, 타 BE 모듈은 admin DTO 의존 없음
- FE: admin 프론트엔드 — OpenAPI Generator 등으로 자동 코드생성을 사용하는 경우 컴포넌트명 변경(`AdminSettelmentListResponse` → `AdminSettlementListResponse`) 따라 클라이언트 코드 재생성 + import rename 필요
- DB 컬럼/HTTP 경로/JSON 키 변동 없음 (Java 식별자만)

## Test plan
- [x] `./gradlew build test` — BUILD SUCCESSFUL
- [x] 리포지토리 전체 `Settelment` 잔존 검색 — 0건 확인
- [x] OpenAPI 영향 분석 — `components.schemas` 키 1개 rename, 응답 본문 동일성 확인
- [x] HTTP 응답 JSON 키 동일성 — `@JsonProperty`/글로벌 Jackson 설정 부재, record 컴포넌트명 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)