### PR TITLE
[Admin] fix : prod.yml의 ES uri수정

### DIFF
--- a/admin/src/main/resources/application-prod.yml
+++ b/admin/src/main/resources/application-prod.yml
@@ -23,7 +23,7 @@ jwt:
   refresh-token-ttl: 604800000
 
 elasticsearch:
-  uris: http://localhost:9200
+  uris: http://elasticsearch:9200
   connection-timeout: 5s
   socket-timeout: 30s
 


### PR DESCRIPTION
배포환경 ES uris변경  
http://localhost:9200  ->  http://elasticsearch:9200