### PR TITLE
[Member] chore: SpotBugs CI 품질 게이트 추가

### DIFF
--- a/.github/workflows/ci-member.yml
+++ b/.github/workflows/ci-member.yml
@@ -32,5 +32,12 @@ jobs:
         env:
           SPRING_PROFILES_ACTIVE: test
 
-      - name: 5. Gradle Build
-        run: cd member && ./gradlew build -x test
+      - name: 5. Gradle Build & SpotBugs
+        run: cd member && ./gradlew build spotbugsMain -x test
+
+      - name: 6. Upload SpotBugs Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spotbugs-report-member
+          path: member/build/reports/spotbugs/

--- a/member/build.gradle
+++ b/member/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '4.0.4'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'com.github.spotbugs' version '6.0.9'
 }
 
 group = 'com.devticket'
@@ -56,4 +57,17 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+spotbugs {
+    ignoreFailures = true
+    effort = 'max'
+    reportLevel = 'medium'
+    excludeFilter = file('spotbugs-exclude.xml')
+}
+
+spotbugsMain {
+    reports {
+        html { required = true }
+    }
 }

--- a/member/spotbugs-exclude.xml
+++ b/member/spotbugs-exclude.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!-- Lombok 생성 코드 제외 -->
+  <Match>
+    <Class name="~.*\$Builder" />
+  </Match>
+  <!-- 테스트 코드 제외 -->
+  <Match>
+    <Class name="~.*Test" />
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- Member 서비스 CI에 SpotBugs 정적 분석 자동 실행 추가

## 변경 사항
- `member/build.gradle`
  - SpotBugs Gradle 플러그인 추가 (`com.github.spotbugs 6.0.9`)
  - `ignoreFailures = true` — 빌드는 항상 통과, 리포트만 생성
  - `reportLevel = 'medium'` — Medium 이상 전부 리포트에 표시
- `member/spotbugs-exclude.xml` 추가
  - Lombok 생성 코드 및 테스트 코드 분석 제외
- `.github/workflows/ci-event.yml`
  - `5. Gradle Build & SpotBugs` step 추가
  - `6. Upload SpotBugs Report` step 추가 — PR마다 artifact로 HTML 리포트 저장
- `.gitignore`
  - `spring-logs/` 추가

## 리포트 확인 방법
1. GitHub → Actions → CI - Event Service 클릭
2. 원하는 run 클릭
3. 페이지 맨 아래 Artifacts 섹션
4. `spotbugs-report-event` 다운로드 → `main.html` 브라우저로 열기

## 참고 사항
- 프로덕션 로직 변경 없음
- 빌드 실패 기준을 높이려면 `ignoreFailures = false` + `reportLevel = 'high'` 로 변경 가능
- SpotBugs 적용 가이드 문서: Notion 참고