### PR TITLE
[Payment] fix: refundPgTicket 동시성 dedup 가드

### DIFF
--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -37,6 +37,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testImplementation 'org.awaitility:awaitility:4.2.1'
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation platform('org.testcontainers:testcontainers-bom:1.20.4')
+	testImplementation 'org.testcontainers:testcontainers'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:postgresql'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'com.h2database:h2'

--- a/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
@@ -150,6 +150,8 @@ public class RefundSagaOrchestrator {
                 orderRefundRepository.save(or);
             });
 
+        refundTicketRepository.markFailedByRefundId(event.refundId());
+
         log.error("[Saga] order 취소 실패 — refundId={}, reason={}",
             event.refundId(), event.reason());
     }
@@ -232,6 +234,8 @@ public class RefundSagaOrchestrator {
         refund.fail();
         refundRepository.save(refund);
 
+        refundTicketRepository.markFailedByRefundId(event.refundId());
+
         RefundOrderCompensateEvent comp = new RefundOrderCompensateEvent(
             event.refundId(),
             event.orderId(),
@@ -282,6 +286,8 @@ public class RefundSagaOrchestrator {
 
         List<UUID> ticketIds = refundTicketRepository.findByRefundId(event.refundId())
             .stream().map(RefundTicket::getTicketId).toList();
+
+        refundTicketRepository.markFailedByRefundId(event.refundId());
 
         RefundTicketCompensateEvent ticketComp = new RefundTicketCompensateEvent(
             event.refundId(),
@@ -382,6 +388,8 @@ public class RefundSagaOrchestrator {
 
         refund.complete(completedAt);
         refundRepository.save(refund);
+
+        refundTicketRepository.markCompletedByRefundId(refund.getRefundId());
 
         int ticketCount = refundTicketRepository.findByRefundId(refund.getRefundId()).size();
         if (ticketCount == 0) {

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
@@ -21,6 +21,7 @@ import com.devticket.payment.refund.domain.exception.RefundException;
 import com.devticket.payment.refund.domain.model.OrderRefund;
 import com.devticket.payment.refund.domain.model.Refund;
 import com.devticket.payment.refund.domain.model.RefundTicket;
+import com.devticket.payment.refund.domain.enums.RefundTicketStatus;
 import com.devticket.payment.refund.domain.repository.OrderRefundRepository;
 import com.devticket.payment.refund.domain.repository.RefundRepository;
 import com.devticket.payment.refund.domain.repository.RefundTicketRepository;
@@ -124,7 +125,8 @@ public class RefundServiceImpl implements RefundService {
 
         UUID ticketUuid = UUID.fromString(ticketId);
 
-        if (refundTicketRepository.existsByTicketId(ticketUuid)) {
+        if (refundTicketRepository.existsByTicketIdAndStatusIn(
+                ticketUuid, List.of(RefundTicketStatus.ACTIVE, RefundTicketStatus.COMPLETED))) {
             throw new RefundException(RefundErrorCode.REFUND_ALREADY_IN_PROGRESS);
         }
 
@@ -285,7 +287,7 @@ public class RefundServiceImpl implements RefundService {
     // Helpers
     // =========================================================
 
-    // ticket_id UNIQUE 제약 위반인지 확인 — 다른 제약 위반(NOT NULL 등)과 구분
+    // ticket_id partial unique index 위반인지 확인 — 다른 제약 위반(NOT NULL 등)과 구분
     // 원인 체인을 끝까지 순회: Spring이 PersistenceException으로 한 번 더 래핑하는 환경 대응
     // contains 사용: H2는 constraint name에 테이블·컬럼 정보가 붙어 오는 경우가 있음
     private boolean isTicketUniqueViolation(DataIntegrityViolationException e) {
@@ -294,11 +296,10 @@ public class RefundServiceImpl implements RefundService {
             if (t instanceof ConstraintViolationException cve) {
                 String name = cve.getConstraintName();
                 if (name != null) {
-                    return name.toLowerCase().contains("uk_refund_ticket_ticket_id");
+                    return name.toLowerCase().contains("uk_refund_ticket_active");
                 }
-                // constraint name을 추출하지 못한 경우 메시지로 fallback
                 String msg = cve.getMessage();
-                return msg != null && msg.toLowerCase().contains("uk_refund_ticket_ticket_id");
+                return msg != null && msg.toLowerCase().contains("uk_refund_ticket_active");
             }
             t = t.getCause();
         }

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
@@ -48,6 +48,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.web.client.HttpClientErrorException;
 
 @Service
@@ -122,6 +124,10 @@ public class RefundServiceImpl implements RefundService {
 
         UUID ticketUuid = UUID.fromString(ticketId);
 
+        if (refundTicketRepository.existsByTicketId(ticketUuid)) {
+            throw new RefundException(RefundErrorCode.REFUND_ALREADY_IN_PROGRESS);
+        }
+
         OrderRefund ledger = upsertOrderRefund(
             orderItem.orderId(), userId, payment.getPaymentId(),
             payment.getPaymentMethod(), payment.getAmount(),
@@ -141,7 +147,14 @@ public class RefundServiceImpl implements RefundService {
             refundRate
         );
         refundRepository.save(refund);
-        refundTicketRepository.save(RefundTicket.of(refund.getRefundId(), ticketUuid));
+        try {
+            refundTicketRepository.save(RefundTicket.of(refund.getRefundId(), ticketUuid));
+        } catch (DataIntegrityViolationException e) {
+            if (!isTicketUniqueViolation(e)) {
+                throw e;
+            }
+            throw new RefundException(RefundErrorCode.REFUND_ALREADY_IN_PROGRESS);
+        }
 
         RefundRequestedEvent requested = new RefundRequestedEvent(
             refund.getRefundId(),
@@ -271,6 +284,26 @@ public class RefundServiceImpl implements RefundService {
     // =========================================================
     // Helpers
     // =========================================================
+
+    // ticket_id UNIQUE 제약 위반인지 확인 — 다른 제약 위반(NOT NULL 등)과 구분
+    // 원인 체인을 끝까지 순회: Spring이 PersistenceException으로 한 번 더 래핑하는 환경 대응
+    // contains 사용: H2는 constraint name에 테이블·컬럼 정보가 붙어 오는 경우가 있음
+    private boolean isTicketUniqueViolation(DataIntegrityViolationException e) {
+        Throwable t = e;
+        while (t != null) {
+            if (t instanceof ConstraintViolationException cve) {
+                String name = cve.getConstraintName();
+                if (name != null) {
+                    return name.toLowerCase().contains("uk_refund_ticket_ticket_id");
+                }
+                // constraint name을 추출하지 못한 경우 메시지로 fallback
+                String msg = cve.getMessage();
+                return msg != null && msg.toLowerCase().contains("uk_refund_ticket_ticket_id");
+            }
+            t = t.getCause();
+        }
+        return false;
+    }
 
     private OrderRefund upsertOrderRefund(
         UUID orderId, UUID userId, UUID paymentId,

--- a/payment/src/main/java/com/devticket/payment/refund/domain/enums/RefundTicketStatus.java
+++ b/payment/src/main/java/com/devticket/payment/refund/domain/enums/RefundTicketStatus.java
@@ -1,0 +1,7 @@
+package com.devticket.payment.refund.domain.enums;
+
+public enum RefundTicketStatus {
+    ACTIVE,
+    COMPLETED,
+    FAILED
+}

--- a/payment/src/main/java/com/devticket/payment/refund/domain/model/RefundTicket.java
+++ b/payment/src/main/java/com/devticket/payment/refund/domain/model/RefundTicket.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,10 +16,15 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "refund_ticket", schema = "payment", indexes = {
-    @Index(name = "idx_refund_ticket_refund_id", columnList = "refund_id"),
-    @Index(name = "idx_refund_ticket_ticket_id", columnList = "ticket_id")
-})
+@Table(name = "refund_ticket", schema = "payment",
+    indexes = {
+        @Index(name = "idx_refund_ticket_refund_id", columnList = "refund_id"),
+        @Index(name = "idx_refund_ticket_ticket_id", columnList = "ticket_id")
+    },
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_refund_ticket_ticket_id", columnNames = "ticket_id")
+    }
+)
 public class RefundTicket {
 
     @Id

--- a/payment/src/main/java/com/devticket/payment/refund/domain/model/RefundTicket.java
+++ b/payment/src/main/java/com/devticket/payment/refund/domain/model/RefundTicket.java
@@ -1,13 +1,15 @@
 package com.devticket.payment.refund.domain.model;
 
+import com.devticket.payment.refund.domain.enums.RefundTicketStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,10 +22,9 @@ import lombok.NoArgsConstructor;
     indexes = {
         @Index(name = "idx_refund_ticket_refund_id", columnList = "refund_id"),
         @Index(name = "idx_refund_ticket_ticket_id", columnList = "ticket_id")
-    },
-    uniqueConstraints = {
-        @UniqueConstraint(name = "uk_refund_ticket_ticket_id", columnNames = "ticket_id")
     }
+    // uk_refund_ticket_active: partial unique index (ticket_id) WHERE status IN ('ACTIVE','COMPLETED')
+    // JPA @UniqueConstraint는 partial index를 표현할 수 없어 DDL 스크립트(RefundTicketPartialIndexInitializer)로 관리
 )
 public class RefundTicket {
 
@@ -37,10 +38,23 @@ public class RefundTicket {
     @Column(name = "ticket_id", nullable = false)
     private UUID ticketId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private RefundTicketStatus status;
+
     public static RefundTicket of(UUID refundId, UUID ticketId) {
         RefundTicket rt = new RefundTicket();
         rt.refundId = refundId;
         rt.ticketId = ticketId;
+        rt.status = RefundTicketStatus.ACTIVE;
         return rt;
+    }
+
+    public void markFailed() {
+        this.status = RefundTicketStatus.FAILED;
+    }
+
+    public void markCompleted() {
+        this.status = RefundTicketStatus.COMPLETED;
     }
 }

--- a/payment/src/main/java/com/devticket/payment/refund/domain/repository/RefundTicketRepository.java
+++ b/payment/src/main/java/com/devticket/payment/refund/domain/repository/RefundTicketRepository.java
@@ -8,4 +8,5 @@ public interface RefundTicketRepository {
     RefundTicket save(RefundTicket refundTicket);
     List<RefundTicket> saveAll(List<RefundTicket> refundTickets);
     List<RefundTicket> findByRefundId(UUID refundId);
+    boolean existsByTicketId(UUID ticketId);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/domain/repository/RefundTicketRepository.java
+++ b/payment/src/main/java/com/devticket/payment/refund/domain/repository/RefundTicketRepository.java
@@ -1,6 +1,7 @@
 package com.devticket.payment.refund.domain.repository;
 
 import com.devticket.payment.refund.domain.model.RefundTicket;
+import com.devticket.payment.refund.domain.enums.RefundTicketStatus;
 import java.util.List;
 import java.util.UUID;
 
@@ -8,5 +9,7 @@ public interface RefundTicketRepository {
     RefundTicket save(RefundTicket refundTicket);
     List<RefundTicket> saveAll(List<RefundTicket> refundTickets);
     List<RefundTicket> findByRefundId(UUID refundId);
-    boolean existsByTicketId(UUID ticketId);
+    boolean existsByTicketIdAndStatusIn(UUID ticketId, List<RefundTicketStatus> statuses);
+    void markFailedByRefundId(UUID refundId);
+    void markCompletedByRefundId(UUID refundId);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundTicketJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundTicketJpaRepository.java
@@ -1,11 +1,21 @@
 package com.devticket.payment.refund.infrastructure.persistence;
 
 import com.devticket.payment.refund.domain.model.RefundTicket;
+import com.devticket.payment.refund.domain.enums.RefundTicketStatus;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RefundTicketJpaRepository extends JpaRepository<RefundTicket, Long> {
     List<RefundTicket> findByRefundId(UUID refundId);
-    boolean existsByTicketId(UUID ticketId);
+    boolean existsByTicketIdAndStatusIn(UUID ticketId, List<RefundTicketStatus> statuses);
+
+    @Modifying
+    @Query("UPDATE RefundTicket rt SET rt.status = :toStatus WHERE rt.refundId = :refundId AND rt.status = :fromStatus")
+    void updateStatusByRefundId(@Param("refundId") UUID refundId,
+                                @Param("fromStatus") RefundTicketStatus fromStatus,
+                                @Param("toStatus") RefundTicketStatus toStatus);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundTicketJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundTicketJpaRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefundTicketJpaRepository extends JpaRepository<RefundTicket, Long> {
     List<RefundTicket> findByRefundId(UUID refundId);
+    boolean existsByTicketId(UUID ticketId);
 }

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundTicketPartialIndexInitializer.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundTicketPartialIndexInitializer.java
@@ -1,0 +1,42 @@
+package com.devticket.payment.refund.infrastructure.persistence;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RefundTicketPartialIndexInitializer {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void createPartialIndex() {
+        // 기존 전체 unique constraint 제거 (ddl-auto: update 환경에서 이전 버전 제약이 남아있을 수 있음)
+        try {
+            jdbcTemplate.execute(
+                "ALTER TABLE payment.refund_ticket DROP CONSTRAINT uk_refund_ticket_ticket_id");
+            log.info("[RefundTicket] 기존 uk_refund_ticket_ticket_id constraint 제거 완료");
+        } catch (Exception e) {
+            log.debug("[RefundTicket] uk_refund_ticket_ticket_id constraint 없음 (정상) — {}", e.getMessage());
+        }
+
+        // ACTIVE·COMPLETED 행에만 유일성을 강제하는 partial unique index 생성
+        // FAILED 행은 제외되므로 실패 후 같은 ticketId로 재시도 가능
+        // H2는 partial unique index 미지원 — 테스트 환경에서는 경고 후 스킵
+        try {
+            jdbcTemplate.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS uk_refund_ticket_active
+                ON payment.refund_ticket(ticket_id)
+                WHERE status = 'ACTIVE' OR status = 'COMPLETED'
+                """);
+            log.info("[RefundTicket] uk_refund_ticket_active partial unique index 확인/생성 완료");
+        } catch (Exception e) {
+            log.warn("[RefundTicket] partial unique index 생성 실패 (H2 미지원) — 운영 환경에서는 PostgreSQL 사용 필요: {}", e.getMessage());
+        }
+    }
+}

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundTicketRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundTicketRepositoryImpl.java
@@ -27,4 +27,9 @@ public class RefundTicketRepositoryImpl implements RefundTicketRepository {
     public List<RefundTicket> findByRefundId(UUID refundId) {
         return jpa.findByRefundId(refundId);
     }
+
+    @Override
+    public boolean existsByTicketId(UUID ticketId) {
+        return jpa.existsByTicketId(ticketId);
+    }
 }

--- a/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundTicketRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/infrastructure/persistence/RefundTicketRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.devticket.payment.refund.infrastructure.persistence;
 
 import com.devticket.payment.refund.domain.model.RefundTicket;
+import com.devticket.payment.refund.domain.enums.RefundTicketStatus;
 import com.devticket.payment.refund.domain.repository.RefundTicketRepository;
 import java.util.List;
 import java.util.UUID;
@@ -29,7 +30,17 @@ public class RefundTicketRepositoryImpl implements RefundTicketRepository {
     }
 
     @Override
-    public boolean existsByTicketId(UUID ticketId) {
-        return jpa.existsByTicketId(ticketId);
+    public boolean existsByTicketIdAndStatusIn(UUID ticketId, List<RefundTicketStatus> statuses) {
+        return jpa.existsByTicketIdAndStatusIn(ticketId, statuses);
+    }
+
+    @Override
+    public void markFailedByRefundId(UUID refundId) {
+        jpa.updateStatusByRefundId(refundId, RefundTicketStatus.ACTIVE, RefundTicketStatus.FAILED);
+    }
+
+    @Override
+    public void markCompletedByRefundId(UUID refundId) {
+        jpa.updateStatusByRefundId(refundId, RefundTicketStatus.ACTIVE, RefundTicketStatus.COMPLETED);
     }
 }

--- a/payment/src/test/java/com/devticket/payment/application/service/RefundServiceImplTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/RefundServiceImplTest.java
@@ -9,19 +9,25 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.devticket.payment.common.outbox.OutboxService;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
 import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
+import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderItemInfoResponse;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.refund.application.service.RefundServiceImpl;
 import com.devticket.payment.refund.domain.enums.RefundStatus;
 import com.devticket.payment.refund.domain.exception.RefundErrorCode;
 import com.devticket.payment.refund.domain.exception.RefundException;
 import com.devticket.payment.refund.domain.model.Refund;
+import com.devticket.payment.refund.domain.repository.OrderRefundRepository;
 import com.devticket.payment.refund.domain.repository.RefundRepository;
+import com.devticket.payment.refund.domain.repository.RefundTicketRepository;
 import com.devticket.payment.refund.infrastructure.client.EventInternalClient;
 import com.devticket.payment.refund.infrastructure.client.dto.InternalEventInfoResponse;
+import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
+import com.devticket.payment.refund.presentation.dto.PgRefundResponse;
 import com.devticket.payment.refund.presentation.dto.SellerRefundListItemResponse;
 import com.devticket.payment.wallet.infrastructure.client.dto.InternalEventOrdersResponse;
 import java.time.LocalDateTime;
@@ -29,6 +35,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.sql.SQLException;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -51,6 +60,9 @@ class RefundServiceImplTest {
     @Mock private PaymentRepository paymentRepository;
     @Mock private PgPaymentClient pgPaymentClient;
     @Mock private RefundRepository refundRepository;
+    @Mock private OrderRefundRepository orderRefundRepository;
+    @Mock private RefundTicketRepository refundTicketRepository;
+    @Mock private OutboxService outboxService;
 
     @InjectMocks
     private RefundServiceImpl refundService;
@@ -239,6 +251,115 @@ class RefundServiceImplTest {
             // then
             assertThat(result.getTotalElements()).isEqualTo(1);
             assertThat(result.getContent().get(0).paymentMethod()).isNull();
+        }
+    }
+
+    // =========================================================
+    // refundPgTicket — 티켓 단건 환불 dedup 가드
+    // =========================================================
+
+    @Nested
+    @DisplayName("티켓 단건 환불 요청 (dedup 가드)")
+    class RefundPgTicketTest {
+
+        private static final String TICKET_ID = "4aa200ae-29d2-4dc5-97eb-b1175956721d";
+        private static final UUID TICKET_UUID = UUID.fromString(TICKET_ID);
+        private static final UUID USER_ID = UUID.fromString("68501ba3-6ab9-4e6b-8c53-d1798d290768");
+
+        private InternalOrderItemInfoResponse orderItem;
+        private Payment payment;
+        private PgRefundRequest request;
+
+        @BeforeEach
+        void setUp() {
+            orderItem = new InternalOrderItemInfoResponse(
+                UUID.randomUUID(), ORDER_ID, USER_ID, UUID.fromString(EVENT_ID), 50000
+            );
+            payment = Payment.create(ORDER_ID, USER_ID, PaymentMethod.PG, 50000);
+            payment.approve("payment-key-123");
+            request = new PgRefundRequest("단순 변심");
+        }
+
+        private void givenCommonStubs() {
+            given(commerceInternalClient.getOrderItemInfoByTicketId(TICKET_ID)).willReturn(orderItem);
+            given(eventInternalClient.getEventInfo(UUID.fromString(EVENT_ID))).willReturn(eventInfo);
+            given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.of(payment));
+        }
+
+        @Test
+        @DisplayName("이미 진행 중인 환불 — existsByTicketId=true → REFUND_ALREADY_IN_PROGRESS(409)")
+        void 이미_진행중인_환불() {
+            givenCommonStubs();
+            given(refundTicketRepository.existsByTicketId(TICKET_UUID)).willReturn(true);
+
+            assertThatThrownBy(() -> refundService.refundPgTicket(USER_ID, TICKET_ID, request))
+                .isInstanceOf(RefundException.class)
+                .extracting(e -> ((RefundException) e).getErrorCode())
+                .isEqualTo(RefundErrorCode.REFUND_ALREADY_IN_PROGRESS);
+
+            verify(orderRefundRepository, never()).findByOrderId(any());
+            verify(refundRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Race condition — ticket_id UNIQUE 위반 시 → REFUND_ALREADY_IN_PROGRESS(409)")
+        void race_condition_ticket_unique_위반() {
+            givenCommonStubs();
+            given(refundTicketRepository.existsByTicketId(TICKET_UUID)).willReturn(false);
+            given(orderRefundRepository.findByOrderId(ORDER_ID)).willReturn(Optional.empty());
+            given(orderRefundRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            given(refundRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            given(refundTicketRepository.save(any())).willThrow(ticketUniqueViolation());
+
+            assertThatThrownBy(() -> refundService.refundPgTicket(USER_ID, TICKET_ID, request))
+                .isInstanceOf(RefundException.class)
+                .extracting(e -> ((RefundException) e).getErrorCode())
+                .isEqualTo(RefundErrorCode.REFUND_ALREADY_IN_PROGRESS);
+        }
+
+        @Test
+        @DisplayName("Race condition — ticket_id 외 다른 제약 위반 시 → DataIntegrityViolationException 그대로 전파")
+        void race_condition_다른_제약_위반_원래_예외_전파() {
+            givenCommonStubs();
+            given(refundTicketRepository.existsByTicketId(TICKET_UUID)).willReturn(false);
+            given(orderRefundRepository.findByOrderId(ORDER_ID)).willReturn(Optional.empty());
+            given(orderRefundRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            given(refundRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            given(refundTicketRepository.save(any())).willThrow(otherConstraintViolation());
+
+            assertThatThrownBy(() -> refundService.refundPgTicket(USER_ID, TICKET_ID, request))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        private DataIntegrityViolationException ticketUniqueViolation() {
+            ConstraintViolationException cause = new ConstraintViolationException(
+                "duplicate key", new SQLException(), "uk_refund_ticket_ticket_id"
+            );
+            return new DataIntegrityViolationException("constraint violation", cause);
+        }
+
+        private DataIntegrityViolationException otherConstraintViolation() {
+            ConstraintViolationException cause = new ConstraintViolationException(
+                "other constraint", new SQLException(), "fk_some_other_constraint"
+            );
+            return new DataIntegrityViolationException("constraint violation", cause);
+        }
+
+        @Test
+        @DisplayName("성공 — 정상 환불 요청 처리")
+        void 성공() {
+            givenCommonStubs();
+            given(refundTicketRepository.existsByTicketId(TICKET_UUID)).willReturn(false);
+            given(orderRefundRepository.findByOrderId(ORDER_ID)).willReturn(Optional.empty());
+            given(orderRefundRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            given(refundRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            given(refundTicketRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            PgRefundResponse response = refundService.refundPgTicket(USER_ID, TICKET_ID, request);
+
+            assertThat(response.ticketId()).isEqualTo(TICKET_ID);
+            assertThat(response.refundStatus()).isEqualTo(RefundStatus.REQUESTED.name());
+            verify(outboxService).save(any(), any(), any(), any(), any());
         }
     }
 }

--- a/payment/src/test/java/com/devticket/payment/application/service/RefundServiceImplTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/RefundServiceImplTest.java
@@ -50,7 +50,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 class RefundServiceImplTest {
@@ -287,10 +286,11 @@ class RefundServiceImplTest {
         }
 
         @Test
-        @DisplayName("이미 진행 중인 환불 — existsByTicketId=true → REFUND_ALREADY_IN_PROGRESS(409)")
+        @DisplayName("이미 진행 중인 환불 — ACTIVE/COMPLETED RefundTicket 존재 시 REFUND_ALREADY_IN_PROGRESS(409)")
         void 이미_진행중인_환불() {
             givenCommonStubs();
-            given(refundTicketRepository.existsByTicketId(TICKET_UUID)).willReturn(true);
+            given(refundTicketRepository.existsByTicketIdAndStatusIn(eq(TICKET_UUID), any()))
+                .willReturn(true);
 
             assertThatThrownBy(() -> refundService.refundPgTicket(USER_ID, TICKET_ID, request))
                 .isInstanceOf(RefundException.class)
@@ -302,10 +302,11 @@ class RefundServiceImplTest {
         }
 
         @Test
-        @DisplayName("Race condition — ticket_id UNIQUE 위반 시 → REFUND_ALREADY_IN_PROGRESS(409)")
+        @DisplayName("Race condition — uk_refund_ticket_active partial unique 위반 시 → REFUND_ALREADY_IN_PROGRESS(409)")
         void race_condition_ticket_unique_위반() {
             givenCommonStubs();
-            given(refundTicketRepository.existsByTicketId(TICKET_UUID)).willReturn(false);
+            given(refundTicketRepository.existsByTicketIdAndStatusIn(eq(TICKET_UUID), any()))
+                .willReturn(false);
             given(orderRefundRepository.findByOrderId(ORDER_ID)).willReturn(Optional.empty());
             given(orderRefundRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
             given(refundRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
@@ -321,7 +322,8 @@ class RefundServiceImplTest {
         @DisplayName("Race condition — ticket_id 외 다른 제약 위반 시 → DataIntegrityViolationException 그대로 전파")
         void race_condition_다른_제약_위반_원래_예외_전파() {
             givenCommonStubs();
-            given(refundTicketRepository.existsByTicketId(TICKET_UUID)).willReturn(false);
+            given(refundTicketRepository.existsByTicketIdAndStatusIn(eq(TICKET_UUID), any()))
+                .willReturn(false);
             given(orderRefundRepository.findByOrderId(ORDER_ID)).willReturn(Optional.empty());
             given(orderRefundRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
             given(refundRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
@@ -333,7 +335,7 @@ class RefundServiceImplTest {
 
         private DataIntegrityViolationException ticketUniqueViolation() {
             ConstraintViolationException cause = new ConstraintViolationException(
-                "duplicate key", new SQLException(), "uk_refund_ticket_ticket_id"
+                "duplicate key", new SQLException(), "uk_refund_ticket_active"
             );
             return new DataIntegrityViolationException("constraint violation", cause);
         }
@@ -349,7 +351,8 @@ class RefundServiceImplTest {
         @DisplayName("성공 — 정상 환불 요청 처리")
         void 성공() {
             givenCommonStubs();
-            given(refundTicketRepository.existsByTicketId(TICKET_UUID)).willReturn(false);
+            given(refundTicketRepository.existsByTicketIdAndStatusIn(eq(TICKET_UUID), any()))
+                .willReturn(false);
             given(orderRefundRepository.findByOrderId(ORDER_ID)).willReturn(Optional.empty());
             given(orderRefundRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
             given(refundRepository.save(any())).willAnswer(inv -> inv.getArgument(0));

--- a/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
@@ -274,7 +274,7 @@ class RefundSagaOrchestratorTest {
     class OnOrderFailedTest {
 
         @Test
-        @DisplayName("실패 수신 — SagaState.FAILED + Refund.fail + OrderRefund.FAILED")
+        @DisplayName("실패 수신 — SagaState.FAILED + Refund.fail + OrderRefund.FAILED + RefundTicket.FAILED")
         void 실패_처리() {
             SagaState st = state(SagaStep.ORDER_CANCELLING);
             given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.of(st));
@@ -286,6 +286,7 @@ class RefundSagaOrchestratorTest {
 
             assertThat(st.getStatus()).isEqualTo(SagaStatus.FAILED);
             assertThat(ledger.getStatus()).isEqualTo(OrderRefundStatus.FAILED);
+            verify(refundTicketRepository).markFailedByRefundId(refundId);
             verify(outboxService, never()).save(any(), any(), any(), any(), any());
         }
     }
@@ -295,7 +296,7 @@ class RefundSagaOrchestratorTest {
     class OnTicketFailedTest {
 
         @Test
-        @DisplayName("ticket 실패 → order.compensate 발행")
+        @DisplayName("ticket 실패 → RefundTicket FAILED 마킹 + order.compensate 발행")
         void 보상_경로() {
             SagaState st = state(SagaStep.TICKET_CANCELLING);
             given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.of(st));
@@ -304,6 +305,7 @@ class RefundSagaOrchestratorTest {
             orchestrator.onTicketFailed(new RefundTicketFailedEvent(refundId, orderId, "reason", Instant.now()));
 
             assertThat(st.getStatus()).isEqualTo(SagaStatus.COMPENSATING);
+            verify(refundTicketRepository).markFailedByRefundId(refundId);
             verify(outboxService).save(
                 eq(refundId.toString()),
                 eq(orderId.toString()),
@@ -319,7 +321,7 @@ class RefundSagaOrchestratorTest {
     class OnStockFailedTest {
 
         @Test
-        @DisplayName("stock 실패 → ticket+order compensate 순차 발행")
+        @DisplayName("stock 실패 → RefundTicket FAILED 마킹 + ticket+order compensate 순차 발행")
         void 보상_두번_발행() {
             SagaState st = state(SagaStep.STOCK_RESTORING);
             given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.of(st));
@@ -330,6 +332,7 @@ class RefundSagaOrchestratorTest {
             orchestrator.onStockFailed(new RefundStockFailedEvent(refundId, orderId, "reason", Instant.now()));
 
             assertThat(st.getStatus()).isEqualTo(SagaStatus.COMPENSATING);
+            verify(refundTicketRepository).markFailedByRefundId(refundId);
             verify(outboxService).save(
                 any(), any(), eq(KafkaTopics.REFUND_TICKET_COMPENSATE),
                 eq(KafkaTopics.REFUND_TICKET_COMPENSATE), any());
@@ -361,6 +364,7 @@ class RefundSagaOrchestratorTest {
 
             verify(walletService).restoreBalance(eq(userId), eq(10_000), any(UUID.class), eq(orderId));
             verify(pgPaymentClient, never()).cancelPartial(any());
+            verify(refundTicketRepository).markCompletedByRefundId(any(UUID.class));
             verify(outboxService).save(
                 any(), any(), eq(KafkaTopics.REFUND_COMPLETED),
                 eq(KafkaTopics.REFUND_COMPLETED), any());
@@ -390,6 +394,7 @@ class RefundSagaOrchestratorTest {
             verify(pgPaymentClient, atLeastOnce()).cancelPartial(cmd.capture());
             assertThat(cmd.getValue().idempotencyKey()).isEqualTo(refund.getRefundId().toString());
             verify(walletService, never()).restoreBalance(any(), anyInt(), any(), any());
+            verify(refundTicketRepository).markCompletedByRefundId(any(UUID.class));
             verify(outboxService).save(any(), any(), eq(KafkaTopics.REFUND_COMPLETED),
                 eq(KafkaTopics.REFUND_COMPLETED), any());
             assertThat(st.getStatus()).isEqualTo(SagaStatus.COMPLETED);
@@ -418,6 +423,7 @@ class RefundSagaOrchestratorTest {
             assertThat(cmd.getValue().idempotencyKey())
                 .isEqualTo(refund.getRefundId().toString() + "-pg");
             verify(walletService).restoreBalance(eq(userId), anyInt(), any(UUID.class), eq(orderId));
+            verify(refundTicketRepository).markCompletedByRefundId(any(UUID.class));
             assertThat(st.getStatus()).isEqualTo(SagaStatus.COMPLETED);
         }
     }

--- a/payment/src/test/java/com/devticket/payment/refund/application/service/RefundServiceImplSagaTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/application/service/RefundServiceImplSagaTest.java
@@ -92,6 +92,7 @@ class RefundServiceImplSagaTest {
         given(commerceInternalClient.getOrderItemInfoByTicketId(anyString())).willReturn(orderItem);
         given(eventInternalClient.getEventInfo(eventId)).willReturn(eventInfo);
         given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
+        given(refundTicketRepository.existsByTicketIdAndStatusIn(eq(ticketId), any())).willReturn(false);
         given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
         given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(inv -> inv.getArgument(0));
         given(refundRepository.save(any(Refund.class))).willAnswer(inv -> inv.getArgument(0));

--- a/payment/src/test/java/com/devticket/payment/refund/integration/RefundPgTicketConcurrencyIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/integration/RefundPgTicketConcurrencyIntegrationTest.java
@@ -13,6 +13,7 @@ import com.devticket.payment.refund.application.service.RefundService;
 import com.devticket.payment.refund.domain.exception.RefundErrorCode;
 import com.devticket.payment.refund.domain.exception.RefundException;
 import com.devticket.payment.refund.domain.model.OrderRefund;
+import com.devticket.payment.refund.domain.enums.RefundTicketStatus;
 import com.devticket.payment.refund.domain.repository.OrderRefundRepository;
 import com.devticket.payment.refund.domain.repository.RefundRepository;
 import com.devticket.payment.refund.domain.repository.RefundTicketRepository;
@@ -20,6 +21,7 @@ import com.devticket.payment.refund.infrastructure.client.EventInternalClient;
 import com.devticket.payment.refund.infrastructure.client.dto.InternalEventInfoResponse;
 import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -31,18 +33,88 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * refundPgTicket 동시성 통합 테스트
  *
- * 실제 DB(H2) UNIQUE 제약 + dedup 가드 검증.
+ * 실제 PostgreSQL(Testcontainers) + partial unique index 검증.
+ * H2는 partial unique index 미지원으로 PostgreSQL 컨테이너 사용.
  * CommerceInternalClient / EventInternalClient 만 Mock (외부 HTTP 호출 차단).
  */
 @SpringBootTest
-@ActiveProfiles("test")
+@Testcontainers
 class RefundPgTicketConcurrencyIntegrationTest {
+
+    @Container
+    @SuppressWarnings("resource")
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        // 컨테이너 시작 후, Spring 컨텍스트 초기화 전에 스키마 생성 (withInitScript가 TC 2.x에서 깨짐)
+        try (java.sql.Connection conn = java.sql.DriverManager.getConnection(
+                postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+             java.sql.Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE SCHEMA IF NOT EXISTS payment");
+            stmt.execute("CREATE SCHEMA IF NOT EXISTS refund");
+            stmt.execute("""
+                CREATE TABLE IF NOT EXISTS payment.shedlock (
+                    name       VARCHAR(64)  NOT NULL PRIMARY KEY,
+                    lock_until TIMESTAMP    NOT NULL,
+                    locked_at  TIMESTAMP    NOT NULL,
+                    locked_by  VARCHAR(255) NOT NULL
+                )""");
+        } catch (Exception e) {
+            throw new RuntimeException("PostgreSQL 스키마 초기화 실패", e);
+        }
+
+        // URL에 이미 ?loggerLevel=OFF 가 붙어 있으므로 currentSchema는 & 로 연결
+        registry.add("spring.datasource.url",
+            () -> postgres.getJdbcUrl() + "&currentSchema=payment");
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+        registry.add("spring.datasource.hikari.maximum-pool-size", () -> "30");
+        registry.add("spring.datasource.hikari.connection-init-sql",
+            () -> "SET search_path TO payment");
+        registry.add("spring.jpa.database-platform",
+            () -> "org.hibernate.dialect.PostgreSQLDialect");
+        registry.add("spring.jpa.properties.hibernate.dialect",
+            () -> "org.hibernate.dialect.PostgreSQLDialect");
+        registry.add("spring.jpa.properties.hibernate.default_schema", () -> "payment");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.jpa.show-sql", () -> "false");
+        registry.add("spring.main.allow-bean-definition-overriding", () -> "true");
+        registry.add("spring.kafka.bootstrap-servers", () -> "localhost:9093");
+        registry.add("spring.kafka.consumer.group-id", () -> "devticket-payment");
+        registry.add("spring.kafka.consumer.auto-offset-reset", () -> "earliest");
+        registry.add("spring.kafka.consumer.key-deserializer",
+            () -> "org.apache.kafka.common.serialization.StringDeserializer");
+        registry.add("spring.kafka.consumer.value-deserializer",
+            () -> "org.apache.kafka.common.serialization.StringDeserializer");
+        registry.add("spring.kafka.producer.key-serializer",
+            () -> "org.apache.kafka.common.serialization.StringSerializer");
+        registry.add("spring.kafka.producer.value-serializer",
+            () -> "org.apache.kafka.common.serialization.StringSerializer");
+        registry.add("kafka-producer.max-block-ms", () -> "3000");
+        registry.add("kafka-producer.request-timeout-ms", () -> "5000");
+        registry.add("kafka-producer.delivery-timeout-ms", () -> "8000");
+        registry.add("kafka-producer.send-timeout-ms", () -> "10000");
+        registry.add("jwt.secret-key", () -> "test-jwt-secret-key");
+        registry.add("jwt.access-token-ttl", () -> "1800000");
+        registry.add("jwt.refresh-token-ttl", () -> "604800000");
+        registry.add("internal.commerce.base-url", () -> "http://localhost:8085");
+        registry.add("internal.event.base-url", () -> "http://localhost:8085");
+        registry.add("pg.toss.base-url", () -> "https://api.tosspayments.com");
+        registry.add("pg.toss.secret-key", () -> "secret-key-dummy");
+        registry.add("server.port", () -> "8085");
+    }
 
     @Autowired private RefundService refundService;
     @Autowired private PaymentRepository paymentRepository;
@@ -66,7 +138,6 @@ class RefundPgTicketConcurrencyIntegrationTest {
         payment.approve("payment-key-test");
         paymentRepository.save(payment);
 
-        // upsertOrderRefund 내부 INSERT 경합 제거를 위해 OrderRefund 선행 생성
         orderRefundRepository.save(OrderRefund.create(
             payment.getOrderId(), userId, payment.getPaymentId(),
             PaymentMethod.PG, 50_000, 1
@@ -92,8 +163,8 @@ class RefundPgTicketConcurrencyIntegrationTest {
     // 테스트 1: 동일 ticketId 동시 10건 — RefundTicket 1건만 생성
     //
     // 공격: 환불 버튼 연타 / 네트워크 재전송 시뮬레이션
-    // 방어 1차: existsByTicketId 선행 체크 → REFUND_ALREADY_IN_PROGRESS(409)
-    // 방어 2차: refund_ticket.ticket_id UNIQUE 제약 + DataIntegrityViolationException catch
+    // 방어 1차: existsByTicketIdAndStatusIn(ACTIVE, COMPLETED) 선행 체크 → REFUND_ALREADY_IN_PROGRESS(409)
+    // 방어 2차: uk_refund_ticket_active partial unique index + DataIntegrityViolationException catch
     // 검증: 성공 1건, 나머지 REFUND_ALREADY_IN_PROGRESS, DB Refund·RefundTicket 각 1건
     // =========================================================
     @Test
@@ -142,7 +213,9 @@ class RefundPgTicketConcurrencyIntegrationTest {
         long refundCount = refundRepository
             .findByUserId(userId, PageRequest.of(0, 100))
             .getTotalElements();
-        boolean ticketExists = refundTicketRepository.existsByTicketId(UUID.fromString(ticketId));
+        boolean ticketExists = refundTicketRepository.existsByTicketIdAndStatusIn(
+            UUID.fromString(ticketId),
+            List.of(RefundTicketStatus.ACTIVE, RefundTicketStatus.COMPLETED));
 
         System.out.println("========== refundPgTicket 동시성 테스트 결과 ==========");
         System.out.println("성공: " + successCount.get() + "건");

--- a/payment/src/test/java/com/devticket/payment/refund/integration/RefundPgTicketConcurrencyIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/integration/RefundPgTicketConcurrencyIntegrationTest.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,7 +49,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  */
 @SpringBootTest
 @Testcontainers
-@Disabled("ci 통과 시간이 오래 걸림으로 테스트 임시 비활성화")
 class RefundPgTicketConcurrencyIntegrationTest {
 
     @Container

--- a/payment/src/test/java/com/devticket/payment/refund/integration/RefundPgTicketConcurrencyIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/integration/RefundPgTicketConcurrencyIntegrationTest.java
@@ -1,0 +1,160 @@
+package com.devticket.payment.refund.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.devticket.payment.payment.domain.enums.PaymentMethod;
+import com.devticket.payment.payment.domain.model.Payment;
+import com.devticket.payment.payment.domain.repository.PaymentRepository;
+import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
+import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderItemInfoResponse;
+import com.devticket.payment.refund.application.service.RefundService;
+import com.devticket.payment.refund.domain.exception.RefundErrorCode;
+import com.devticket.payment.refund.domain.exception.RefundException;
+import com.devticket.payment.refund.domain.model.OrderRefund;
+import com.devticket.payment.refund.domain.repository.OrderRefundRepository;
+import com.devticket.payment.refund.domain.repository.RefundRepository;
+import com.devticket.payment.refund.domain.repository.RefundTicketRepository;
+import com.devticket.payment.refund.infrastructure.client.EventInternalClient;
+import com.devticket.payment.refund.infrastructure.client.dto.InternalEventInfoResponse;
+import com.devticket.payment.refund.presentation.dto.PgRefundRequest;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * refundPgTicket 동시성 통합 테스트
+ *
+ * 실제 DB(H2) UNIQUE 제약 + dedup 가드 검증.
+ * CommerceInternalClient / EventInternalClient 만 Mock (외부 HTTP 호출 차단).
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class RefundPgTicketConcurrencyIntegrationTest {
+
+    @Autowired private RefundService refundService;
+    @Autowired private PaymentRepository paymentRepository;
+    @Autowired private OrderRefundRepository orderRefundRepository;
+    @Autowired private RefundRepository refundRepository;
+    @Autowired private RefundTicketRepository refundTicketRepository;
+
+    @MockitoBean private CommerceInternalClient commerceInternalClient;
+    @MockitoBean private EventInternalClient eventInternalClient;
+
+    private UUID userId;
+    private String ticketId;
+    private Payment payment;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        ticketId = UUID.randomUUID().toString();
+
+        payment = Payment.create(UUID.randomUUID(), userId, PaymentMethod.PG, 50_000);
+        payment.approve("payment-key-test");
+        paymentRepository.save(payment);
+
+        // upsertOrderRefund 내부 INSERT 경합 제거를 위해 OrderRefund 선행 생성
+        orderRefundRepository.save(OrderRefund.create(
+            payment.getOrderId(), userId, payment.getPaymentId(),
+            PaymentMethod.PG, 50_000, 1
+        ));
+
+        InternalEventInfoResponse eventInfo = new InternalEventInfoResponse(
+            UUID.randomUUID(), UUID.randomUUID(), "테스트 이벤트", 50_000,
+            "ACTIVE", "CONCERT", 100, 4, 50,
+            LocalDateTime.now().plusDays(10).toString(),
+            LocalDateTime.now().minusDays(5).toString(),
+            LocalDateTime.now().plusDays(5).toString()
+        );
+
+        given(commerceInternalClient.getOrderItemInfoByTicketId(ticketId))
+            .willReturn(new InternalOrderItemInfoResponse(
+                UUID.fromString(ticketId), payment.getOrderId(), userId,
+                eventInfo.eventId(), 50_000
+            ));
+        given(eventInternalClient.getEventInfo(any())).willReturn(eventInfo);
+    }
+
+    // =========================================================
+    // 테스트 1: 동일 ticketId 동시 10건 — RefundTicket 1건만 생성
+    //
+    // 공격: 환불 버튼 연타 / 네트워크 재전송 시뮬레이션
+    // 방어 1차: existsByTicketId 선행 체크 → REFUND_ALREADY_IN_PROGRESS(409)
+    // 방어 2차: refund_ticket.ticket_id UNIQUE 제약 + DataIntegrityViolationException catch
+    // 검증: 성공 1건, 나머지 REFUND_ALREADY_IN_PROGRESS, DB Refund·RefundTicket 각 1건
+    // =========================================================
+    @Test
+    @DisplayName("동일 ticketId로 동시 10건 요청 시 RefundTicket·Refund는 각 1건만 생성된다")
+    void 동일_ticketId_동시요청_1건만_생성() throws InterruptedException {
+        int threadCount = 10;
+        PgRefundRequest request = new PgRefundRequest("단순 변심");
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger alreadyInProgressCount = new AtomicInteger(0);
+        AtomicInteger otherErrorCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    refundService.refundPgTicket(userId, ticketId, request);
+                    successCount.incrementAndGet();
+                } catch (RefundException e) {
+                    if (e.getErrorCode() == RefundErrorCode.REFUND_ALREADY_IN_PROGRESS) {
+                        alreadyInProgressCount.incrementAndGet();
+                    } else {
+                        otherErrorCount.incrementAndGet();
+                        System.out.println("  기타 RefundException: " + e.getErrorCode());
+                    }
+                } catch (Exception e) {
+                    otherErrorCount.incrementAndGet();
+                    System.out.println("  기타 에러: " + e.getClass().getSimpleName() + " — " + e.getMessage());
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+        executor.shutdown();
+
+        long refundCount = refundRepository
+            .findByUserId(userId, PageRequest.of(0, 100))
+            .getTotalElements();
+        boolean ticketExists = refundTicketRepository.existsByTicketId(UUID.fromString(ticketId));
+
+        System.out.println("========== refundPgTicket 동시성 테스트 결과 ==========");
+        System.out.println("성공: " + successCount.get() + "건");
+        System.out.println("REFUND_ALREADY_IN_PROGRESS: " + alreadyInProgressCount.get() + "건");
+        System.out.println("기타 에러: " + otherErrorCount.get() + "건");
+        System.out.println("DB Refund 수: " + refundCount + "건");
+        System.out.println("DB RefundTicket 존재: " + ticketExists);
+
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(alreadyInProgressCount.get()).isEqualTo(threadCount - 1);
+        assertThat(otherErrorCount.get()).isEqualTo(0);
+        assertThat(refundCount).isEqualTo(1);
+        assertThat(ticketExists).isTrue();
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/refund/integration/RefundPgTicketConcurrencyIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/integration/RefundPgTicketConcurrencyIntegrationTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,6 +50,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  */
 @SpringBootTest
 @Testcontainers
+@Disabled("ci 통과 시간이 오래 걸림으로 테스트 임시 비활성화")
 class RefundPgTicketConcurrencyIntegrationTest {
 
     @Container

--- a/payment/src/test/resources/db/pg-test-init.sql
+++ b/payment/src/test/resources/db/pg-test-init.sql
@@ -1,0 +1,8 @@
+CREATE SCHEMA IF NOT EXISTS payment;
+CREATE SCHEMA IF NOT EXISTS refund;
+CREATE TABLE IF NOT EXISTS payment.shedlock (
+    name       VARCHAR(64)  NOT NULL PRIMARY KEY,
+    lock_until TIMESTAMP    NOT NULL,
+    locked_at  TIMESTAMP    NOT NULL,
+    locked_by  VARCHAR(255) NOT NULL
+);


### PR DESCRIPTION
## 배경 / 문제

환불 버튼 연타 또는 네트워크 재전송 상황에서 동일한 `ticketId`로 `refundPgTicket`이 동시에 호출되면,
기존 코드는 중복 `RefundTicket` 삽입을 막지 못해 같은 티켓이 두 번 이상 환불될 위험이 있었다.

---

## 해결 방법

2단계 dedup 가드를 적용했다.

### 1차 — 선행 존재 확인 (빠른 경로)

`refundTicketRepository.existsByTicketId(ticketId)` 로 이미 환불된 티켓인지 먼저 체크한다.
이미 존재하면 PG 호출 전에 즉시 `REFUND_ALREADY_IN_PROGRESS(409)` 를 반환한다.

### 2차 — DB UNIQUE 제약 + 예외 캐치 (레이스 컨디션 방어)

1차 체크를 통과한 요청이 DB 삽입 직전에 경합하는 경우를 대비해,  
`refund_ticket.ticket_id` 컬럼에 `uk_refund_ticket_ticket_id` UNIQUE 제약을 추가했다.  
삽입 시 `DataIntegrityViolationException` 이 발생하면 원인 체인을 순회해 해당 제약 위반인지 확인하고,
맞으면 `REFUND_ALREADY_IN_PROGRESS(409)` 를 던진다.  
다른 제약 위반(NOT NULL 등)은 그대로 전파한다.

---

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `RefundTicket.java` | `@UniqueConstraint(uk_refund_ticket_ticket_id)` 추가 |
| `RefundTicketRepository.java` | `existsByTicketId(UUID)` 메서드 추가 |
| `RefundTicketJpaRepository.java` | Spring Data JPA `existsByTicketId` 선언 추가 |
| `RefundTicketRepositoryImpl.java` | `existsByTicketId` 위임 구현 추가 |
| `RefundServiceImpl.java` | 선행 dedup 체크 + `save()` 래핑 try-catch + `isTicketUniqueViolation()` 헬퍼 추가 |
| `RefundServiceImplTest.java` | 티켓 단건 환불 dedup 가드 유닛 테스트 추가 |
| `RefundPgTicketConcurrencyIntegrationTest.java` | 동일 ticketId 동시 10건 통합 테스트 추가 (신규) |

---

## 테스트

### 유닛 테스트 (`RefundServiceImplTest`)

- `existsByTicketId=true` → `REFUND_ALREADY_IN_PROGRESS` 반환, 이후 로직 미호출
- `refundTicketRepository.save()` 에서 `uk_refund_ticket_ticket_id` UNIQUE 위반 → `REFUND_ALREADY_IN_PROGRESS` 반환
- 다른 제약 위반 → `DataIntegrityViolationException` 그대로 전파
- 정상 환불 → 응답 및 Outbox 저장 호출 확인

### 통합 테스트 (`RefundPgTicketConcurrencyIntegrationTest`)

실제 H2 DB + UNIQUE 제약 조건으로 동일 `ticketId`에 10개 스레드가 동시에 요청하는 시나리오를 검증한다.

- 성공: 1건
- `REFUND_ALREADY_IN_PROGRESS`: 9건
- DB `Refund` 레코드: 1건
- DB `RefundTicket` 레코드: 1건 존재

---

## 주요 고려사항

- `isTicketUniqueViolation()` 은 원인 체인을 끝까지 순회한다 — Spring이 `PersistenceException` 으로 한 번 더 래핑하는 환경에 대응하기 위함이다.
- H2에서는 constraint name에 테이블·컬럼 정보가 붙어오는 경우가 있어 `contains` 로 비교한다.
- 선행 체크와 DB 제약 두 계층이 모두 필요하다: 선행 체크만으로는 극단적인 레이스를 막지 못하고, DB 제약만으로는 에러 핸들링이 불명확해진다.
