### PR TITLE
[Payment] fix: readyPayment 재시도 정상화 + dead 코드 정리 (Commerce client 2건, processBatchRefund stub)

### DIFF
--- a/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/payment/application/service/PaymentServiceImpl.java
@@ -61,34 +61,51 @@ public class PaymentServiceImpl implements PaymentService {
         validateOrderOwner(userId, order.userId());
         validateOrderPayable(order);
 
-        // 중복 요청: 동일 orderId + 동일 결제수단의 READY Payment면 재사용, 그 외는 ALREADY_PROCESSED
+        // 기존 Payment 처리 — READY는 재시도/멱등 재사용 허용, 종단 상태는 변경 불가
         Optional<Payment> existing = paymentRepository.findByOrderId(order.id());
+        Payment retryTarget = null;
+
         if (existing.isPresent()) {
-            Payment existingPayment = existing.get();
-            if (existingPayment.getPaymentMethod() == request.paymentMethod()
-                && existingPayment.getStatus() == PaymentStatus.READY) {
+            Payment ep = existing.get();
+
+            if (ep.getStatus() != PaymentStatus.READY) {
+                throw new PaymentException(PaymentErrorCode.ALREADY_PROCESSED_PAYMENT);
+            }
+
+            if (isSameReadyRequest(ep, request)) {
                 log.info("[ReadyPayment] 기존 READY Payment 재사용 — orderId={}, method={}",
                     order.id(), request.paymentMethod());
                 return PaymentReadyResponse.from(
-                    existingPayment, request.orderId(), order.orderNumber(), order.status());
+                    ep, request.orderId(), order.orderNumber(), order.status());
             }
-            throw new PaymentException(PaymentErrorCode.ALREADY_PROCESSED_PAYMENT);
+
+            if (ep.getPaymentMethod() == PaymentMethod.WALLET_PG
+                && ep.getWalletAmount() != null && ep.getWalletAmount() > 0) {
+                walletService.restoreForWalletPgFail(ep.getUserId(), ep.getWalletAmount(), ep.getOrderId());
+                log.info("[ReadyPayment] 결제수단 변경 — 기존 WALLET_PG 예치금 환원. orderId={}, walletAmount={}",
+                    ep.getOrderId(), ep.getWalletAmount());
+            }
+            retryTarget = ep;
         }
 
         // WALLET_PG 복합결제
         if (request.paymentMethod() == PaymentMethod.WALLET_PG) {
-            return readyWalletPgPayment(userId, request, order);
+            return readyWalletPgPayment(userId, request, order, retryTarget);
         }
 
         // PG 결제
         if (request.paymentMethod() == PaymentMethod.PG) {
-            Payment payment = Payment.create(order.id(), userId, PaymentMethod.PG, order.totalAmount());
+            Payment payment = (retryTarget != null)
+                ? applyRetry(retryTarget, PaymentMethod.PG, order.totalAmount(), 0, 0)
+                : Payment.create(order.id(), userId, PaymentMethod.PG, order.totalAmount());
             Payment savedPayment = paymentRepository.save(payment);
             return PaymentReadyResponse.from(savedPayment, request.orderId(), order.orderNumber(), order.status());
         }
 
         // WALLET 결제
-        Payment payment = Payment.create(order.id(), userId, PaymentMethod.WALLET, order.totalAmount());
+        Payment payment = (retryTarget != null)
+            ? applyRetry(retryTarget, PaymentMethod.WALLET, order.totalAmount(), 0, 0)
+            : Payment.create(order.id(), userId, PaymentMethod.WALLET, order.totalAmount());
         paymentRepository.save(payment);
         List<PaymentCompletedEvent.OrderItem> walletOrderItems = order.orderItems() == null
             ? List.of()
@@ -101,7 +118,8 @@ public class PaymentServiceImpl implements PaymentService {
         return PaymentReadyResponse.from(updated, request.orderId(), order.orderNumber(), order.status());
     }
 
-    private PaymentReadyResponse readyWalletPgPayment(UUID userId, PaymentReadyRequest request, InternalOrderInfoResponse order) {
+    private PaymentReadyResponse readyWalletPgPayment(
+        UUID userId, PaymentReadyRequest request, InternalOrderInfoResponse order, Payment retryTarget) {
         int totalAmount = order.totalAmount();
 
         // 입력값 검증
@@ -115,14 +133,32 @@ public class PaymentServiceImpl implements PaymentService {
         // 예치금 차감 (WalletTransaction USE 기록 포함)
         walletService.deductForWalletPg(userId, order.id(), walletAmount);
 
-        // Payment 생성 (READY, WALLET_PG)
-        Payment payment = Payment.create(order.id(), userId, PaymentMethod.WALLET_PG, totalAmount, walletAmount, pgAmount);
+        // Payment 생성 또는 재초기화 (READY, WALLET_PG)
+        Payment payment = (retryTarget != null)
+            ? applyRetry(retryTarget, PaymentMethod.WALLET_PG, totalAmount, walletAmount, pgAmount)
+            : Payment.create(order.id(), userId, PaymentMethod.WALLET_PG, totalAmount, walletAmount, pgAmount);
         Payment savedPayment = paymentRepository.save(payment);
 
         log.info("[ReadyPayment] WALLET_PG 결제 준비 — orderId={}, walletAmount={}, pgAmount={}",
             order.id(), walletAmount, pgAmount);
 
         return PaymentReadyResponse.from(savedPayment, request.orderId(), order.orderNumber(), order.status());
+    }
+
+    private boolean isSameReadyRequest(Payment existing, PaymentReadyRequest request) {
+        if (existing.getPaymentMethod() != request.paymentMethod()) {
+            return false;
+        }
+        if (request.paymentMethod() == PaymentMethod.WALLET_PG) {
+            Integer reqWallet = request.walletAmount();
+            return reqWallet != null && reqWallet.equals(existing.getWalletAmount());
+        }
+        return true;
+    }
+
+    private Payment applyRetry(Payment target, PaymentMethod method, Integer amount, Integer walletAmount, Integer pgAmount) {
+        target.resetForRetry(method, amount, walletAmount, pgAmount);
+        return target;
     }
 
     @Override

--- a/payment/src/main/java/com/devticket/payment/payment/domain/model/Payment.java
+++ b/payment/src/main/java/com/devticket/payment/payment/domain/model/Payment.java
@@ -118,6 +118,20 @@ public class Payment extends BaseEntity {
         상태 변경 메서드
        ======================= */
 
+    /**
+     * READY 상태인 Payment를 다른 결제수단/금액으로 재초기화.
+     * status / paymentId / orderId / userId 는 보존, 결제 정보만 갱신.
+     */
+    public void resetForRetry(PaymentMethod method, Integer amount, Integer walletAmount, Integer pgAmount) {
+        if (this.status != PaymentStatus.READY) {
+            throw new PaymentException(PaymentErrorCode.INVALID_STATUS_TRANSITION);
+        }
+        this.paymentMethod = method;
+        this.amount = amount;
+        this.walletAmount = walletAmount != null ? walletAmount : 0;
+        this.pgAmount = pgAmount != null ? pgAmount : 0;
+    }
+
     public void approve(String paymentKey) {
         validateTransition(PaymentStatus.SUCCESS);
         this.paymentKey = paymentKey;

--- a/payment/src/main/java/com/devticket/payment/payment/infrastructure/client/CommerceInternalClient.java
+++ b/payment/src/main/java/com/devticket/payment/payment/infrastructure/client/CommerceInternalClient.java
@@ -42,27 +42,6 @@ public class CommerceInternalClient {
         }
     }
 
-    public void completePayment(UUID orderId) {
-        try {
-            restClient.post()
-                .uri("/internal/orders/{orderId}/payment-completed", orderId)
-                .retrieve()
-                .toBodilessEntity();
-        } catch (ResourceAccessException e) {
-            throw e;
-        } catch (RestClientResponseException e) {
-            throw e;
-        }
-    }
-
-    public void failOrder(UUID orderId) {
-        restClient.post()
-            .uri("/internal/orders/{orderId}/payment-failed", orderId)
-            .retrieve()
-            .toBodilessEntity();
-    }
-
-
     public InternalEventOrdersResponse getOrdersByEvent(UUID eventId) {
         log.info("[CommerceClient] 이벤트 주문 조회 — eventId={}", eventId);
         try {

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletService.java
@@ -36,8 +36,6 @@ public interface WalletService {
 
     void restoreForWalletPgFail(UUID userId, int walletAmount, UUID orderId);
 
-    void processBatchRefund(UUID eventId);
-
     void recoverStalePendingCharge(UUID chargeId);
 
     void depositFromSettlement(SettlementDepositRequest request);

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -21,10 +21,8 @@ import com.devticket.payment.common.outbox.OutboxService;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmCommand;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
-import com.devticket.payment.payment.domain.enums.PaymentStatus;
 import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
-import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentStatusResponse;
 import com.devticket.payment.wallet.application.event.PaymentCompletedEvent;
@@ -37,7 +35,6 @@ import com.devticket.payment.wallet.domain.model.WalletTransaction;
 import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
 import com.devticket.payment.wallet.domain.repository.WalletRepository;
 import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
-import com.devticket.payment.wallet.infrastructure.client.dto.InternalEventOrdersResponse;
 import com.devticket.payment.wallet.presentation.dto.SettlementDepositRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletBalanceResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmRequest;
@@ -61,7 +58,6 @@ public class WalletServiceImpl implements WalletService {
     // private final RefundRepository refundRepository; // TODO: Refund 모듈 완성 후 활성화
     private final PgPaymentClient pgPaymentClient;
     private final OutboxService outboxService;
-    private final CommerceInternalClient commerceInternalClient;
     private final WalletChargeTransactionService walletChargeTransactionService;
 
     // =====================================================================
@@ -364,68 +360,6 @@ public class WalletServiceImpl implements WalletService {
 
         log.info("[WalletPG] 예치금 복구 완료 — orderId={}, walletAmount={}, balanceAfter={}",
             orderId, walletAmount, wallet.getBalance());
-    }
-
-    // =====================================================================
-    // event.force-cancelled / event.sale-stopped — 일괄 환불
-    // =====================================================================
-
-    @Override
-    @Transactional
-    public void processBatchRefund(UUID eventId) {
-        InternalEventOrdersResponse response = commerceInternalClient.getOrdersByEvent(eventId);
-
-        if (response == null || response.getOrders() == null || response.getOrders().isEmpty()) {
-            log.info("[BatchRefund] 환불 대상 주문 없음 — eventId={}", eventId);
-            return;
-        }
-
-        List<InternalEventOrdersResponse.OrderInfo> orders = response.getOrders().stream()
-            .filter(o -> "PAID".equals(o.getStatus()))
-            .toList();
-
-        log.info("[BatchRefund] 일괄 환불 시작 — eventId={}, 대상 건수={}", eventId, orders.size());
-
-        for (InternalEventOrdersResponse.OrderInfo orderInfo : orders) {
-            UUID orderId = orderInfo.getOrderId();
-            UUID userId = UUID.fromString(orderInfo.getUserId());
-            int refundAmount = orderInfo.getTotalAmount();
-
-            Payment payment = paymentRepository.findByOrderId(orderId).orElse(null);
-            if (payment == null) {
-                log.warn("[BatchRefund] Payment 없음 — orderId={}", orderId);
-                continue;
-            }
-            if (payment.getStatus() == PaymentStatus.REFUNDED) {
-                log.info("[BatchRefund] 이미 환불됨 — orderId={}", orderId);
-                continue;
-            }
-
-            // TODO: Refund 모듈 완성 후 주석 해제
-            // Refund refund = Refund.createForBatch(payment, refundAmount, 100);
-            // refundRepository.save(refund);
-            // payment.refund();
-
-            // if ("WALLET".equals(orderInfo.getPaymentMethod())) {
-            // restoreBalance(userId, refundAmount, refund.getRefundId(), orderId);
-            // }
-
-            // RefundCompletedEvent event = RefundCompletedEvent.builder()
-            // .refundId(refund.getRefundId())
-            // .orderId(orderId)
-            // .userId(userId)
-            // .paymentId(payment.getPaymentId())
-            // .paymentMethod(payment.getPaymentMethod())
-            // .refundAmount(refundAmount)
-            // .refundRate(100)
-            // .timestamp(Instant.now())
-            // .build();
-            // outboxService.save("REFUND", refund.getId(), KafkaTopics.REFUND_COMPLETED, event);
-
-            // log.info("[BatchRefund] 환불 완료 — orderId={}, refundId={}",
-            // orderId, refund.getRefundId());
-            log.info("[BatchRefund] Refund 모듈 미완성 — 스킵 orderId={}", orderId);
-        }
     }
 
     // =====================================================================

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -358,6 +358,12 @@ public class WalletServiceImpl implements WalletService {
         );
         walletTransactionRepository.save(tx);
 
+        // 기존 USE_<orderId> 키 무효화 — readyPayment 재시도(예: WALLET_PG 2000→3000)에서
+        // 새 deductForWalletPg 가 동일 키 충돌로 멱등 skip 되며 차감 누락되는 문제 방지.
+        String useKey = "USE_" + orderId;
+        walletTransactionRepository.findByTransactionKey(useKey)
+            .ifPresent(WalletTransaction::revoke);
+
         log.info("[WalletPG] 예치금 복구 완료 — orderId={}, walletAmount={}, balanceAfter={}",
             orderId, walletAmount, wallet.getBalance());
     }

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/model/WalletTransaction.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/model/WalletTransaction.java
@@ -157,6 +157,17 @@ public class WalletTransaction extends BaseEntity {
         this.deletedAt = LocalDateTime.now();
     }
 
+    /**
+     * transactionKey 를 무효화한다 — 재시도 흐름에서 같은 orderId 로 새 차감/환원이 가능하도록
+     * 기존 키를 unique 충돌 없는 형태로 rename + softDelete.
+     * Why: WALLET_PG 재시도(예: 2000→3000) 시 기존 USE_<orderId> 행이 멱등 키를 점유해
+     *      두 번째 deduct 가 skip 되며 차감 누락이 발생. 환원 시 이 메서드로 USE 키를 해제한다.
+     */
+    public void revoke() {
+        this.transactionKey = "REVOKED_" + this.transactionKey + "_" + UUID.randomUUID();
+        this.deletedAt = LocalDateTime.now();
+    }
+
     public boolean isSameTransactionKey(String transactionKey) {
         return this.transactionKey.equals(transactionKey);
     }

--- a/payment/src/main/java/com/devticket/payment/wallet/domain/repository/WalletTransactionRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/domain/repository/WalletTransactionRepository.java
@@ -1,6 +1,7 @@
 package com.devticket.payment.wallet.domain.repository;
 
 import com.devticket.payment.wallet.domain.model.WalletTransaction;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,6 +12,8 @@ public interface WalletTransactionRepository {
     WalletTransaction saveAndFlush(WalletTransaction walletTransaction);
 
     boolean existsByTransactionKey(String transactionKey);
+
+    Optional<WalletTransaction> findByTransactionKey(String transactionKey);
 
     Page<WalletTransaction> findAllByWalletId(Long walletId, Pageable pageable);
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletTransactionJpaRepository.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletTransactionJpaRepository.java
@@ -1,6 +1,7 @@
 package com.devticket.payment.wallet.infrastructure.persistence;
 
 import com.devticket.payment.wallet.domain.model.WalletTransaction;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface WalletTransactionJpaRepository extends JpaRepository<WalletTransaction, Long> {
 
     boolean existsByTransactionKey(String transactionKey);
+
+    Optional<WalletTransaction> findByTransactionKey(String transactionKey);
 
     Page<WalletTransaction> findAllByWalletId(Long walletId, Pageable pageable);
 }

--- a/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletTransactionRepositoryImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/infrastructure/persistence/WalletTransactionRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.devticket.payment.wallet.infrastructure.persistence;
 
 import com.devticket.payment.wallet.domain.model.WalletTransaction;
 import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +27,11 @@ public class WalletTransactionRepositoryImpl implements WalletTransactionReposit
     @Override
     public boolean existsByTransactionKey(String transactionKey) {
         return walletTransactionJpaRepository.existsByTransactionKey(transactionKey);
+    }
+
+    @Override
+    public Optional<WalletTransaction> findByTransactionKey(String transactionKey) {
+        return walletTransactionJpaRepository.findByTransactionKey(transactionKey);
     }
 
     @Override

--- a/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
@@ -18,7 +18,6 @@ import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.enums.PaymentStatus;
 import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
-import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.wallet.application.event.PaymentCompletedEvent;
 import com.devticket.payment.wallet.application.service.WalletServiceImpl;
@@ -34,7 +33,6 @@ import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
 import com.devticket.payment.wallet.domain.repository.WalletRepository;
 import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
-import com.devticket.payment.wallet.infrastructure.client.dto.InternalEventOrdersResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletBalanceResponse;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmRequest;
 import com.devticket.payment.wallet.presentation.dto.WalletChargeConfirmResponse;
@@ -75,7 +73,6 @@ class WalletServiceTest {
     // @Mock private RefundRepository refundRepository; // TODO: Refund 모듈 완성 후 활성화
     @Mock private PgPaymentClient pgPaymentClient;
     @Mock private OutboxService outboxService;
-    @Mock private CommerceInternalClient commerceInternalClient;
     @Mock private WalletChargeTransactionService walletChargeTransactionService;
 
     @Spy
@@ -995,24 +992,4 @@ class WalletServiceTest {
         return payment;
     }
 
-    private InternalEventOrdersResponse eventOrdersOf(
-        UUID eventId, List<InternalEventOrdersResponse.OrderInfo> orders
-    ) {
-        InternalEventOrdersResponse res = new InternalEventOrdersResponse();
-        ReflectionTestUtils.setField(res, "eventId", eventId);
-        ReflectionTestUtils.setField(res, "orders", orders);
-        return res;
-    }
-
-    private InternalEventOrdersResponse.OrderInfo orderInfoOf(
-        UUID orderId, String userId, String paymentMethod, int totalAmount, String status
-    ) {
-        InternalEventOrdersResponse.OrderInfo info = new InternalEventOrdersResponse.OrderInfo();
-        ReflectionTestUtils.setField(info, "orderId", orderId);
-        ReflectionTestUtils.setField(info, "userId", userId);
-        ReflectionTestUtils.setField(info, "paymentMethod", paymentMethod);
-        ReflectionTestUtils.setField(info, "totalAmount", totalAmount);
-        ReflectionTestUtils.setField(info, "status", status);
-        return info;
-    }
 }

--- a/payment/src/test/java/com/devticket/payment/integration/WalletPgRetryIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/integration/WalletPgRetryIntegrationTest.java
@@ -1,0 +1,180 @@
+package com.devticket.payment.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.devticket.payment.payment.application.service.PaymentService;
+import com.devticket.payment.payment.domain.enums.PaymentMethod;
+import com.devticket.payment.payment.domain.model.Payment;
+import com.devticket.payment.payment.domain.repository.PaymentRepository;
+import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
+import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderInfoResponse;
+import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
+import com.devticket.payment.payment.presentation.dto.PaymentReadyRequest;
+import com.devticket.payment.wallet.domain.model.Wallet;
+import com.devticket.payment.wallet.domain.model.WalletTransaction;
+import com.devticket.payment.wallet.domain.repository.WalletRepository;
+import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * WALLET_PG 재시도 시 잔액 차감 누락 회귀 방지 통합 테스트.
+ *
+ * 검증 대상: readyPayment 가 같은 orderId 로 결제수단/금액을 변경할 때
+ *  - 기존 USE_&lt;orderId&gt; 트랜잭션 키가 환원 시 무효화되는지
+ *  - 두 번째 deductForWalletPg 가 멱등 skip 되지 않고 실제 잔액을 차감하는지
+ *
+ * 실제 DB(PostgreSQL) UNIQUE(transaction_key) 제약 + atomic update 동작을 그대로 검증.
+ * Mock: 외부 의존성만(Commerce REST, PG REST) 차단.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class WalletPgRetryIntegrationTest {
+
+    @Autowired private PaymentService paymentService;
+    @Autowired private WalletRepository walletRepository;
+    @Autowired private WalletTransactionRepository walletTransactionRepository;
+    @Autowired private PaymentRepository paymentRepository;
+
+    @MockitoBean private CommerceInternalClient commerceInternalClient;
+    @MockitoBean private PgPaymentClient pgPaymentClient;
+
+    private UUID userId;
+    private UUID orderId;
+
+    private static final int INITIAL_BALANCE = 100_000;
+    private static final int TOTAL_AMOUNT = 50_000;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        orderId = UUID.randomUUID();
+        Wallet wallet = Wallet.create(userId);
+        wallet.charge(INITIAL_BALANCE);
+        walletRepository.save(wallet);
+    }
+
+    @Test
+    @DisplayName("WALLET_PG 2000 → 3000 재시도 — 환원 + 새 차감으로 잔액 정확히 -3000")
+    void WALLET_PG_금액변경_재시도_차감_정확성() {
+        // given
+        InternalOrderInfoResponse orderInfo = orderInfoOf(orderId, userId, TOTAL_AMOUNT);
+        when(commerceInternalClient.getOrderInfo(orderId)).thenReturn(orderInfo);
+
+        PaymentReadyRequest first = new PaymentReadyRequest(orderId, PaymentMethod.WALLET_PG, 2000);
+        PaymentReadyRequest second = new PaymentReadyRequest(orderId, PaymentMethod.WALLET_PG, 3000);
+
+        // when 1: 첫 시도 — wallet 2000 차감
+        paymentService.readyPayment(userId, first);
+
+        Wallet afterFirst = walletRepository.findByUserId(userId).orElseThrow();
+        assertThat(afterFirst.getBalance()).isEqualTo(INITIAL_BALANCE - 2000);
+
+        // when 2: 재시도 — 기존 USE 키 무효화 후 새 차감(3000) 정상 진행
+        paymentService.readyPayment(userId, second);
+
+        // then 1: 잔액 = INITIAL_BALANCE - 3000 (차감 누락 없음)
+        Wallet afterSecond = walletRepository.findByUserId(userId).orElseThrow();
+        assertThat(afterSecond.getBalance())
+            .as("환원 후 새 차감이 정상 적용되어야 함 — 차감 누락 시 잔액 = INITIAL_BALANCE - 2000 으로 남음")
+            .isEqualTo(INITIAL_BALANCE - 3000);
+
+        // then 2: Payment 가 in-place 갱신
+        Payment payment = paymentRepository.findByOrderId(orderId).orElseThrow();
+        assertThat(payment.getPaymentMethod()).isEqualTo(PaymentMethod.WALLET_PG);
+        assertThat(payment.getWalletAmount()).isEqualTo(3000);
+        assertThat(payment.getPgAmount()).isEqualTo(TOTAL_AMOUNT - 3000);
+
+        // then 3: 트랜잭션 키 흔적 검증
+        //   - USE_<orderId> 가 활성 row 로 존재 (재시도 deduct 결과, 새로 점유)
+        //   - REVOKED_USE_<orderId>_* 도 존재 (첫 deduct 무효화 흔적, 단언은 not-empty 한도)
+        Optional<WalletTransaction> useNow = walletTransactionRepository.findByTransactionKey("USE_" + orderId);
+        assertThat(useNow).as("재시도 후 USE 키가 새 deduct 로 점유되어야 함").isPresent();
+        assertThat(useNow.get().getAmount()).isEqualTo(3000);
+        assertThat(useNow.get().getDeletedAt()).isNull();
+
+        Optional<WalletTransaction> restored = walletTransactionRepository
+            .findByTransactionKey("PG_WALLET_RESTORE_" + orderId);
+        assertThat(restored).as("환원 트랜잭션이 기록되어야 함").isPresent();
+        assertThat(restored.get().getAmount()).isEqualTo(2000);
+    }
+
+    @Test
+    @DisplayName("WALLET_PG 2000 → PG 단독 재시도 — 환원만, 잔액 INITIAL_BALANCE 회복")
+    void WALLET_PG에서_PG로_변경_환원만() {
+        // given
+        InternalOrderInfoResponse orderInfo = orderInfoOf(orderId, userId, TOTAL_AMOUNT);
+        when(commerceInternalClient.getOrderInfo(orderId)).thenReturn(orderInfo);
+
+        PaymentReadyRequest first = new PaymentReadyRequest(orderId, PaymentMethod.WALLET_PG, 2000);
+        PaymentReadyRequest second = new PaymentReadyRequest(orderId, PaymentMethod.PG, null);
+
+        // when
+        paymentService.readyPayment(userId, first);
+        paymentService.readyPayment(userId, second);
+
+        // then: 잔액 환원 + 추가 차감 없음 = INITIAL_BALANCE
+        Wallet wallet = walletRepository.findByUserId(userId).orElseThrow();
+        assertThat(wallet.getBalance()).isEqualTo(INITIAL_BALANCE);
+
+        Payment payment = paymentRepository.findByOrderId(orderId).orElseThrow();
+        assertThat(payment.getPaymentMethod()).isEqualTo(PaymentMethod.PG);
+        assertThat(payment.getWalletAmount()).isEqualTo(0);
+        assertThat(payment.getPgAmount()).isEqualTo(0);
+
+        // 환원 트랜잭션 기록 확인 + 기존 USE 키는 무효화되어 활성 row 없음
+        assertThat(walletTransactionRepository
+            .findByTransactionKey("PG_WALLET_RESTORE_" + orderId)).isPresent();
+        assertThat(walletTransactionRepository
+            .findByTransactionKey("USE_" + orderId))
+            .as("PG 단독으로 변경 후에는 USE 활성 row 가 없어야 함")
+            .isEmpty();
+    }
+
+    @Test
+    @DisplayName("WALLET_PG 2000 동일 재요청 — 멱등 재사용, 잔액 변동 없음")
+    void WALLET_PG_동일요청_멱등재사용() {
+        // given
+        InternalOrderInfoResponse orderInfo = orderInfoOf(orderId, userId, TOTAL_AMOUNT);
+        when(commerceInternalClient.getOrderInfo(orderId)).thenReturn(orderInfo);
+
+        PaymentReadyRequest request = new PaymentReadyRequest(orderId, PaymentMethod.WALLET_PG, 2000);
+
+        // when: 같은 요청 두 번
+        paymentService.readyPayment(userId, request);
+        Wallet afterFirst = walletRepository.findByUserId(userId).orElseThrow();
+        paymentService.readyPayment(userId, request);
+
+        // then: 잔액은 첫 차감 그대로(이중 차감 없음), 환원도 발생하지 않음
+        Wallet afterSecond = walletRepository.findByUserId(userId).orElseThrow();
+        assertThat(afterSecond.getBalance()).isEqualTo(afterFirst.getBalance());
+        assertThat(afterSecond.getBalance()).isEqualTo(INITIAL_BALANCE - 2000);
+
+        assertThat(walletTransactionRepository
+            .findByTransactionKey("PG_WALLET_RESTORE_" + orderId))
+            .as("동일 요청은 멱등 재사용이므로 환원 트랜잭션이 기록되지 않아야 함")
+            .isEmpty();
+    }
+
+    private InternalOrderInfoResponse orderInfoOf(UUID orderId, UUID userId, int totalAmount) {
+        return new InternalOrderInfoResponse(
+            orderId,
+            userId,
+            "ORD-" + orderId,
+            totalAmount,
+            "PAYMENT_PENDING",
+            LocalDateTime.now().toString(),
+            List.of()
+        );
+    }
+}


### PR DESCRIPTION
## 서비스                                                                                                                                                                                                                                                                                                           
  - [ ] Gateway                                                                                                                                                                                                                                                                                                       
  - [ ] Member                                                                                                                                                                                                                                                                                                        
  - [ ] Event                                                                                                                                                                                                                                                                                                         
  - [ ] Commerce                                                                                                                                                                                                                                                                                                      
  - [x] Payment                                                                                                                                                                                                                                                                                                       
  - [ ] Settlement                                                                                                                                                                                                                                                                                                    
  - [ ] Log                                                                                                                                                                                                                                                                                                           
  - [ ] Admin

  ## 관련 이슈
  - 본 작업은 #569 의 후속 정정 + 추가 시나리오 2건 + dead 코드 정리 2건을 통합 처리한다.
  - Commerce 측 짝(`InternalOrderController.completeOrder/failOrder`, `OrderService/OrderUsecase` 동명 메서드 4개) 정리는 별건 PR (`cleanup/commerce-dead-payment-callbacks`).

  ## 작업 범위 (4커밋)

  | 트랙 | 내용 | 우선순위 | 커밋 |
  |---|---|---|---|
  | A | `readyPayment` 결제수단/금액 변경 시 재시도 허용 + WALLET_PG 예치금 환원 | 🔴 버그 fix | `fix(payment): readyPayment 결제수단/금액 변경 허용 + WALLET_PG 예치금 환원` |
  | B | `CommerceInternalClient.completePayment / failOrder` dead 메서드 제거 | 🟡 cleanup | `cleanup(payment): CommerceInternalClient dead 메서드 2건 제거` |
  | C | `WalletService.processBatchRefund` dead stub 제거 | 🟡 cleanup | `cleanup(payment): WalletService.processBatchRefund dead stub 제거` |
  | D | WALLET_PG 재시도 시 `USE_<orderId>` 키 무효화 — 잔액 차감 누락 방지 + 통합 테스트 3건 | 🔴 버그 fix | `fix(payment): WALLET_PG 재시도 시 USE 키 무효화 — 잔액 차감 누락 방지` |

  ---

  ## 트랙 A — `readyPayment` 재시도 정상화 (#569 후속)

  ### A-1. 버그 설명

  `PaymentServiceImpl.readyPayment` 의 중복 처리 로직이 다음 3가지 시나리오에서 잘못 동작했음.

  | # | 기존 Payment | 새 요청 | 현재 동작 | 기대 동작 |
  |---|---|---|---|---|
  | A1 | READY + WALLET_PG | PG 또는 WALLET 변경 | ALREADY_PROCESSED_PAYMENT 예외 ❌ | 변경 허용 + 기존 wallet 차감분 환원 |
  | A2 | READY + WALLET_PG (walletAmount=2000) | WALLET_PG (walletAmount=3000) | 기존 그대로 반환 — 금액 미반영 ❌ | 기존 환원 + 새 분배 |
  | A3 | READY + PG | WALLET 또는 WALLET_PG 변경 | ALREADY_PROCESSED_PAYMENT 예외 ❌ | 변경 허용 |

  부수 결함 (A1/A2 공통): 기존 WALLET_PG 의 `walletService.deductForWalletPg` 차감분이 환원되지 않아 사용자 잔액 손실 + Wallet/Payment 정합성 깨짐.

  ### A-2. 수정 설계

  - `Payment.resetForRetry(method, amount, walletAmount, pgAmount)` — READY 상태 가드 + status / paymentId / orderId / userId 보존, 결제 정보만 in-place 갱신.
  - `readyPayment` 분기 재구성:
    - 종단 상태(SUCCESS/FAILED/CANCELLED/REFUNDED) → ALREADY_PROCESSED_PAYMENT 유지
    - READY + 동일 method (+ WALLET_PG 시 동일 walletAmount) → 멱등 재사용
    - READY + 다른 method/금액 → 기존 WALLET_PG 였다면 `restoreForWalletPgFail` 로 예치금 환원 후 in-place 갱신
  - 헬퍼: `isSameReadyRequest`, `applyRetry` 추가
  - `readyWalletPgPayment` 시그니처에 `retryTarget` 파라미터 추가

  ---

  ## 트랙 B — `CommerceInternalClient` dead 메서드 제거

  | 메서드 | 호출처 | 비고 |
  |---|---|---|
  | `completePayment(UUID orderId)` | 0건 | `payment.completed` Kafka 일원화로 대체됨 |
  | `failOrder(UUID orderId)` | 0건 | client POST vs controller @PatchMapping 으로 빌드 시점부터 깨진 채 방치 |

  대체 경로: `payment.completed` / `payment.failed` Kafka 일원화 (Commerce `PaymentCompletedConsumer` / `PaymentFailedConsumer`).

  Commerce 측 짝 정리 (별건): `cleanup/commerce-dead-payment-callbacks`
  - `InternalOrderController.completeOrder / failOrder`
  - `OrderService.completeOrder / failOrder`
  - `OrderUsecase.completeOrder / failOrder`

  ---

  ## 트랙 C — `WalletService.processBatchRefund` dead stub 제거

  `WalletServiceImpl.processBatchRefund` 본문의 핵심 로직 5줄(`Refund.createForBatch`, `refundRepository.save`, `payment.refund()`, `restoreBalance`, `outboxService.save`) 전부 주석 처리된 빈 stub. 호출처 0건.

  대체 경로: `WalletEventConsumer.java:30-32` 코멘트가 정답
  > event.force-cancelled / event.sale-stopped 의 fan-out 은 Commerce 서비스 책임이다. Payment 는 Commerce 가 orderId 별로 발행한 refund.requested 를 소비하여 Saga 를 진행한다.

  실제 강제취소 일괄환불 흐름:
  Admin/Seller → RefundServiceImpl.cancelAdminEvent / cancelSellerEvent
      → eventInternalClient.forceCancel (REST)
      → Event 서비스: 상태 전이 + event.force-cancelled Outbox
      → Commerce EventForceCancelledConsumer
      → RefundFanoutService (PAID 주문 fan-out)
      → 각 orderId별 refund.requested
      → Payment RefundSagaConsumer
      → RefundSagaOrchestrator (PG 취소 + Wallet 복구)

  `processBatchRefund(eventId)` 는 이 fan-out 설계 도입 이전 구버전 stub — 새 경로로 대체되며 도태됨.

  동반 정리:
  - `WalletServiceImpl` 의 `InternalEventOrdersResponse` / `PaymentStatus` / `CommerceInternalClient` 미사용 의존성 제거
  - `WalletServiceTest` 의 unused `commerceInternalClient` mock + `InternalEventOrdersResponse` helper 동반 제거

  ---

  ## 트랙 D — WALLET_PG 재시도 시 `USE_<orderId>` 키 무효화

  ### D-1. 버그 설명

  트랙 A 재시도 흐름에서 발견된 후속 정합성 결함:
  - `deductForWalletPg` 멱등 키 = `"USE_" + orderId`
  - 첫 차감 시 `USE_<orderId>` 가 `wallet_transaction` 에 기록됨 (UNIQUE 제약)
  - 재시도 시 `restoreForWalletPgFail` 은 `PG_WALLET_RESTORE_<orderId>` 키로 환원하지만, 두 번째 `deductForWalletPg` 호출 시 `USE_<orderId>` 가 존재해 `existsByTransactionKey` 멱등 skip → **새 차감 누락**
  - 결과: `Payment.walletAmount` 만 새 값으로 갱신되고 지갑은 환원만 반영 → 사용자 잔액 +오차 (시나리오 #5: 2000 → 3000 시 +2000 누락)

  ### D-2. 수정 설계

  - `WalletTransaction.revoke()` — `transactionKey` rename + `softDelete`. 재시도 시 USE 키 점유 해제.
  - `WalletTransactionRepository.findByTransactionKey(String)` 추가 (단건 조회).
  - `restoreForWalletPgFail` 마지막에 기존 `USE_<orderId>` 행을 `revoke()` 로 무효화 → 다음 `deductForWalletPg` 가 정상 진행.
  - 환원 자체의 멱등성은 별도 키 `PG_WALLET_RESTORE_<orderId>` 로 그대로 유지.

  ### D-3. 통합 테스트 — `WalletPgRetryIntegrationTest` (`@SpringBootTest`, 실제 DB)

  | 케이스 | 단언 |
  |---|---|
  | WALLET_PG 2000 → 3000 재시도 (시나리오 #5) | 최종 잔액 = `INITIAL_BALANCE - 3000` (차감 누락 시 -2000으로 남음) |
  | WALLET_PG 2000 → PG 단독 변경 | 잔액 환원만, `USE_<orderId>` 활성 row 없음 |
  | WALLET_PG 2000 동일 재요청 | 멱등 재사용, 잔액 변동 없음 + 환원 트랜잭션 미기록 |

  ---

  ## 검증

  - [x] `./gradlew :payment:compileJava :payment:compileTestJava` — BUILD SUCCESSFUL
  - [x] `./gradlew :payment:test` — BUILD SUCCESSFUL (전체 회귀 + 신규 통합 테스트 3건 포함)
  - [x] `./gradlew test --tests "com.devticket.payment.integration.WalletPgRetryIntegrationTest"` — 3/3 통과
  - [x] `git grep -n "commerceInternalClient\.completePayment\|commerceInternalClient\.failOrder\|processBatchRefund"` → 0건
  - [x] Reflection / SpEL / yaml / @KafkaListener / @Scheduled / @EventListener 동적 dispatch — 모두 0건 확인

  ## 영향 범위 (Payment 모듈 단독)

  | 요소 | 트랙 | 변경 |
  |---|---|---|
  | `Payment.java` | A | ✏️ `resetForRetry` 메서드 추가 |
  | `PaymentServiceImpl.java` | A | ✏️ `readyPayment` / `readyWalletPgPayment` / 헬퍼 |
  | `CommerceInternalClient.java` | B | ➖ `completePayment` / `failOrder` 삭제 |
  | `WalletService.java` | C | ➖ `processBatchRefund` 인터페이스 선언 삭제 |
  | `WalletServiceImpl.java` | C, D | ➖ `processBatchRefund` 구현 + 섹션 코멘트 + unused import/필드<br> ✏️ `restoreForWalletPgFail` 마지막에 USE 키 `revoke` 로직 추가 |
  | `WalletServiceTest.java` | C | ➖ unused mock + helper 동반 정리 |
  | `WalletTransaction.java` | D | ✏️ `revoke()` 메서드 추가 |
  | `WalletTransactionRepository.java` | D | ✏️ `findByTransactionKey` 추가 |
  | `WalletTransactionJpaRepository.java` | D | ✏️ `findByTransactionKey` 추가 |
  | `WalletTransactionRepositoryImpl.java` | D | ✏️ `findByTransactionKey` delegate 추가 |
  | `WalletPgRetryIntegrationTest.java` | D | 🆕 신규 통합 테스트 3건 |
  | Wallet / Refund 외부 / Commerce / Event / Settlement / Log | — | 변경 없음 |
  | DB 스키마 (`payment.payment`, `payment.wallet_transaction`) | — | 변경 없음 |
  | Kafka 토픽 / 페이로드 (`payment.completed/payment.failed` 등) | — | 변경 없음 |
  | Public API (`/api/payments/ready` 등) | — | 시그니처 / 응답 동일 |

  ---

  ## 후속 별건 (본 PR 범위 외)

  | 항목 | 트랙 | 분리 PR |
  |---|---|---|
  | Commerce 측 dead 짝 4개 정리 | 코드 | `cleanup/commerce-dead-payment-callbacks` |
  | ALREADY_PROCESSED_PAYMENT 에러 코드 의미 정정 | 코드 | `chore/payment-error-code-rename` |
  | ServiceOverview.md 미결 표현 정정 | 문서 (P5) | `docs/serviceoverview-fix-batchrefund` |
  | `readyPayment` 추가 단위 테스트 (`resetForRetry` CANCELLED/REFUNDED 거부, `isSameReadyRequest` reqWallet=null, WALLET 단독 멱등 재사용, ReadyPaymentTest 재시도 시나리오 8건) | 테스트 | 후속 1커밋 |

  ## 운영 이슈 별건 (본 PR 무관)
  - 운영 환경 판매자/관리자 이벤트 취소 API 라우팅/배포/URL 불일치: #601