### PR TITLE
[Commerce] cleanup: 식별자 오타 Settelment → Settlement 정정

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -234,7 +234,7 @@ public class OrderService implements OrderUsecase {
     }
 
     @Override
-    public InternalSettlementDataResponse getSettelmentData(UUID sellerId, String periodStart, String periodEnd) {
+    public InternalSettlementDataResponse getSettlementData(UUID sellerId, String periodStart, String periodEnd) {
         try {
             log.info("[Settlement Debug] 시작 - sellerId: {}, period: {} ~ {}", sellerId, periodStart, periodEnd);
 

--- a/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
@@ -37,7 +37,7 @@ public interface OrderUsecase {
 
     void failOrder(UUID orderId);
 
-    InternalSettlementDataResponse getSettelmentData(UUID sellerId, String periodStart, String periodEnd);
+    InternalSettlementDataResponse getSettlementData(UUID sellerId, String periodStart, String periodEnd);
 
     InternalOrderItemResponse getOrderItemByTicketId(UUID ticketId);
 

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/InternalOrderController.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/InternalOrderController.java
@@ -48,12 +48,12 @@ public class InternalOrderController {
 //        return ResponseEntity.ok(response).getBody();
 //    }
 
-    //Settelement -> Commerce : 기간별 정산 대상 데이터 조회
+    //Settlement -> Commerce : 기간별 정산 대상 데이터 조회
     @GetMapping("/orders/settlement-data")
     public ResponseEntity<InternalSettlementDataResponse> getSettlementData(@RequestParam UUID sellerId,
         @RequestParam String periodStart, @RequestParam String periodEnd) {
 
-        InternalSettlementDataResponse response = orderUsecase.getSettelmentData(sellerId, periodStart, periodEnd);
+        InternalSettlementDataResponse response = orderUsecase.getSettlementData(sellerId, periodStart, periodEnd);
         return ResponseEntity.ok(response);
     }
 

--- a/commerce/src/test/java/com/devticket/commerce/ticket/application/service/RefundTicketServiceTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/ticket/application/service/RefundTicketServiceTest.java
@@ -3,6 +3,7 @@ package com.devticket.commerce.ticket.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -12,6 +13,7 @@ import com.devticket.commerce.common.messaging.KafkaTopics;
 import com.devticket.commerce.common.messaging.MessageDeduplicationService;
 import com.devticket.commerce.common.messaging.event.refund.RefundTicketCancelEvent;
 import com.devticket.commerce.common.messaging.event.refund.RefundTicketCompensateEvent;
+import com.devticket.commerce.common.messaging.event.refund.RefundTicketDoneEvent;
 import com.devticket.commerce.common.outbox.OutboxService;
 import com.devticket.commerce.order.domain.repository.OrderRepository;
 import com.devticket.commerce.ticket.domain.enums.TicketStatus;
@@ -98,7 +100,7 @@ class RefundTicketServiceTest {
     }
 
     @Test
-    void processTicketRefundCancel_다중_이벤트면_이벤트별로_done_분할_발행() {
+    void processTicketRefundCancel_다중_이벤트면_items로_묶어_done_1건_발행() {
         UUID messageId = UUID.randomUUID();
         UUID orderId = UUID.randomUUID();
         UUID eventA = UUID.randomUUID();
@@ -116,9 +118,12 @@ class RefundTicketServiceTest {
         refundTicketService.processTicketRefundCancel(
             messageId, KafkaTopics.REFUND_TICKET_CANCEL, toJson(event));
 
-        then(outboxService).should(Mockito.times(2)).save(
+        then(outboxService).should(Mockito.times(1)).save(
             anyString(), anyString(), eq("REFUND_TICKET_DONE"),
-            eq(KafkaTopics.REFUND_TICKET_DONE), any());
+            eq(KafkaTopics.REFUND_TICKET_DONE),
+            argThat(payload -> payload instanceof RefundTicketDoneEvent done
+                && done.items().size() == 2
+                && done.ticketIds().size() == 3));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Settlement 식별자 오타 정정: `Settelment` → `Settlement` (3파일)
  - `OrderUsecase` / `OrderService` `getSettelmentData` → `getSettlementData`
  - `InternalOrderController` 호출부 + 주석 `Settelement` → `Settlement`
- 동반: `RefundTicketServiceTest` 통합 발행 정렬
  - `826f6cd` 이후 `refund.ticket.done` 발행 전략이 "이벤트별 분할" → "items 1건 통합"으로 변경됐으나 테스트 미동기화
  - `times(2)` → `times(1)` + `items.size()==2` + `ticketIds.size()==3` 검증

## 영향 범위
- HTTP 경로·JSON 응답 키 변동 없음 (Java 식별자만)
- 환불 Saga 프로덕션 코드 무변경 (테스트만 정렬)

## Test plan
- [x] `./gradlew compileJava compileTestJava` BUILD SUCCESSFUL
- [x] `./gradlew test` 140 tests passed
- [ ] (추가 권장) Settlement 모듈 레포에서 `getSettelmentData` Feign Client 등 직접 참조 부재 확인

## 참고
- 환불 영역 변경분은 본 작업자 담당 외(CLAUDE.md). `826f6cd` 후속 정렬 차원의 테스트 동기화만 수행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)