### PR TITLE
fix(payment): processed_message messageId 타입 UUID → String 통일 (#583)

### DIFF
--- a/payment/src/main/java/com/devticket/payment/common/messaging/MessageDeduplicationService.java
+++ b/payment/src/main/java/com/devticket/payment/common/messaging/MessageDeduplicationService.java
@@ -1,6 +1,5 @@
 package com.devticket.payment.common.messaging;
 
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +12,7 @@ public class MessageDeduplicationService {
     /**
      * 이미 처리된 메시지인지 확인한다.
      */
-    public boolean isDuplicate(UUID messageId) {
+    public boolean isDuplicate(String messageId) {
         return processedMessageRepository.existsByMessageId(messageId);
     }
 
@@ -21,7 +20,7 @@ public class MessageDeduplicationService {
      * 메시지를 처리 완료로 기록한다.
      * 반드시 비즈니스 로직과 같은 트랜잭션 안에서 호출해야 한다.
      */
-    public void markProcessed(UUID messageId, String topic) {
+    public void markProcessed(String messageId, String topic) {
         processedMessageRepository.save(ProcessedMessage.of(messageId, topic));
     }
 }

--- a/payment/src/main/java/com/devticket/payment/common/messaging/ProcessedMessage.java
+++ b/payment/src/main/java/com/devticket/payment/common/messaging/ProcessedMessage.java
@@ -7,7 +7,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,8 +21,8 @@ public class ProcessedMessage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "message_id", nullable = false, unique = true)
-    private UUID messageId;
+    @Column(name = "message_id", nullable = false, unique = true, length = 36)
+    private String messageId;
 
     @Column(name = "topic", nullable = false, length = 128)
     private String topic;
@@ -31,7 +30,7 @@ public class ProcessedMessage {
     @Column(name = "processed_at", nullable = false, updatable = false)
     private LocalDateTime processedAt;
 
-    public static ProcessedMessage of(UUID messageId, String topic) {
+    public static ProcessedMessage of(String messageId, String topic) {
         ProcessedMessage pm = new ProcessedMessage();
         pm.messageId = messageId;
         pm.topic = topic;

--- a/payment/src/main/java/com/devticket/payment/common/messaging/ProcessedMessageRepository.java
+++ b/payment/src/main/java/com/devticket/payment/common/messaging/ProcessedMessageRepository.java
@@ -1,9 +1,8 @@
 package com.devticket.payment.common.messaging;
 
-import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProcessedMessageRepository extends JpaRepository<ProcessedMessage, Long> {
 
-    boolean existsByMessageId(UUID messageId);
+    boolean existsByMessageId(String messageId);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/RefundSagaConsumer.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/RefundSagaConsumer.java
@@ -36,7 +36,7 @@ public class RefundSagaConsumer {
         containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeRefundRequested(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        UUID messageId = extractMessageId(record);
+        String messageId = extractMessageId(record);
         if (deduplicationService.isDuplicate(messageId)) {
             ack.acknowledge();
             return;
@@ -57,7 +57,7 @@ public class RefundSagaConsumer {
         containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeOrderDone(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        UUID messageId = extractMessageId(record);
+        String messageId = extractMessageId(record);
         if (deduplicationService.isDuplicate(messageId)) {
             ack.acknowledge();
             return;
@@ -78,7 +78,7 @@ public class RefundSagaConsumer {
         containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeOrderFailed(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        UUID messageId = extractMessageId(record);
+        String messageId = extractMessageId(record);
         if (deduplicationService.isDuplicate(messageId)) {
             ack.acknowledge();
             return;
@@ -99,7 +99,7 @@ public class RefundSagaConsumer {
         containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeTicketDone(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        UUID messageId = extractMessageId(record);
+        String messageId = extractMessageId(record);
         if (deduplicationService.isDuplicate(messageId)) {
             ack.acknowledge();
             return;
@@ -120,7 +120,7 @@ public class RefundSagaConsumer {
         containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeTicketFailed(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        UUID messageId = extractMessageId(record);
+        String messageId = extractMessageId(record);
         if (deduplicationService.isDuplicate(messageId)) {
             ack.acknowledge();
             return;
@@ -141,7 +141,7 @@ public class RefundSagaConsumer {
         containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeStockDone(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        UUID messageId = extractMessageId(record);
+        String messageId = extractMessageId(record);
         if (deduplicationService.isDuplicate(messageId)) {
             ack.acknowledge();
             return;
@@ -162,7 +162,7 @@ public class RefundSagaConsumer {
         containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeStockFailed(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        UUID messageId = extractMessageId(record);
+        String messageId = extractMessageId(record);
         if (deduplicationService.isDuplicate(messageId)) {
             ack.acknowledge();
             return;
@@ -177,17 +177,17 @@ public class RefundSagaConsumer {
         }
     }
 
-    private UUID extractMessageId(ConsumerRecord<String, String> record) {
+    private String extractMessageId(ConsumerRecord<String, String> record) {
         Header header = record.headers().lastHeader("X-Message-Id");
         if (header != null) {
             try {
-                return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8));
+                return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8)).toString();
             } catch (IllegalArgumentException e) {
                 log.warn("[Saga.Consumer] X-Message-Id 파싱 실패 — topic={}, offset={}",
                     record.topic(), record.offset());
             }
         }
         String fallback = record.topic() + ":" + record.partition() + ":" + record.offset();
-        return UUID.nameUUIDFromBytes(fallback.getBytes(StandardCharsets.UTF_8));
+        return UUID.nameUUIDFromBytes(fallback.getBytes(StandardCharsets.UTF_8)).toString();
     }
 }

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/RefundSagaHandler.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/RefundSagaHandler.java
@@ -9,7 +9,6 @@ import com.devticket.payment.refund.application.saga.event.RefundStockDoneEvent;
 import com.devticket.payment.refund.application.saga.event.RefundStockFailedEvent;
 import com.devticket.payment.refund.application.saga.event.RefundTicketDoneEvent;
 import com.devticket.payment.refund.application.saga.event.RefundTicketFailedEvent;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,43 +26,43 @@ public class RefundSagaHandler {
     private final MessageDeduplicationService deduplicationService;
 
     @Transactional
-    public void startAndMark(RefundRequestedEvent event, UUID messageId, String topic) {
+    public void startAndMark(RefundRequestedEvent event, String messageId, String topic) {
         orchestrator.start(event);
         deduplicationService.markProcessed(messageId, topic);
     }
 
     @Transactional
-    public void onOrderDoneAndMark(RefundOrderDoneEvent event, UUID messageId, String topic) {
+    public void onOrderDoneAndMark(RefundOrderDoneEvent event, String messageId, String topic) {
         orchestrator.onOrderDone(event);
         deduplicationService.markProcessed(messageId, topic);
     }
 
     @Transactional
-    public void onOrderFailedAndMark(RefundOrderFailedEvent event, UUID messageId, String topic) {
+    public void onOrderFailedAndMark(RefundOrderFailedEvent event, String messageId, String topic) {
         orchestrator.onOrderFailed(event);
         deduplicationService.markProcessed(messageId, topic);
     }
 
     @Transactional
-    public void onTicketDoneAndMark(RefundTicketDoneEvent event, UUID messageId, String topic) {
+    public void onTicketDoneAndMark(RefundTicketDoneEvent event, String messageId, String topic) {
         orchestrator.onTicketDone(event);
         deduplicationService.markProcessed(messageId, topic);
     }
 
     @Transactional
-    public void onTicketFailedAndMark(RefundTicketFailedEvent event, UUID messageId, String topic) {
+    public void onTicketFailedAndMark(RefundTicketFailedEvent event, String messageId, String topic) {
         orchestrator.onTicketFailed(event);
         deduplicationService.markProcessed(messageId, topic);
     }
 
     @Transactional
-    public void onStockDoneAndMark(RefundStockDoneEvent event, UUID messageId, String topic) {
+    public void onStockDoneAndMark(RefundStockDoneEvent event, String messageId, String topic) {
         orchestrator.onStockDone(event);
         deduplicationService.markProcessed(messageId, topic);
     }
 
     @Transactional
-    public void onStockFailedAndMark(RefundStockFailedEvent event, UUID messageId, String topic) {
+    public void onStockFailedAndMark(RefundStockFailedEvent event, String messageId, String topic) {
         orchestrator.onStockFailed(event);
         deduplicationService.markProcessed(messageId, topic);
     }

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/TicketIssueFailedConsumer.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/TicketIssueFailedConsumer.java
@@ -37,7 +37,7 @@ public class TicketIssueFailedConsumer {
         containerFactory = "kafkaListenerContainerFactory"
     )
     public void consume(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        UUID messageId = extractMessageId(record);
+        String messageId = extractMessageId(record);
         if (deduplicationService.isDuplicate(messageId)) {
             ack.acknowledge();
             return;
@@ -53,17 +53,17 @@ public class TicketIssueFailedConsumer {
         }
     }
 
-    private UUID extractMessageId(ConsumerRecord<String, String> record) {
+    private String extractMessageId(ConsumerRecord<String, String> record) {
         Header header = record.headers().lastHeader("X-Message-Id");
         if (header != null) {
             try {
-                return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8));
+                return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8)).toString();
             } catch (IllegalArgumentException e) {
                 log.warn("[Consumer] X-Message-Id 파싱 실패 — topic={}, offset={}",
                     record.topic(), record.offset());
             }
         }
         String fallback = record.topic() + ":" + record.partition() + ":" + record.offset();
-        return UUID.nameUUIDFromBytes(fallback.getBytes(StandardCharsets.UTF_8));
+        return UUID.nameUUIDFromBytes(fallback.getBytes(StandardCharsets.UTF_8)).toString();
     }
 }

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/TicketIssueFailedHandler.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/TicketIssueFailedHandler.java
@@ -42,7 +42,7 @@ public class TicketIssueFailedHandler {
     private final MessageDeduplicationService deduplicationService;
 
     @Transactional
-    public void handleAndMark(TicketIssueFailedEvent event, UUID messageId, String topic) {
+    public void handleAndMark(TicketIssueFailedEvent event, String messageId, String topic) {
         Payment payment = paymentRepository.findByPaymentId(event.paymentId())
             .orElseThrow(() -> new RefundException(RefundErrorCode.PAYMENT_NOT_FOUND));
 

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/RefundCompletedHandler.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/RefundCompletedHandler.java
@@ -1,7 +1,5 @@
 package com.devticket.payment.wallet.infrastructure.kafka;
 
-import java.util.UUID;
-
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -16,7 +14,7 @@ public class RefundCompletedHandler {
     private final MessageDeduplicationService deduplicationService;
 
     @Transactional
-    public void markProcessedOnly(UUID messageId, String topic) {
+    public void markProcessedOnly(String messageId, String topic) {
         deduplicationService.markProcessed(messageId, topic);
     }
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/WalletEventConsumer.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/kafka/WalletEventConsumer.java
@@ -37,20 +37,20 @@ public class WalletEventConsumer {
         containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeRefundCompleted(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        UUID messageUUID = extractMessageId(record);
+        String messageId = extractMessageId(record);
 
-        if (deduplicationService.isDuplicate(messageUUID)) {
+        if (deduplicationService.isDuplicate(messageId)) {
             log.info("[Consumer] 중복 메시지 스킵 — topic={}, offset={}", record.topic(), record.offset());
             ack.acknowledge();
             return;
         }
 
         try {
-            refundCompletedHandler.markProcessedOnly(messageUUID, record.topic());
+            refundCompletedHandler.markProcessedOnly(messageId, record.topic());
             ack.acknowledge();
         } catch (Exception e) {
             log.error("[Consumer] refund.completed 처리 실패 — messageId={}, error={}",
-                messageUUID, e.getMessage(), e);
+                messageId, e.getMessage(), e);
             throw new RuntimeException("refund.completed 처리 실패", e);
         }
     }
@@ -59,11 +59,11 @@ public class WalletEventConsumer {
      * Kafka 헤더에서 X-Message-Id를 추출한다.
      * 헤더가 없거나 파싱 실패 시 topic:partition:offset 기반 결정적 UUID(v3)로 폴백한다.
      */
-    private UUID extractMessageId(ConsumerRecord<String, String> record) {
+    private String extractMessageId(ConsumerRecord<String, String> record) {
         Header header = record.headers().lastHeader("X-Message-Id");
         if (header != null) {
             try {
-                return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8));
+                return UUID.fromString(new String(header.value(), StandardCharsets.UTF_8)).toString();
             } catch (IllegalArgumentException e) {
                 log.warn("[Consumer] X-Message-Id 파싱 실패, 레거시 폴백 사용 — topic={}, offset={}",
                     record.topic(), record.offset());
@@ -71,6 +71,6 @@ public class WalletEventConsumer {
         }
         // 폴백: 헤더 없거나 파싱 실패 시 topic:partition:offset 기반 결정적 UUID
         String fallback = record.topic() + ":" + record.partition() + ":" + record.offset();
-        return UUID.nameUUIDFromBytes(fallback.getBytes(StandardCharsets.UTF_8));
+        return UUID.nameUUIDFromBytes(fallback.getBytes(StandardCharsets.UTF_8)).toString();
     }
 }

--- a/payment/src/test/java/com/devticket/payment/common/messaging/MessageDeduplicationServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/messaging/MessageDeduplicationServiceTest.java
@@ -1,0 +1,112 @@
+package com.devticket.payment.common.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * MessageDeduplicationService — Consumer dedup 회귀 방지.
+ *
+ * 본 테스트는 messageId 타입 통일(UUID → String) 변경(issue #583)에 따른 회귀 가드.
+ *  - kafka-idempotency-guide.md §3-5: messageId = String / VARCHAR(36)
+ *  - 3모듈(Commerce/Event/Payment) 컨벤션 일치
+ *
+ * @SpringBootTest + @Transactional — 각 테스트 메서드 종료 시 자동 롤백.
+ * @DataJpaTest 는 본 프로젝트 Spring Boot 4.0 starter 구성상 사용 불가.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("MessageDeduplicationService — Consumer dedup")
+class MessageDeduplicationServiceTest {
+
+    @Autowired
+    private MessageDeduplicationService deduplicationService;
+
+    @Autowired
+    private ProcessedMessageRepository processedMessageRepository;
+
+    private static final String TOPIC = "payment.completed";
+
+    @Nested
+    @DisplayName("isDuplicate(String)")
+    class IsDuplicate {
+
+        @Test
+        void 미처리_messageId는_false_반환() {
+            String messageId = UUID.randomUUID().toString();
+
+            boolean result = deduplicationService.isDuplicate(messageId);
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        void markProcessed_후_동일_messageId는_true_반환() {
+            String messageId = UUID.randomUUID().toString();
+            deduplicationService.markProcessed(messageId, TOPIC);
+
+            boolean result = deduplicationService.isDuplicate(messageId);
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void 서로_다른_messageId는_독립적으로_판정된다() {
+            String first = UUID.randomUUID().toString();
+            String second = UUID.randomUUID().toString();
+            deduplicationService.markProcessed(first, TOPIC);
+
+            boolean result = deduplicationService.isDuplicate(second);
+
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("markProcessed(String, String)")
+    class MarkProcessed {
+
+        @Test
+        void ProcessedMessage_row가_저장된다() {
+            String messageId = UUID.randomUUID().toString();
+
+            deduplicationService.markProcessed(messageId, TOPIC);
+
+            assertThat(processedMessageRepository.existsByMessageId(messageId)).isTrue();
+        }
+
+        @Test
+        void UUID_표준_36자_String_정상_저장() {
+            // UUID v4 toString() = 8-4-4-4-12 = 36자 (하이픈 4개 포함)
+            String messageId = UUID.randomUUID().toString();
+            assertThat(messageId).hasSize(36);
+
+            deduplicationService.markProcessed(messageId, TOPIC);
+
+            assertThat(processedMessageRepository.existsByMessageId(messageId)).isTrue();
+        }
+
+        @Test
+        void nameUUIDFromBytes_fallback도_36자_보장() {
+            // extractMessageId() 의 fallback 경로 — topic:partition:offset 기반 UUID v3
+            String fallback = UUID.nameUUIDFromBytes(
+                "payment.completed:0:42".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+            ).toString();
+            assertThat(fallback).hasSize(36);
+
+            deduplicationService.markProcessed(fallback, TOPIC);
+
+            assertThat(processedMessageRepository.existsByMessageId(fallback)).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`docs/kafka-idempotency-guide.md §3-5` 의 3모듈 통일 정책(messageId = `String` / `VARCHAR(36)`) 에서 Payment 만 `UUID` 로 어긋나 있던 Consumer dedup 경로 정렬.

Closes #583

## Changes

### 운영 코드 (9 파일)

| 영역 | 파일 |
|---|---|
| Core | `common/messaging/` — ProcessedMessage / Repository / DedupService |
| Saga | `refund/.../` — RefundSagaConsumer / RefundSagaHandler |
| Ticket | `refund/.../` — TicketIssueFailedConsumer / TicketIssueFailedHandler |
| Wallet | `wallet/.../` — WalletEventConsumer / RefundCompletedHandler |

### 테스트 (1 파일 신규)

- `MessageDeduplicationServiceTest` — 6 테스트 메서드 (isDuplicate 3 + markProcessed 3)

### 핵심 패턴

- `extractMessageId()` — `UUID.fromString().toString()` 으로 형식 검증 유지 + String 반환
- `import java.util.UUID` 는 fallback / `List<UUID>` 에서 사용하는 파일에 한해 유지

## Wire 호환성

- ✅ `X-Message-Id` 헤더 포맷 무변동 (UTF-8 String)
- ✅ Outbox 측 `messageId` 이미 String (`Outbox.java:53,73`)
- ✅ Commerce / Event 모듈 영향 없음

## Test Plan

- [x] `./gradlew :payment:compileJava` BUILD SUCCESSFUL
- [x] `./gradlew :payment:test` BUILD SUCCESSFUL (2m 43s, 회귀 0)
- [x] 신규 `MessageDeduplicationServiceTest` 6 메서드 그린

## DB 마이그레이션 — 운영 수동 실행 필요

```sql
ALTER TABLE payment.processed_message
    ALTER COLUMN message_id TYPE VARCHAR(36) USING message_id::text;
```

- `USING` 절 필수 (PostgreSQL `UUID` → `text` 자동 변환 불가)
- dev/local 도 동일 SQL 권장 (`ddl-auto:update` 가 타입 변경 미보장)

## 별건 권고

- `docs/schema_plan.md` 수동 실행 표에 본 SQL 추가 (PR 분리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
