### PR TITLE
[Gateway] fix : prod 라우팅에 판매자/관리자 이벤트 취소 분기 추가

### DIFF
--- a/apigateway/src/main/resources/application-prod.yml
+++ b/apigateway/src/main/resources/application-prod.yml
@@ -12,6 +12,14 @@ spring:
               uri: http://commerce:8083
               predicates:
                 - Path=/api/cart, /api/cart/**, /api/orders, /api/orders/**, /api/tickets, /api/tickets/**, /api/seller/events/{eventId}/participants
+            - id: payment-seller-event-cancel
+              uri: http://payment:8084
+              predicates:
+                - Path=/api/seller/events/{eventId}/cancel
+            - id: payment-admin-event-cancel
+              uri: http://payment:8084
+              predicates:
+                - Path=/api/admin/events/{eventId}/cancel
             - id: event-service
               uri: http://event:8082
               predicates:


### PR DESCRIPTION
## 관련 이슈
- closes #601

## 배경
운영에서 아래 두 호출이 실패 중이었습니다.

| 프론트 호출 | 응답 | 예외 |
|---|---|---|
| `POST /api/seller/events/{id}/cancel` | 404 | `NoResourceFoundException` |
| `POST /api/admin/events/{id}/force-cancel` | 405 | `HttpRequestMethodNotSupportedException` |

Payment 팀 분석 결과, 운영 Gateway 라우팅이 두 path 를 Payment 가 아닌 Event/Admin 서비스로 흘려보내고 있던 것이 원인이었습니다.

## 원인
`application.yml` (local) 에는 커밋 `3447b0e` 에서 `payment-seller-event-cancel`, `payment-admin-event-cancel` 두 룰이 추가되었지만, **`application-prod.yml` 에는 동일 룰이 누락**되어 있었습니다.

그 결과 prod 에서는 다음과 같이 매칭되었습니다.
- `/api/seller/events/{id}/cancel` → `event-service` (`/api/seller/events/**`) → Event:8082 → 핸들러 없음 → 404
- `/api/admin/events/{id}/cancel` → `admin-service` (`/api/admin/**`) → Admin:8087

## 변경 내용
`application-prod.yml` 의 `commerce-service` 와 `event-service` 사이에 두 룰을 삽입합니다. `event-service` / `admin-service` 의 와일드카드보다 위에 위치시켜 우선 매칭되도록 합니다.

```yaml
- id: payment-seller-event-cancel
  uri: http://payment:8084
  predicates:
    - Path=/api/seller/events/{eventId}/cancel
- id: payment-admin-event-cancel
  uri: http://payment:8084
  predicates:
    - Path=/api/admin/events/{eventId}/cancel
```

## 비고
- `force-cancel` 케이스는 Payment 팀 결정에 따라 프론트에서 `cancel` 로 path 를 정정하기로 함. Gateway 측 추가 라우팅은 불필요.
- 기존 `payment-service` 룰(`/api/payments/**`, `/api/refunds/**` 등) 과는 path prefix 가 달라 겹치지 않으며, 별도 룰 등록이 필요한 구조입니다.
- local(`application.yml`) 설정과 일치하도록 정렬했습니다.

## Test plan
- [ ] 운영 배포 후 `POST /api/seller/events/{id}/cancel` 호출 시 Payment 서비스(`SellerRefundController`) 로 라우팅되는지 확인
- [ ] `POST /api/admin/events/{id}/cancel` 호출 시 Payment 서비스(`AdminRefundController`) 로 라우팅되는지 확인
- [ ] 기존 `/api/seller/events/**` (Event), `/api/admin/**` (Admin) 라우팅 회귀 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)