### PR TITLE
[Payment] refactor: outbox 직접 발행 + 스케줄러 fallback 전환

### DIFF
--- a/payment/src/main/java/com/devticket/payment/common/config/OutboxAsyncConfig.java
+++ b/payment/src/main/java/com/devticket/payment/common/config/OutboxAsyncConfig.java
@@ -1,0 +1,25 @@
+package com.devticket.payment.common.config;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class OutboxAsyncConfig {
+
+    public static final String OUTBOX_AFTER_COMMIT_EXECUTOR = "outboxAfterCommitExecutor";
+
+    @Bean(name = OUTBOX_AFTER_COMMIT_EXECUTOR, destroyMethod = "shutdown")
+    public Executor outboxAfterCommitExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("outbox-after-commit-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxAfterCommitPublisher.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxAfterCommitPublisher.java
@@ -1,0 +1,98 @@
+package com.devticket.payment.common.outbox;
+
+import com.devticket.payment.common.config.OutboxAsyncConfig;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * 트랜잭션 커밋 직후 Outbox row를 비동기로 Kafka에 발행한다.
+ * 발행 실패는 throw 하지 않고 로그만 남기며, 미처리 row는 OutboxScheduler가 grace period 이후 보완한다.
+ */
+@Slf4j
+@Component
+public class OutboxAfterCommitPublisher {
+
+    private final OutboxRepository outboxRepository;
+    private final OutboxEventProducer outboxEventProducer;
+    private final Executor executor;
+    private final TransactionTemplate markSentTx;
+
+    public OutboxAfterCommitPublisher(
+        OutboxRepository outboxRepository,
+        OutboxEventProducer outboxEventProducer,
+        PlatformTransactionManager transactionManager,
+        @Qualifier(OutboxAsyncConfig.OUTBOX_AFTER_COMMIT_EXECUTOR) Executor executor
+    ) {
+        this.outboxRepository = outboxRepository;
+        this.outboxEventProducer = outboxEventProducer;
+        this.executor = executor;
+        this.markSentTx = new TransactionTemplate(transactionManager);
+        this.markSentTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    }
+
+    /**
+     * 별도 executor 스레드에서 발행을 실행한다.
+     * executor 큐가 가득 차면 그냥 로그만 남기고 통과 — 스케줄러 fallback에 맡긴다.
+     */
+    public void publishAsync(Long outboxId) {
+        try {
+            executor.execute(() -> publish(outboxId));
+        } catch (RejectedExecutionException e) {
+            log.warn("[OutboxAfterCommit] executor reject — outboxId={}, fallback to scheduler",
+                outboxId, e);
+        }
+    }
+
+    private void publish(Long outboxId) {
+        OutboxEventMessage message = loadMessage(outboxId);
+        if (message == null) {
+            return;
+        }
+        try {
+            outboxEventProducer.publish(message);
+        } catch (OutboxPublishException e) {
+            log.warn("[OutboxAfterCommit] Kafka 발행 실패 — outboxId={}, eventType={}, error={}",
+                outboxId, message.eventType(), e.getMessage());
+            return;
+        } catch (RuntimeException e) {
+            log.warn("[OutboxAfterCommit] 예기치 못한 발행 오류 — outboxId={}, error={}",
+                outboxId, e.getMessage(), e);
+            return;
+        }
+        markSentSafely(outboxId);
+    }
+
+    private OutboxEventMessage loadMessage(Long outboxId) {
+        Outbox outbox = outboxRepository.findById(outboxId).orElse(null);
+        if (outbox == null) {
+            log.warn("[OutboxAfterCommit] Outbox row not found — outboxId={}", outboxId);
+            return null;
+        }
+        if (!outbox.isPending()) {
+            return null;
+        }
+        return OutboxEventMessage.from(outbox);
+    }
+
+    private void markSentSafely(Long outboxId) {
+        try {
+            markSentTx.executeWithoutResult(status ->
+                outboxRepository.findById(outboxId).ifPresent(o -> {
+                    if (o.isPending()) {
+                        o.markSent();
+                        outboxRepository.save(o);
+                    }
+                })
+            );
+        } catch (RuntimeException e) {
+            log.warn("[OutboxAfterCommit] markSent 실패 — outboxId={}, fallback to scheduler",
+                outboxId, e);
+        }
+    }
+}

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxRepository.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxRepository.java
@@ -1,6 +1,7 @@
 package com.devticket.payment.common.outbox;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,7 +11,9 @@ public interface OutboxRepository extends JpaRepository<Outbox, Long> {
 
     @Query("SELECT o FROM Outbox o WHERE o.status = :status " +
            "AND (o.nextRetryAt IS NULL OR o.nextRetryAt < :now) " +
+           "AND o.createdAt < :graceCutoff " +
            "ORDER BY o.createdAt ASC LIMIT 50")
     List<Outbox> findPendingToPublish(@Param("status") OutboxStatus status,
-                                      @Param("now") Instant now);
+                                      @Param("now") Instant now,
+                                      @Param("graceCutoff") LocalDateTime graceCutoff);
 }

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxScheduler.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxScheduler.java
@@ -26,7 +26,7 @@ public class OutboxScheduler {
         this.graceSeconds = graceSeconds;
     }
 
-    @Scheduled(fixedDelay = 3000)
+    @Scheduled(fixedDelayString = "${outbox.poll-interval-ms:60000}")
     @SchedulerLock(name = "outbox-scheduler", lockAtMostFor = "5m", lockAtLeastFor = "5s")
     public void publishPendingEvents() {
         Instant now = Instant.now();

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxScheduler.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxScheduler.java
@@ -1,26 +1,39 @@
 package com.devticket.payment.common.outbox;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class OutboxScheduler {
 
     private final OutboxRepository outboxRepository;
     private final OutboxService outboxService;
+    private final long graceSeconds;
+
+    public OutboxScheduler(OutboxRepository outboxRepository,
+                           OutboxService outboxService,
+                           @Value("${outbox.publish-grace-seconds:5}") long graceSeconds) {
+        this.outboxRepository = outboxRepository;
+        this.outboxService = outboxService;
+        this.graceSeconds = graceSeconds;
+    }
 
     @Scheduled(fixedDelay = 3000)
     @SchedulerLock(name = "outbox-scheduler", lockAtMostFor = "5m", lockAtLeastFor = "5s")
     public void publishPendingEvents() {
+        Instant now = Instant.now();
+        LocalDateTime graceCutoff =
+            LocalDateTime.ofInstant(now.minusSeconds(graceSeconds), ZoneId.systemDefault());
         List<Outbox> pendingList =
-            outboxRepository.findPendingToPublish(OutboxStatus.PENDING, Instant.now());
+            outboxRepository.findPendingToPublish(OutboxStatus.PENDING, now, graceCutoff);
 
         if (pendingList.isEmpty()) {
             return;

--- a/payment/src/main/java/com/devticket/payment/common/outbox/OutboxService.java
+++ b/payment/src/main/java/com/devticket/payment/common/outbox/OutboxService.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -15,11 +17,15 @@ public class OutboxService {
 
     private final OutboxRepository outboxRepository;
     private final OutboxEventProducer outboxEventProducer;
+    private final OutboxAfterCommitPublisher outboxAfterCommitPublisher;
     private final ObjectMapper objectMapper;
 
     /**
      * Outbox 이벤트를 저장한다.
      * 반드시 비즈니스 로직과 같은 트랜잭션 안에서 호출해야 한다.
+     *
+     * <p>저장 직후 트랜잭션 커밋이 끝나면 비동기 발행이 시작된다.
+     * 발행 실패 시 row는 PENDING으로 남고 OutboxScheduler가 grace period 이후 보완한다.
      *
      * @param aggregateId  관련 엔티티 식별자 (UUID 문자열)
      * @param partitionKey Kafka 파티션 키 (예: orderId)
@@ -34,12 +40,26 @@ public class OutboxService {
         try {
             String json = objectMapper.writeValueAsString(event);
             Outbox outbox = Outbox.create(aggregateId, partitionKey, eventType, topic, json);
-            return outboxRepository.save(outbox);
+            Outbox saved = outboxRepository.save(outbox);
+            registerAfterCommitPublish(saved.getId());
+            return saved;
         } catch (JsonProcessingException e) {
             log.error("[Outbox] 페이로드 직렬화 실패 — aggregateId={}, eventType={}, topic={}",
                 aggregateId, eventType, topic, e);
             throw new IllegalStateException("Outbox 페이로드 직렬화 실패", e);
         }
+    }
+
+    private void registerAfterCommitPublish(Long outboxId) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                outboxAfterCommitPublisher.publishAsync(outboxId);
+            }
+        });
     }
 
     // @Transactional 없음 — 스케줄러 루프 전체를 트랜잭션으로 묶지 않고 건별 save()로 개별 커밋

--- a/payment/src/main/resources/application-test.yml
+++ b/payment/src/main/resources/application-test.yml
@@ -35,6 +35,10 @@ kafka-producer:
   delivery-timeout-ms: 8000
   send-timeout-ms: 10000
 
+# 테스트는 grace period을 0으로 두어 스케줄러 fallback 경로를 즉시 검증할 수 있도록 한다.
+outbox:
+  publish-grace-seconds: 0
+
 server:
   port: 8085
 

--- a/payment/src/main/resources/application-test.yml
+++ b/payment/src/main/resources/application-test.yml
@@ -36,8 +36,10 @@ kafka-producer:
   send-timeout-ms: 10000
 
 # 테스트는 grace period을 0으로 두어 스케줄러 fallback 경로를 즉시 검증할 수 있도록 한다.
+# 폴링 주기도 짧게 둬 OutboxSchedulerIntegrationTest의 10초 awaitility 안에 픽업되도록 한다.
 outbox:
   publish-grace-seconds: 0
+  poll-interval-ms: 3000
 
 server:
   port: 8085

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -15,6 +15,11 @@ kafka-producer:
   delivery-timeout-ms: 1500
   send-timeout-ms: 2000
 
+# Outbox 직접 발행 우선 + 스케줄러 fallback grace period (초)
+# 직접 발행 경로가 실패한 row만 스케줄러가 잡도록 createdAt < now - graceSeconds 조건에 사용.
+outbox:
+  publish-grace-seconds: 5
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -17,8 +17,10 @@ kafka-producer:
 
 # Outbox 직접 발행 우선 + 스케줄러 fallback grace period (초)
 # 직접 발행 경로가 실패한 row만 스케줄러가 잡도록 createdAt < now - graceSeconds 조건에 사용.
+# poll-interval-ms: 폴링 주기 — fallback 전용이므로 길게 잡는다 (장애 시 최대 지연 ≒ poll + grace).
 outbox:
   publish-grace-seconds: 5
+  poll-interval-ms: 60000
 
 springdoc:
   swagger-ui:

--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxRepositoryTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxRepositoryTest.java
@@ -70,7 +70,7 @@ class OutboxRepositoryTest {
             Outbox saved = saveWithNextRetryAt(null);
 
             List<Outbox> result = outboxRepository.findPendingToPublish(
-                OutboxStatus.PENDING, Instant.now());
+                OutboxStatus.PENDING, Instant.now(), java.time.LocalDateTime.now().plusSeconds(60));
 
             assertThat(result).extracting(Outbox::getId).contains(saved.getId());
         }
@@ -81,7 +81,7 @@ class OutboxRepositoryTest {
             Outbox saved = saveWithNextRetryAt(now.minusSeconds(1));
 
             List<Outbox> result = outboxRepository.findPendingToPublish(
-                OutboxStatus.PENDING, now);
+                OutboxStatus.PENDING, now, java.time.LocalDateTime.now().plusSeconds(60));
 
             assertThat(result).extracting(Outbox::getId).contains(saved.getId());
         }
@@ -93,7 +93,7 @@ class OutboxRepositoryTest {
             Outbox saved = saveWithNextRetryAt(now);
 
             List<Outbox> result = outboxRepository.findPendingToPublish(
-                OutboxStatus.PENDING, now);
+                OutboxStatus.PENDING, now, java.time.LocalDateTime.now().plusSeconds(60));
 
             assertThat(result).extracting(Outbox::getId).doesNotContain(saved.getId());
         }
@@ -104,7 +104,7 @@ class OutboxRepositoryTest {
             Outbox saved = saveWithNextRetryAt(now.plusSeconds(10));
 
             List<Outbox> result = outboxRepository.findPendingToPublish(
-                OutboxStatus.PENDING, now);
+                OutboxStatus.PENDING, now, java.time.LocalDateTime.now().plusSeconds(60));
 
             assertThat(result).extracting(Outbox::getId).doesNotContain(saved.getId());
         }
@@ -116,9 +116,37 @@ class OutboxRepositoryTest {
             outboxRepository.saveAndFlush(outbox);
 
             List<Outbox> result = outboxRepository.findPendingToPublish(
-                OutboxStatus.PENDING, Instant.now());
+                OutboxStatus.PENDING, Instant.now(), java.time.LocalDateTime.now().plusSeconds(60));
 
             assertThat(result).extracting(Outbox::getId).doesNotContain(outbox.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("createdAt < :graceCutoff 경계 조건")
+    class GracePeriod {
+
+        @Test
+        void createdAt이_graceCutoff보다_과거이면_픽업된다() {
+            Outbox saved = saveWithNextRetryAt(null);
+
+            java.time.LocalDateTime graceCutoff = java.time.LocalDateTime.now().plusSeconds(60);
+            List<Outbox> result = outboxRepository.findPendingToPublish(
+                OutboxStatus.PENDING, Instant.now(), graceCutoff);
+
+            assertThat(result).extracting(Outbox::getId).contains(saved.getId());
+        }
+
+        @Test
+        void createdAt이_graceCutoff_이후이면_스킵된다() {
+            Outbox saved = saveWithNextRetryAt(null);
+
+            // graceCutoff가 createdAt보다 과거 → 5초 grace 내 row를 시뮬레이션
+            java.time.LocalDateTime graceCutoff = java.time.LocalDateTime.now().minusSeconds(60);
+            List<Outbox> result = outboxRepository.findPendingToPublish(
+                OutboxStatus.PENDING, Instant.now(), graceCutoff);
+
+            assertThat(result).extracting(Outbox::getId).doesNotContain(saved.getId());
         }
     }
 
@@ -141,7 +169,7 @@ class OutboxRepositoryTest {
             em.flush();
 
             List<Outbox> result = outboxRepository.findPendingToPublish(
-                OutboxStatus.PENDING, Instant.now());
+                OutboxStatus.PENDING, Instant.now(), java.time.LocalDateTime.now().plusSeconds(60));
 
             assertThat(result).hasSize(50);
         }

--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxSchedulerTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxSchedulerTest.java
@@ -8,9 +8,9 @@ import static org.mockito.Mockito.times;
 
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -24,8 +24,12 @@ class OutboxSchedulerTest {
     @Mock
     private OutboxService outboxService;
 
-    @InjectMocks
     private OutboxScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new OutboxScheduler(outboxRepository, outboxService, 5L);
+    }
 
     private Outbox createOutbox(String topic, String partitionKey) {
         return Outbox.create(
@@ -39,7 +43,7 @@ class OutboxSchedulerTest {
 
     @Test
     void PENDING_없으면_processOne_미호출() {
-        given(outboxRepository.findPendingToPublish(any(), any())).willReturn(List.of());
+        given(outboxRepository.findPendingToPublish(any(), any(), any())).willReturn(List.of());
 
         scheduler.publishPendingEvents();
 
@@ -49,7 +53,7 @@ class OutboxSchedulerTest {
     @Test
     void PENDING_단건이면_processOne_1회_호출() {
         Outbox outbox = createOutbox("payment.completed", "order-uuid-001");
-        given(outboxRepository.findPendingToPublish(any(), any())).willReturn(List.of(outbox));
+        given(outboxRepository.findPendingToPublish(any(), any(), any())).willReturn(List.of(outbox));
 
         scheduler.publishPendingEvents();
 
@@ -61,7 +65,7 @@ class OutboxSchedulerTest {
         Outbox o1 = createOutbox("payment.completed", "order-001");
         Outbox o2 = createOutbox("payment.completed", "order-002");
         Outbox o3 = createOutbox("payment.completed", "order-003");
-        given(outboxRepository.findPendingToPublish(any(), any())).willReturn(List.of(o1, o2, o3));
+        given(outboxRepository.findPendingToPublish(any(), any(), any())).willReturn(List.of(o1, o2, o3));
 
         scheduler.publishPendingEvents();
 

--- a/payment/src/test/java/com/devticket/payment/common/outbox/OutboxServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/common/outbox/OutboxServiceTest.java
@@ -28,6 +28,9 @@ class OutboxServiceTest {
     private OutboxEventProducer outboxEventProducer;
 
     @Mock
+    private OutboxAfterCommitPublisher outboxAfterCommitPublisher;
+
+    @Mock
     private ObjectMapper objectMapper;
 
     @InjectMocks

--- a/payment/src/test/java/com/devticket/payment/integration/PaymentKafkaIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/integration/PaymentKafkaIntegrationTest.java
@@ -274,7 +274,9 @@ class PaymentKafkaIntegrationTest {
 
             // Outbox INSERT 확인
             List<Outbox> outboxes = outboxRepository.findPendingToPublish(
-                OutboxStatus.PENDING, java.time.Instant.now().plusSeconds(60));
+                OutboxStatus.PENDING,
+                java.time.Instant.now().plusSeconds(60),
+                java.time.LocalDateTime.now().plusSeconds(60));
             assertThat(outboxes).anyMatch(o ->
                 "payment.completed".equals(o.getEventType())
                 && o.getPartitionKey().equals(orderId.toString())


### PR DESCRIPTION
## 관련 이슈
- close #

## 배경 / 문제

기존 Outbox 발행 경로는 **3초 폴링 스케줄러 단일 채널**.

```
[비즈 TX] → outboxService.save (PENDING) → COMMIT
                                ⏳ (평균 1.5s, 최악 3s+ 폴링 락 대기)
[OutboxScheduler @3s] → findPendingToPublish → publish → markSent
```

문제점
- 정상 케이스에서도 사용자 응답 → 컨슈머 반응 사이에 평균 1.5s, 최악 3s+ 폴링 지연이 박혀 있음.
- 스케줄러가 단일 장애점(SPOF) — ShedLock 인스턴스가 죽으면 전 메시지 발행이 정지.

## 작업 내용

정상 흐름은 **트랜잭션 커밋 직후 직접 비동기 발행**으로 즉시 전송하고, 스케줄러는 **누락/실패 메시지 복구용 안전망**으로만 동작하도록 전환한다. Outbox row는 그대로 같은 TX에 기록 — 패턴의 핵심 보장(원자성)은 유지.

```
[비즈 TX]
 ├─ outboxService.save (PENDING)
 │   └─ TransactionSynchronizationManager.registerSynchronization(afterCommit)
 └─ COMMIT
        │
        ▼ afterCommit (별도 executor 스레드 — 수십 ms)
   OutboxAfterCommitPublisher.publishAsync(outboxId)
     ├─ outboxEventProducer.publish (Kafka 동기, 2s 타임아웃)
     └─ REQUIRES_NEW TX → markSent
```

장애 시 (afterCommit 미실행 / Kafka 일시 장애 / markSent 실패)는 PENDING으로 남아 스케줄러가 grace period 이후 보완. 중복 발행은 기존 `X-Message-Id` 기반 `ProcessedMessage` dedup으로 무해화.

### 컴포넌트별 역할 변화

| 컴포넌트 | 변화 |
|---|---|
| `OutboxService.save()` | ✏️ 저장 후 `afterCommit` 훅 등록 추가 (MANDATORY 트랜잭션 유지) |
| `OutboxAfterCommitPublisher` (신규) | 🆕 트랜잭션 커밋 직후 별도 executor에서 비동기 발행 + `REQUIRES_NEW` TX로 markSent |
| `OutboxAsyncConfig` (신규) | 🆕 `outboxAfterCommitExecutor` 빈 (core=2, max=4, queue=200) |
| `OutboxRepository.findPendingToPublish` | ✏️ `createdAt < :graceCutoff` 조건 추가 (직접 발행 경로가 우선 처리할 시간 확보) |
| `OutboxScheduler` | ✏️ `graceSeconds` 주입 + 폴링 주기 3s → 60s (설정 키화) |
| `OutboxEventProducer`, `Outbox` 엔티티, `processOne()` | 변경 없음 — 재사용 |

### Grace period 설계

- `application.yml`: `outbox.publish-grace-seconds: 5`
- 스케줄러는 `LocalDateTime.now().minusSeconds(5)` 이전에 생성된 row만 픽업 → 직접 발행 경로(수십 ms) 가 정상이면 스케줄러는 항상 빈 결과만 조회.
- 재시도 row(`nextRetryAt` 채워진 케이스)는 이미 충분히 과거에 생성된 row이므로 자연 통과.

### 폴링 주기 완화 (3s → 60s)

직접 발행이 정상이면 스케줄러는 fallback 전용이므로 짧은 주기가 불필요.
- 운영(`application.yml`): `outbox.poll-interval-ms: 60000`
- 테스트(`application-test.yml`): `3000` 유지 (기존 통합 테스트의 10초 awaitility 만족용)
- 장애 시 최대 지연: `poll(60s) + grace(5s) ≒ 65s`

### afterCommit 비동기 처리 세부

- `outboxAfterCommitExecutor` 빈: core=2, max=4, queue=200, `AbortPolicy`
- afterCommit 콜백은 **`outboxId`(Long) 만 전달**. JPA 영속성 컨텍스트는 트랜잭션 종료 후라 안전하게 들고 다닐 수 없으므로 executor 스레드 안에서 새로 조회 후 `OutboxEventMessage.from(outbox)` 변환.
- markSent는 별도 짧은 TX (`TransactionTemplate` REQUIRES_NEW). Spring 자가호출 함정을 피하기 위해 어노테이션이 아닌 템플릿 사용.
- executor reject / Kafka 발행 실패 / markSent 실패는 모두 `throw` 대신 `warn` 로그 — fallback에 위임.

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `payment/.../common/outbox/OutboxAfterCommitPublisher.java` | 🆕 afterCommit 비동기 발행 + `REQUIRES_NEW` markSent |
| `payment/.../common/config/OutboxAsyncConfig.java` | 🆕 `outboxAfterCommitExecutor` 빈 |
| `payment/.../common/outbox/OutboxService.java` | ✏️ `save()` 에 `afterCommit` 훅 등록 |
| `payment/.../common/outbox/OutboxRepository.java` | ✏️ `findPendingToPublish` 에 `graceCutoff (LocalDateTime)` 추가 |
| `payment/.../common/outbox/OutboxScheduler.java` | ✏️ `graceSeconds`/`pollIntervalMs` 주입, `Instant → LocalDateTime` 변환 |
| `payment/.../resources/application.yml` | ✏️ `outbox.publish-grace-seconds: 5`, `outbox.poll-interval-ms: 60000` |
| `payment/.../resources/application-test.yml` | ✏️ `outbox.publish-grace-seconds: 0`, `outbox.poll-interval-ms: 3000` |
| `payment/.../test/.../OutboxRepositoryTest.java` | ✏️ 신규 시그니처 반영 + `GracePeriod` Nested 케이스 2건 추가 |
| `payment/.../test/.../OutboxSchedulerTest.java` | ✏️ 생성자 주입으로 변경 (`@InjectMocks` → `new OutboxScheduler(..., 5L)`), matcher 3-arg 화 |
| `payment/.../test/.../OutboxServiceTest.java` | ✏️ `OutboxAfterCommitPublisher` mock 추가 |
| `payment/.../test/.../PaymentKafkaIntegrationTest.java` | ✏️ 신규 시그니처 반영 (Instant + LocalDateTime) |

호출부(`outboxService.save(...)` 28개 지점)는 **변경 불필요** — 동작이 추가될 뿐 시그니처/시맨틱이 동일.

## 트레이드오프

이 변경은 **부하 총량을 줄이지 않는다** — 줄어드는 건 레이턴시.

| | 기존 | 변경 |
|---|---|---|
| 정상 1건당 트랜잭션 | 2개 (비즈 + 스케줄러 배치) | 3개 (비즈 + afterCommit 발행 + markSent) |
| 정상 1건당 추가 DB 작업 | — | findById 1회 |
| 스레드 풀 | 스케줄러 1개 | 스케줄러 1개 + afterCommit executor (core=2) |
| 폴링 부하 | @3s | @60s (대폭 완화) |
| **메시지 도달 시간** | **평균 1.5s, 최악 3s+** | **수십 ms** |
| SPOF | 스케줄러 노드 단일 | 정상 케이스는 노드 독립 |

폴링 주기 60s 완화로 폴링 자체의 DB 부하는 크게 줄어 전체적으로는 **부하는 비슷**, **레이턴시는 압도적으로 개선**.

## 검증

- [x] `./gradlew :payment:compileJava :payment:compileTestJava` — BUILD SUCCESSFUL
- [x] `./gradlew :payment:test --tests "com.devticket.payment.common.outbox.*"` — BUILD SUCCESSFUL
- [x] `./gradlew :payment:test` 전체 회귀 — 255건 중 254건 통과. 1건 실패는 `RefundPgTicketConcurrencyIntegrationTest` initializationError (Testcontainers Docker 환경 의존, 본 변경과 무관)
- [x] `OutboxRepositoryTest.GracePeriod` 신규 2건 — `createdAt < graceCutoff` 경계 양방향 검증
- [x] `OutboxServicePropagationTest` — 외부 TX 없이 호출 시 `IllegalTransactionStateException` 회귀 없음 (afterCommit 등록은 synchronization 활성 시점에만 동작하도록 가드)
- [ ] CI 통과
- [ ] 로컬 수동 검증 (Kafka 토픽 stopwatch — 이전 1.5~3s → 100ms 미만 기대)

## 영향 범위 (Payment 모듈 단독)

| 요소 | 변경 |
|---|---|
| Outbox row INSERT 시점 / 시그니처 | 동일 |
| Outbox row 상태 전이 (PENDING → SENT/FAILED) | 동일 |
| Kafka 메시지 페이로드 / 헤더 / partitionKey | 동일 |
| Public API / Consumer dedup 동작 | 동일 |
| DB 스키마 (`payment.outbox`) | 동일 |
| Outbox 호출부 28개 지점 | 시그니처 / 시맨틱 동일 — 변경 없음 |

## 후속 (별건 PR)

- commerce / event 모듈 동일 패턴 적용 (`refactor/commerce-outbox-fallback`, `refactor/event-outbox-fallback`)
- `OutboxAfterCommitPublisher` 단위 테스트 보강 (executor reject / Kafka 실패 / markSent 실패 3-갈래)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XZNdyakL4GDtJJKaGExHPQ)_