### PR TITLE
[Event] feat: 이벤트 상태 전환 정책 정비 및 ENDED 상태 추가

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventInternalService.java
+++ b/event/src/main/java/com/devticket/event/application/EventInternalService.java
@@ -242,6 +242,9 @@ public class EventInternalService {
         if (status == EventStatus.CANCELLED || status == EventStatus.FORCE_CANCELLED) {
             return PurchaseUnavailableReason.EVENT_CANCELLED;
         }
+        if (status == EventStatus.ENDED) {
+            return PurchaseUnavailableReason.SALE_ENDED;
+        }
         if (status == EventStatus.SOLD_OUT) {
             return PurchaseUnavailableReason.SOLD_OUT;
         }

--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -273,6 +273,29 @@ public class EventService {
 
     @Scheduled(fixedDelay = 60000)
     @Transactional
+    public void expireSaleEvents() {
+        List<Event> events = eventRepository.findAllByStatusInAndSaleEndAtBefore(
+            List.of(EventStatus.ON_SALE, EventStatus.SOLD_OUT), LocalDateTime.now());
+        events.forEach(event -> {
+            event.expireSale();
+            syncToElasticsearch(event);
+        });
+    }
+
+    @Scheduled(fixedDelay = 60000)
+    @Transactional
+    public void endEvents() {
+        List<Event> events = eventRepository.findAllByStatusInAndEventDateTimeBefore(
+            List.of(EventStatus.ON_SALE, EventStatus.SOLD_OUT, EventStatus.SALE_ENDED),
+            LocalDateTime.now());
+        events.forEach(event -> {
+            event.endEvent();
+            syncToElasticsearch(event);
+        });
+    }
+
+    @Scheduled(fixedDelay = 60000)
+    @Transactional
     public void promoteDraftEvents() {
         List<Event> events = eventRepository
             .findAllByStatusAndSaleStartAtBefore(EventStatus.DRAFT, LocalDateTime.now());

--- a/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
+++ b/event/src/main/java/com/devticket/event/common/config/ElasticsearchIndexInitializer.java
@@ -30,10 +30,10 @@ import org.springframework.stereotype.Component;
 public class ElasticsearchIndexInitializer {
 
     private static final List<EventStatus> ACTIVE_STATUSES =
-        List.of(EventStatus.DRAFT, EventStatus.ON_SALE, EventStatus.SOLD_OUT);
+        List.of(EventStatus.DRAFT, EventStatus.ON_SALE, EventStatus.SOLD_OUT, EventStatus.SALE_ENDED);
 
     private static final List<EventStatus> TERMINATED_STATUSES =
-        List.of(EventStatus.CANCELLED, EventStatus.FORCE_CANCELLED);
+        List.of(EventStatus.ENDED, EventStatus.CANCELLED, EventStatus.FORCE_CANCELLED);
 
     private static final int BATCH_SIZE = 50;
 

--- a/event/src/main/java/com/devticket/event/domain/enums/EventStatus.java
+++ b/event/src/main/java/com/devticket/event/domain/enums/EventStatus.java
@@ -10,6 +10,7 @@ public enum EventStatus {
     ON_SALE("판매 중"),
     SOLD_OUT("매진"),
     SALE_ENDED("판매 종료"),
+    ENDED("행사 종료"),
     CANCELLED("취소됨(판매자)"),
     FORCE_CANCELLED("강제 취소됨(어드민)");
 

--- a/event/src/main/java/com/devticket/event/domain/model/Event.java
+++ b/event/src/main/java/com/devticket/event/domain/model/Event.java
@@ -129,7 +129,8 @@ public class Event extends BaseEntity {
     public boolean canBeCancelled() {
         return this.status != EventStatus.CANCELLED
             && this.status != EventStatus.FORCE_CANCELLED
-            && this.status != EventStatus.SALE_ENDED;
+            && this.status != EventStatus.SALE_ENDED
+            && this.status != EventStatus.ENDED;
     }
 
     public void update(String title, String description, String location,
@@ -187,12 +188,30 @@ public class Event extends BaseEntity {
         if (quantity < 1) {
             throw new BusinessException(EventErrorCode.INVALID_STOCK_QUANTITY);
         }
-        if (this.status == EventStatus.CANCELLED || this.status == EventStatus.FORCE_CANCELLED) {
+        if (this.status == EventStatus.CANCELLED
+                || this.status == EventStatus.FORCE_CANCELLED
+                || this.status == EventStatus.ENDED) {
             throw new BusinessException(EventErrorCode.CANNOT_CHANGE_STATUS);
         }
         this.remainingQuantity = Math.min(this.totalQuantity, this.remainingQuantity + quantity);
         if (this.status == EventStatus.SOLD_OUT && this.remainingQuantity > 0) {
             this.status = EventStatus.ON_SALE;
+        }
+    }
+
+    public void expireSale() {
+        if ((this.status == EventStatus.ON_SALE || this.status == EventStatus.SOLD_OUT)
+                && LocalDateTime.now().isAfter(this.saleEndAt)) {
+            this.status = EventStatus.SALE_ENDED;
+        }
+    }
+
+    public void endEvent() {
+        if ((this.status == EventStatus.ON_SALE
+                || this.status == EventStatus.SOLD_OUT
+                || this.status == EventStatus.SALE_ENDED)
+                && LocalDateTime.now().isAfter(this.eventDateTime)) {
+            this.status = EventStatus.ENDED;
         }
     }
 

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventRepository.java
@@ -78,6 +78,10 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     List<Event> findAllByStatusAndSaleStartAtBefore(EventStatus status, LocalDateTime now);
 
+    List<Event> findAllByStatusInAndSaleEndAtBefore(List<EventStatus> statuses, LocalDateTime now);
+
+    List<Event> findAllByStatusInAndEventDateTimeBefore(List<EventStatus> statuses, LocalDateTime now);
+
     // 판매자별 이벤트 조회
     List<Event> findBySellerIdOrderByCreatedAtDesc(UUID sellerId);
 


### PR DESCRIPTION
## 작업 내용
- EventStatus enum에 ENDED(행사 종료) 상태 추가
- saleEndAt 경과 시 ON_SALE/SOLD_OUT → SALE_ENDED 자동 전환 스케줄러 추가
- eventDateTime 경과 시 ON_SALE/SOLD_OUT/SALE_ENDED → ENDED 자동 전환 스케줄러 추가
- ENDED 이벤트는 공개 목록에서 미노출 (ACTIVE_STATUSES에 미포함)
- ENDED 상태에서 재고 복원 및 취소 차단
- ES 초기화 시 SALE_ENDED를 ACTIVE_STATUSES에 포함, ENDED를 TERMINATED_STATUSES에 포함

## 변경 사항
- `EventStatus.java` — ENDED 추가
- `Event.java` — expireSale(), endEvent() 추가 / canBeCancelled(), restoreStock() 수정
- `EventRepository.java` — 스케줄러용 쿼리 2개 추가
- `EventService.java` — expireSaleEvents(), endEvents() 스케줄러 추가
- `ElasticsearchIndexInitializer.java` — ACTIVE_STATUSES, TERMINATED_STATUSES 수정
- `EventInternalService.java` — resolveReason()에 ENDED 처리 추가

## 참고 사항
DB 스키마 변경 필요 (events_status_check constraint에 ENDED 추가)
```sql
ALTER TABLE event.events DROP CONSTRAINT events_status_check;
ALTER TABLE event.events ADD CONSTRAINT events_status_check
CHECK (status IN ('DRAFT','ON_SALE','SOLD_OUT','SALE_ENDED','ENDED','CANCELLED','FORCE_CANCELLED'));