### PR TITLE
[gateway] fix : SecurityConfig에 허용Origin목록 추가_http://43.201.143.128:30000

### DIFF
--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/config/SecurityConfig.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/config/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
 
     private CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:13000","http://127.0.0.1:13000", "http://192.168.56.10:30000"));
+        config.setAllowedOrigins(List.of("http://localhost:13000","http://127.0.0.1:13000", "http://192.168.56.10:30000","http://43.201.143.128:30000"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);


### PR DESCRIPTION
SecurityConfig의 허용Origin목록에 http://43.201.143.128:30000추가