### PR TITLE
[Event] fix: 판매 시작 전 이벤트 DRAFT 상태 처리 및 ON_SALE 자동 전환

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -194,7 +194,7 @@ public class EventService {
         if (request.status() != null) {
             allowedStatuses = List.of(request.status());
         } else if (!isOwnEventRequest) {
-            allowedStatuses = List.of(EventStatus.ON_SALE, EventStatus.SOLD_OUT, EventStatus.SALE_ENDED);
+            allowedStatuses = List.of(EventStatus.DRAFT, EventStatus.ON_SALE, EventStatus.SOLD_OUT, EventStatus.SALE_ENDED);
         }
 
         // ES 검색

--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -53,6 +53,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -270,10 +271,22 @@ public class EventService {
         return SellerEventSummaryResponse.from(event);
     }
 
+    @Scheduled(fixedDelay = 60000)
+    @Transactional
+    public void promoteDraftEvents() {
+        List<Event> events = eventRepository
+            .findAllByStatusAndSaleStartAtBefore(EventStatus.DRAFT, LocalDateTime.now());
+        events.forEach(event -> {
+            event.promoteToOnSale();
+            syncToElasticsearch(event);
+        });
+    }
+
     private boolean isPublicStatus(EventStatus status) {
         return status == EventStatus.ON_SALE ||
             status == EventStatus.SOLD_OUT ||
-            status == EventStatus.SALE_ENDED;
+            status == EventStatus.SALE_ENDED ||
+            status == EventStatus.DRAFT;
     }
 
     @Transactional

--- a/event/src/main/java/com/devticket/event/domain/model/Event.java
+++ b/event/src/main/java/com/devticket/event/domain/model/Event.java
@@ -117,7 +117,7 @@ public class Event extends BaseEntity {
             .totalQuantity(totalQuantity)
             .maxQuantity(maxQuantity)
             .remainingQuantity(totalQuantity)
-            .status(EventStatus.ON_SALE)
+            .status(LocalDateTime.now().isBefore(saleStartAt) ? EventStatus.DRAFT : EventStatus.ON_SALE)
             .category(category)
             .build();
     }

--- a/event/src/main/java/com/devticket/event/domain/model/Event.java
+++ b/event/src/main/java/com/devticket/event/domain/model/Event.java
@@ -196,6 +196,12 @@ public class Event extends BaseEntity {
         }
     }
 
+    public void promoteToOnSale() {
+        if (this.status == EventStatus.DRAFT && !LocalDateTime.now().isBefore(this.saleStartAt)) {
+            this.status = EventStatus.ON_SALE;
+        }
+    }
+
     public boolean isPurchasable(int requestedQuantity) {
         if (requestedQuantity < 1) {
             return false;

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
@@ -76,6 +76,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     @Query("SELECT e FROM Event e WHERE e.eventId IN :eventIds ORDER BY e.eventId ASC")
     List<Event> findAllByEventIdInWithLock(@Param("eventIds") List<UUID> eventIds);
 
+    List<Event> findAllByStatusAndSaleStartAtBefore(EventStatus status, LocalDateTime now);
+
     // 판매자별 이벤트 조회
     List<Event> findBySellerIdOrderByCreatedAtDesc(UUID sellerId);
 

--- a/event/src/test/java/com/devticket/event/application/EventServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventServiceTest.java
@@ -151,7 +151,7 @@ class EventServiceTest {
 
         // then
         assertThat(response.eventId()).isEqualTo(expectedUuid);
-        assertThat(response.status()).isEqualTo(EventStatus.ON_SALE);
+        assertThat(response.status()).isEqualTo(EventStatus.DRAFT);
 
         // save 3회 호출 — (1) 이벤트 본체 + (2) techStackIds + (3) imageUrls (fixture 에 "url1" 포함)
         verify(eventRepository, times(3)).save(argThat(event -> event != null));
@@ -377,29 +377,39 @@ class EventServiceTest {
     }
 
     @Test
-    void 타인_비공개_이벤트_조회시_권한예외_발생() {
+    void DRAFT_상태는_공개_상태이므로_타인도_조회_가능하다() {
         // given
         UUID sellerId = UUID.randomUUID();
-        UUID otherUserId = UUID.randomUUID(); // 다른 사용자 (타인)
+        UUID otherUserId = UUID.randomUUID();
         EventListRequest request = new EventListRequest(null, null, null, sellerId, EventStatus.DRAFT);
         Pageable pageable = PageRequest.of(0, 20);
 
-        // when & then
-        assertThatThrownBy(() -> eventService.getEventList(request, otherUserId, pageable))
-            .isInstanceOf(BusinessException.class)
-            .hasMessageContaining(EventErrorCode.UNAUTHORIZED_SELLER.getMessage());
+        doReturn(mockEmptySearchHits())
+            .when(elasticsearchOperations).search(any(Query.class), eq(EventDocument.class));
+
+        // when
+        EventListResponse response = eventService.getEventList(request, otherUserId, pageable);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.content()).isEmpty();
     }
 
     @Test
-    void 비로그인_사용자_비공개_이벤트_조회시_권한예외_발생() {
+    void DRAFT_상태는_공개_상태이므로_비로그인_사용자도_조회_가능하다() {
         // given
         EventListRequest request = new EventListRequest(null, null, null, null, EventStatus.DRAFT);
         Pageable pageable = PageRequest.of(0, 20);
 
-        // when & then (currentUserId에 null 전달)
-        assertThatThrownBy(() -> eventService.getEventList(request, null, pageable))
-            .isInstanceOf(BusinessException.class)
-            .hasMessageContaining(EventErrorCode.UNAUTHORIZED_SELLER.getMessage());
+        doReturn(mockEmptySearchHits())
+            .when(elasticsearchOperations).search(any(Query.class), eq(EventDocument.class));
+
+        // when
+        EventListResponse response = eventService.getEventList(request, null, pageable);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.content()).isEmpty();
     }
 
     @Test

--- a/event/src/test/java/com/devticket/event/elasticsearch/EventDocumentTest.java
+++ b/event/src/test/java/com/devticket/event/elasticsearch/EventDocumentTest.java
@@ -44,7 +44,7 @@ class EventDocumentTest {
         assertThat(doc.getEventId()).isEqualTo(eventId.toString());
         assertThat(doc.getTitle()).isEqualTo("스프링 부트 밋업");
         assertThat(doc.getCategory()).isEqualTo(EventCategory.MEETUP.name());
-        assertThat(doc.getStatus()).isEqualTo(EventStatus.ON_SALE.name());
+        assertThat(doc.getStatus()).isEqualTo(EventStatus.DRAFT.name());
         assertThat(doc.getSellerId()).isEqualTo(sellerId.toString());
     }
 


### PR DESCRIPTION
## 관련 이슈
- close #606

## 작업 내용
- 이벤트 생성 시 saleStartAt 이전이면 DRAFT, 이후면 ON_SALE로 초기 상태 결정
- 1분마다 saleStartAt이 지난 DRAFT 이벤트를 ON_SALE로 자동 전환하는 스케줄러 추가
- 스케줄러 실행 시 ES 상태도 함께 동기화
- isPublicStatus()에 DRAFT 추가하여 status=DRAFT 명시 필터 요청 허용
- 공개 목록 기본 조회 허용 상태에 DRAFT 추가

## 변경 사항
- `Event.java` — create() 초기 status 결정 로직 수정, promoteToOnSale() 메서드 추가
- `EventRepository.java` — findAllByStatusAndSaleStartAtBefore() 쿼리 추가
- `EventService.java` — promoteDraftEvents() 스케줄러 추가, isPublicStatus()에 DRAFT 추가

## 참고 사항
- 스케줄러는 1분 주기(fixedDelay=60000)로 실행되어 최대 1분 지연 발생 가능
- 구매 불가 처리는 기존 isPurchasable(), deductStock()의 saleStartAt 체크로 보장