### PR TITLE
[Event] fix: ES 초기화 OOMKilled 수정 - 비동기 전환 및 배치 처리

### DIFF
--- a/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
+++ b/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
@@ -7,6 +7,7 @@ import com.devticket.event.domain.model.Event;
 import com.devticket.event.infrastructure.persistence.EventRepository;
 import com.devticket.event.infrastructure.search.EventDocument;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -105,21 +106,36 @@ public class ElasticsearchIndexInitializer {
 
     @SuppressWarnings("unchecked")
     private Set<String> getAllEsDocumentIds() {
-        try {
-            var response = esClient.search(s -> s
-                    .index("event")
-                    .size(1000)
-                    .source(src -> src.fetch(false))
-                    .query(q -> q.matchAll(m -> m)),
-                java.util.Map.class);
+        Set<String> ids = new HashSet<>();
+        int from = 0;
+        final int pageSize = 1000;
 
-            return response.hits().hits().stream()
-                .map(hit -> hit.id())
-                .collect(Collectors.toSet());
+        try {
+            while (true) {
+                final int currentFrom = from;
+                var response = esClient.search(s -> s
+                        .index("event")
+                        .from(currentFrom)
+                        .size(pageSize)
+                        .source(src -> src.fetch(false))
+                        .query(q -> q.matchAll(m -> m)),
+                    java.util.Map.class);
+
+                var hits = response.hits().hits();
+                if (hits.isEmpty()) {
+                    break;
+                }
+                hits.forEach(hit -> ids.add(hit.id()));
+                if (hits.size() < pageSize) {
+                    break;
+                }
+                from += pageSize;
+            }
         } catch (Exception e) {
             log.warn("[ES] 전체 ID 조회 실패 - 동기화 스킵", e);
             return Set.of();
         }
+        return ids;
     }
 
     private void reindexAllEvents() {

--- a/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
+++ b/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
@@ -17,6 +17,7 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -31,11 +32,14 @@ public class ElasticsearchIndexInitializer {
     private static final List<EventStatus> TERMINATED_STATUSES =
         List.of(EventStatus.SALE_ENDED, EventStatus.CANCELLED, EventStatus.FORCE_CANCELLED);
 
+    private static final int BATCH_SIZE = 50;
+
     private final ElasticsearchOperations elasticsearchOperations;
     private final ElasticsearchClient esClient;
     private final EventRepository eventRepository;
     private final EventService eventService;
 
+    @Async
     @EventListener(ApplicationReadyEvent.class)
     public void initializeIndex() {
         try {
@@ -51,7 +55,6 @@ public class ElasticsearchIndexInitializer {
 
         } catch (Exception e) {
             log.error("[ES Index 초기화 실패]", e);
-            throw new RuntimeException("ElasticSearch 인덱스 초기화 실패", e);
         }
     }
 
@@ -74,16 +77,7 @@ public class ElasticsearchIndexInitializer {
 
         if (!missingIds.isEmpty()) {
             log.info("[ES] 누락 이벤트 {}건 색인 시작", missingIds.size());
-            List<Event> events = eventRepository.findAllWithDetailsByEventIdIn(new ArrayList<>(missingIds));
-            int count = 0;
-            for (Event event : events) {
-                try {
-                    eventService.syncToElasticsearch(event);
-                    count++;
-                } catch (Exception e) {
-                    log.warn("[ES 색인 실패] eventId: {}", event.getEventId(), e);
-                }
-            }
+            int count = indexInBatches(new ArrayList<>(missingIds), "[ES 색인 실패]");
             log.info("[ES] 누락 색인 완료. {}건", count);
         } else {
             log.info("[ES] 활성 이벤트 모두 색인됨 ({}건)", activeDbIds.size());
@@ -114,7 +108,7 @@ public class ElasticsearchIndexInitializer {
         try {
             var response = esClient.search(s -> s
                     .index("event")
-                    .size(10000)
+                    .size(1000)
                     .source(src -> src.fetch(false))
                     .query(q -> q.matchAll(m -> m)),
                 java.util.Map.class);
@@ -136,17 +130,24 @@ public class ElasticsearchIndexInitializer {
             return;
         }
 
-        List<Event> events = eventRepository.findAllWithDetailsByEventIdIn(allEventIds);
+        int count = indexInBatches(allEventIds, "[ES 재색인 실패]");
+        log.info("[ES 재색인] 완료. 총 {}건", count);
+    }
 
+    private int indexInBatches(List<UUID> eventIds, String errorLogPrefix) {
         int count = 0;
-        for (Event event : events) {
-            try {
-                eventService.syncToElasticsearch(event);
-                count++;
-            } catch (Exception e) {
-                log.warn("[ES 재색인 실패] eventId: {}", event.getEventId(), e);
+        for (int i = 0; i < eventIds.size(); i += BATCH_SIZE) {
+            List<UUID> batch = eventIds.subList(i, Math.min(i + BATCH_SIZE, eventIds.size()));
+            List<Event> events = eventRepository.findAllWithDetailsByEventIdIn(batch);
+            for (Event event : events) {
+                try {
+                    eventService.syncToElasticsearch(event);
+                    count++;
+                } catch (Exception e) {
+                    log.warn("{} eventId: {}", errorLogPrefix, event.getEventId(), e);
+                }
             }
         }
-        log.info("[ES 재색인] 완료. 총 {}건", count);
+        return count;
     }
 }


### PR DESCRIPTION
## 문제
로컬 환경에서는 정상 동작하였으나 프로덕션 배포 환경(k3s, memory limit 384Mi)에서
event pod가 CrashLoopBackOff 상태로 서비스 불가
OOMKilled (exit code 137)

## 원인
로컬은 메모리 제한이 없어 문제가 드러나지 않았으나 배포 환경의 384Mi 제한 하에서
ElasticsearchIndexInitializer가 ApplicationReady 시점에 동기 실행되어
시작 직후 메모리 피크 발생

## 변경 사항
- `@Async` 추가로 ES 초기화를 백그라운드 스레드에서 실행
- `indexInBatches()` 도입, 이벤트 50개 단위 배치 처리
- ES 전체 문서 조회 size 10000 → 1000 축소
- 초기화 실패 시 앱이 종료되지 않도록 예외 처리 개선