### PR TITLE
[Admin] fix: 강제취소 internal 호출 method/body 정정 (#601)

### DIFF
--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImpl.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImpl.java
@@ -1,5 +1,6 @@
 package com.devticket.admin.infrastructure.external.client;
 
+import com.devticket.admin.infrastructure.external.dto.req.InternalEventForceCancelRequest;
 import com.devticket.admin.infrastructure.external.dto.res.InternalAdminEventPageResponse;
 import com.devticket.admin.infrastructure.external.dto.res.InternalResponse;
 import com.devticket.admin.presentation.dto.req.AdminEventSearchRequest;
@@ -7,6 +8,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -42,8 +44,10 @@ public class RestClientEventInternalClientImpl implements EventInternalClient {
 
     @Override
     public void forceCancel(UUID eventId) {
-        restClient.post()
+        restClient.patch()
             .uri(eventServerUrl + "/internal/events/{eventId}/force-cancel", eventId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(new InternalEventForceCancelRequest("관리자 강제 취소"))
             .retrieve()
             .toBodilessEntity();
     }

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/req/InternalEventForceCancelRequest.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/dto/req/InternalEventForceCancelRequest.java
@@ -1,0 +1,5 @@
+package com.devticket.admin.infrastructure.external.dto.req;
+
+public record InternalEventForceCancelRequest(String reason) {
+
+}

--- a/admin/src/test/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImplTest.java
+++ b/admin/src/test/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImplTest.java
@@ -1,0 +1,95 @@
+package com.devticket.admin.infrastructure.external.client;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withNoContent;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClient;
+
+@DisplayName("RestClientEventInternalClientImpl")
+class RestClientEventInternalClientImplTest {
+
+    private static final String EVENT_SERVER_URL = "http://event:8082";
+
+    private MockRestServiceServer server;
+    private RestClientEventInternalClientImpl sut;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        RestClient restClient = builder.build();
+        sut = new RestClientEventInternalClientImpl(restClient);
+        ReflectionTestUtils.setField(sut, "eventServerUrl", EVENT_SERVER_URL);
+    }
+
+    @Nested
+    @DisplayName("forceCancel")
+    class ForceCancel {
+
+        @Test
+        @DisplayName("PATCH 메서드와 reason 본문을 포함해 event-svc 의 internal 강제취소 엔드포인트를 호출한다")
+        void shouldCallEventInternalForceCancelWithPatchAndReasonBody() {
+            UUID eventId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+            server.expect(requestTo(EVENT_SERVER_URL + "/internal/events/" + eventId + "/force-cancel"))
+                .andExpect(method(HttpMethod.PATCH))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.reason").value("관리자 강제 취소"))
+                .andRespond(withNoContent());
+
+            sut.forceCancel(eventId);
+
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("event-svc 가 5xx 응답하면 HttpServerErrorException 을 그대로 전파한다")
+        void shouldPropagateHttpServerErrorExceptionWhenEventReturns5xx() {
+            UUID eventId = UUID.randomUUID();
+
+            server.expect(requestTo(EVENT_SERVER_URL + "/internal/events/" + eventId + "/force-cancel"))
+                .andExpect(method(HttpMethod.PATCH))
+                .andRespond(withServerError());
+
+            assertThatThrownBy(() -> sut.forceCancel(eventId))
+                .isInstanceOf(HttpServerErrorException.class);
+
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("event-svc 가 4xx 응답하면 HttpClientErrorException 을 그대로 전파한다")
+        void shouldPropagateHttpClientErrorExceptionWhenEventReturns4xx() {
+            UUID eventId = UUID.randomUUID();
+
+            server.expect(requestTo(EVENT_SERVER_URL + "/internal/events/" + eventId + "/force-cancel"))
+                .andExpect(method(HttpMethod.PATCH))
+                .andRespond(withStatus(HttpStatus.BAD_REQUEST));
+
+            assertThatThrownBy(() -> sut.forceCancel(eventId))
+                .isInstanceOf(HttpClientErrorException.class);
+
+            server.verify();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- admin 의 event-svc internal 호출(\`/internal/events/{eventId}/force-cancel\`)이 **POST + body 없음** 으로 나가고 있었으나, event-svc 매핑은 **PATCH + \`reason\` 필수** 라 운영에서 force-cancel 이 500(COMMON_006) 으로 차단되던 문제 수정.
- \`RestClient\` 호출을 \`post()\` → \`patch()\` 로 변경, \`Content-Type: application/json\` + \`InternalEventForceCancelRequest("관리자 강제 취소")\` body 추가.
- admin 측 \`InternalEventForceCancelRequest\` record 신규 추가.
- 회귀 안전망으로 \`RestClientEventInternalClientImplTest\` 신규 추가 (PATCH/body wire + 4xx/5xx propagate 검증).

## Closes
issue #601 (1차 hotfix — root cause 진단 결과 admin → event 의 internal 호출 불일치였음)

## 진단 요약

운영 라이브 재현 + admin / gateway / event-svc 로그 cross-check 결과:
- FE 결백 (PATCH 로 호출 중)
- gateway 결백 (라우팅 정상, method 차단 없음)
- **admin 의 internal client 가 event-svc 매핑과 method/body 불일치** ← 진짜 원인

상세는 issue #601 댓글의 진단 기록 참조.

## 변경 내역

| 파일 | 변경 |
|---|---|
| \`RestClientEventInternalClientImpl.java:44-51\` | \`post()\` → \`patch()\` + \`Content-Type\` + body 추가, import 보강 |
| \`InternalEventForceCancelRequest.java\` | 신규 — \`record (String reason)\` |
| \`RestClientEventInternalClientImplTest.java\` | 신규 — PATCH/body 검증 + 4xx/5xx propagate 검증 (3 cases) |

\`EventInternalClient\` 인터페이스 시그니처 (\`void forceCancel(UUID eventId)\`) 는 그대로 유지 → 컨트롤러/서비스 영향 없음 → 기존 단위 테스트 그대로 통과.

## Reason 정책

1차로 \`"관리자 강제 취소"\` 하드코딩.

이유:
- 운영 차단을 즉시 해제하는 게 우선
- 사유 입력 UI 는 FE 협의·디자인 필요해 별도 PR 로 분리하는 게 안전
- event-svc 의 reason 은 환불 fan-out 이벤트(\`event.force-cancelled\`)에 실려 commerce/payment 로 전파되므로, 추후 실데이터 사유 입력 도입 가치 있음 (별도 후속 작업으로 추적)

## Test plan

- [x] 신규 단위 테스트 \`RestClientEventInternalClientImplTest\` 3건 통과 (PATCH/body wire + 4xx/5xx propagate)
- [x] 기존 \`AdminEventServiceImplTest.ForceCancel\` 회귀 통과 (인터페이스 미변경)
- [x] 로컬 빌드 \`./gradlew :admin:test\` BUILD SUCCESSFUL
- [ ] 로컬 통합 — admin + event-svc 동시 기동 후 실 PATCH 호출 → 204 응답 + \`event.force-cancelled\` Kafka 발행 확인 (리뷰 시점에 reviewer 가 가능하면 확인)
- [ ] dev 배포 후 어드민 FE 강제취소 클릭 → 204 + saga 정상 진행 확인

## 함께 추적해야 할 별건 (이 PR 범위 아님)

운영 진단 중 같이 발견됐으나 별도 트랙으로 가는 것들:
- \`seller cancel 500\` — gateway 의 prod 라우팅 fix (\`1f51eb1\`) 운영 미배포로 인해 \`/api/seller/events/{id}/cancel\` 이 event-svc 로 잘못 떨어짐. **gateway 측 운영 배포 트리거 필요**.
- event-svc \`GlobalExceptionHandler\` 가 \`HttpRequestMethodNotSupportedException\` 등 4xx 계열도 generic 500 으로 swallow 중 → 호출 측 디버깅 효율 위해 4xx propagate 분기 보강 권장 (낮은 우선순위, 별도 이슈).
- admin 부팅 시 ES \`localhost:9200\` connection refused — admin 의 ES 클라이언트가 K3s 환경에서 \`localhost\` 가 아닌 \`elasticsearch\` service 로 잡혀야 함. 별도 이슈로 분리 추적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)