### PR TITLE
[Commerce] fix: 장바구니 담기 시 1인당 이벤트별 최대 티켓 구매 수량 제한 미적용 버그 수정

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
@@ -21,6 +21,8 @@ import com.devticket.commerce.cart.presentation.dto.res.CartResponse;
 import com.devticket.commerce.common.exception.BusinessException;
 import com.devticket.commerce.common.messaging.event.ActionLogDomainEvent;
 import com.devticket.commerce.common.messaging.event.ActionType;
+import com.devticket.commerce.ticket.domain.enums.TicketStatus;
+import com.devticket.commerce.ticket.domain.repository.TicketRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -39,6 +41,7 @@ public class CartService implements CartUseCase, CartItemUseCase {
 
     private final CartRepository cartRepository;
     private final CartItemRepository cartItemRepository;
+    private final TicketRepository ticketRepository;
     private final EventClient eventClient;
     private final TransactionTemplate transactionTemplate;
     private final ApplicationEventPublisher eventPublisher;
@@ -54,14 +57,23 @@ public class CartService implements CartUseCase, CartItemUseCase {
 
     @Override
     public CartItemResponse save(UUID userId, CartItemRequest request) {
-        //외부 API 호출 및 정책 검증 : Event서비스호출, 상품의 구매가능상태,구매가능 수량 등 검증
-        InternalPurchaseValidationResponse event = eventClient.getValidateEventStatus(request.eventId(), userId,
-            request.quantity());
+        // 이벤트 상태 및 재고 검증 (새 요청 수량 기준 — 재고는 이미 구매분이 차감된 값)
+        InternalPurchaseValidationResponse event = eventClient.getValidateEventStatus(
+            request.eventId(), userId, request.quantity());
         handlePurchaseValidationError(event);
 
-        //DB 작업 : 장바구니 확보와 장바구니에 아이템 담기 로직을 한개 트랜잭션 단위로 묶음.
-        //Cart와 CartItem -> 객체참조x, 연관관계 매핑 없이 식별자참조.
+        // Cart와 CartItem -> 객체참조x, 연관관계 매핑 없이 식별자참조.
         Cart cart = findOrCreateCart(userId);
+
+        // 1인당 구매 한도 검증: 장바구니 수량 + 구매 완료 수량 + 새 요청 수량
+        int existingCartQty = cartItemRepository.findByCartIdAndEventId(cart.getId(), request.eventId())
+            .map(CartItem::getQuantity)
+            .orElse(0);
+        int issuedTicketCount = ticketRepository.countByUserIdAndEventIdAndStatus(
+            userId, request.eventId(), TicketStatus.ISSUED);
+        if (existingCartQty + issuedTicketCount + request.quantity() > event.maxQuantity()) {
+            throw new BusinessException(CartErrorCode.EXCEED_MAX_PURCHASE);
+        }
 
         CartItem cartItem = transactionTemplate.execute(status -> {
             CartItem item = addOrUpdateCartItem(cart.getId(), request);
@@ -71,7 +83,6 @@ public class CartService implements CartUseCase, CartItemUseCase {
             return item;
         });
 
-        //응답데이터 구성
         return CartItemResponse.of(cart, cartItem, event.title(), event.price());
     }
 
@@ -138,6 +149,13 @@ public class CartService implements CartUseCase, CartItemUseCase {
             newQuantity);
         // Event 구매 가능 검증 - 2) Event의 구매 가능 상태 확인
         handlePurchaseValidationError(event);
+
+        // 1인당 구매 한도 검증: 변경 후 장바구니 수량 + 구매 완료 수량 (newQuantity는 이미 기존 장바구니 수량 포함)
+        int issuedTicketCount = ticketRepository.countByUserIdAndEventIdAndStatus(
+            userId, cartItem.getEventId(), TicketStatus.ISSUED);
+        if (newQuantity + issuedTicketCount > event.maxQuantity()) {
+            throw new BusinessException(CartErrorCode.EXCEED_MAX_PURCHASE);
+        }
 
         cartItem.addQuantity(request.quantity());
 

--- a/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
@@ -30,4 +30,6 @@ public interface TicketRepository {
     List<Ticket> findAllByOrderId(Long orderId);
 
     List<Ticket> findAllByOrderIdAndStatus(Long orderId, TicketStatus status);
+
+    int countByUserIdAndEventIdAndStatus(UUID userId, UUID eventId, TicketStatus status);
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketJpaRepository.java
@@ -41,4 +41,6 @@ public interface TicketJpaRepository extends JpaRepository<Ticket, Long> {
     List<Ticket> findAllByOrderIdAndStatus(
         @Param("orderId") Long orderId,
         @Param("status") TicketStatus status);
+
+    int countByUserIdAndEventIdAndStatus(UUID userId, UUID eventId, TicketStatus status);
 }

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
@@ -68,4 +68,9 @@ public class TicketRepositoryAdapter implements TicketRepository {
     public List<Ticket> findAllByOrderIdAndStatus(Long orderId, TicketStatus status) {
         return ticketJpaRepository.findAllByOrderIdAndStatus(orderId, status);
     }
+
+    @Override
+    public int countByUserIdAndEventIdAndStatus(UUID userId, UUID eventId, TicketStatus status) {
+        return ticketJpaRepository.countByUserIdAndEventIdAndStatus(userId, eventId, status);
+    }
 }

--- a/commerce/src/test/java/com/devticket/commerce/cart/application/service/CartServiceTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/cart/application/service/CartServiceTest.java
@@ -1,5 +1,267 @@
 package com.devticket.commerce.cart.application.service;
 
-public class CartServiceTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
+import com.devticket.commerce.cart.domain.exception.CartErrorCode;
+import com.devticket.commerce.cart.domain.model.Cart;
+import com.devticket.commerce.cart.domain.model.CartItem;
+import com.devticket.commerce.cart.domain.repository.CartItemRepository;
+import com.devticket.commerce.cart.domain.repository.CartRepository;
+import com.devticket.commerce.cart.infrastructure.external.client.EventClient;
+import com.devticket.commerce.cart.infrastructure.external.client.dto.InternalPurchaseValidationResponse;
+import com.devticket.commerce.cart.presentation.dto.req.CartItemQuantityRequest;
+import com.devticket.commerce.cart.presentation.dto.req.CartItemRequest;
+import com.devticket.commerce.cart.presentation.dto.res.CartItemQuantityResponse;
+import com.devticket.commerce.cart.presentation.dto.res.CartItemResponse;
+import com.devticket.commerce.common.exception.BusinessException;
+import com.devticket.commerce.ticket.domain.enums.TicketStatus;
+import com.devticket.commerce.ticket.domain.repository.TicketRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class CartServiceTest {
+
+    @Mock private CartRepository cartRepository;
+    @Mock private CartItemRepository cartItemRepository;
+    @Mock private TicketRepository ticketRepository;
+    @Mock private EventClient eventClient;
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    private CartService cartService;
+
+    private static final Long CART_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        PlatformTransactionManager noopTxManager = new PlatformTransactionManager() {
+            @Override public TransactionStatus getTransaction(TransactionDefinition def) { return new SimpleTransactionStatus(); }
+            @Override public void commit(TransactionStatus status) {}
+            @Override public void rollback(TransactionStatus status) {}
+        };
+
+        cartService = new CartService(
+            cartRepository, cartItemRepository, ticketRepository,
+            eventClient, new TransactionTemplate(noopTxManager), eventPublisher
+        );
+    }
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────────────
+
+    private Cart cart(UUID userId) {
+        return Cart.builder().id(CART_ID).userId(userId).build();
+    }
+
+    private CartItem cartItem(UUID eventId, int quantity) {
+        return CartItem.create(CART_ID, eventId, quantity);
+    }
+
+    private InternalPurchaseValidationResponse purchasableEvent(UUID eventId, int maxQuantity) {
+        return new InternalPurchaseValidationResponse(eventId, true, null, maxQuantity, "테스트 이벤트", 10_000);
+    }
+
+    // ── save — 1인당 한도 검증 ─────────────────────────────────────────────────
+
+    @Nested
+    class save_한도_검증 {
+
+        @Test
+        void 장바구니와_구매_이력이_없을_때_한도_이내면_성공한다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            CartItem newItem = cartItem(eventId, 1);
+
+            given(eventClient.getValidateEventStatus(eventId, userId, 1))
+                .willReturn(purchasableEvent(eventId, 2));
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findByCartIdAndEventId(CART_ID, eventId)).willReturn(Optional.empty());
+            given(ticketRepository.countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED)).willReturn(0);
+            given(cartItemRepository.save(any())).willReturn(newItem);
+
+            // 0(cart) + 0(issued) + 1(new) = 1 <= 2
+            CartItemResponse response = cartService.save(userId, new CartItemRequest(eventId, 1));
+
+            assertThat(response).isNotNull();
+        }
+
+        @Test
+        void 장바구니_수량_구매_이력_새_요청_합산이_한도_이내면_성공한다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            CartItem existing = cartItem(eventId, 2);
+
+            given(eventClient.getValidateEventStatus(eventId, userId, 1))
+                .willReturn(purchasableEvent(eventId, 5));
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findByCartIdAndEventId(CART_ID, eventId)).willReturn(Optional.of(existing));
+            given(ticketRepository.countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED)).willReturn(1);
+            given(cartItemRepository.save(any())).willReturn(existing);
+
+            // 2(cart) + 1(issued) + 1(new) = 4 <= 5
+            CartItemResponse response = cartService.save(userId, new CartItemRequest(eventId, 1));
+
+            assertThat(response).isNotNull();
+        }
+
+        @Test
+        void 장바구니_기존_수량과_새_요청_합산이_한도_초과면_예외를_던진다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            CartItem existing = cartItem(eventId, 2);
+
+            given(eventClient.getValidateEventStatus(eventId, userId, 1))
+                .willReturn(purchasableEvent(eventId, 2));
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findByCartIdAndEventId(CART_ID, eventId)).willReturn(Optional.of(existing));
+            given(ticketRepository.countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED)).willReturn(0);
+
+            // 2(cart) + 0(issued) + 1(new) = 3 > 2
+            assertThatThrownBy(() -> cartService.save(userId, new CartItemRequest(eventId, 1)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                    .isEqualTo(CartErrorCode.EXCEED_MAX_PURCHASE));
+        }
+
+        @Test
+        void 구매_완료_수량과_새_요청_합산이_한도_초과면_예외를_던진다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+
+            given(eventClient.getValidateEventStatus(eventId, userId, 1))
+                .willReturn(purchasableEvent(eventId, 2));
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findByCartIdAndEventId(CART_ID, eventId)).willReturn(Optional.empty());
+            given(ticketRepository.countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED)).willReturn(2);
+
+            // 0(cart) + 2(issued) + 1(new) = 3 > 2
+            assertThatThrownBy(() -> cartService.save(userId, new CartItemRequest(eventId, 1)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                    .isEqualTo(CartErrorCode.EXCEED_MAX_PURCHASE));
+        }
+
+        @Test
+        void 각각은_한도_이내여도_세_수량_합산이_초과면_예외를_던진다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            CartItem existing = cartItem(eventId, 1);
+
+            given(eventClient.getValidateEventStatus(eventId, userId, 2))
+                .willReturn(purchasableEvent(eventId, 3));
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findByCartIdAndEventId(CART_ID, eventId)).willReturn(Optional.of(existing));
+            given(ticketRepository.countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED)).willReturn(1);
+
+            // 1(cart) + 1(issued) + 2(new) = 4 > 3
+            assertThatThrownBy(() -> cartService.save(userId, new CartItemRequest(eventId, 2)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                    .isEqualTo(CartErrorCode.EXCEED_MAX_PURCHASE));
+        }
+
+        @Test
+        void 구매_이력_집계는_ISSUED_상태만_조회한다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            CartItem newItem = cartItem(eventId, 1);
+
+            given(eventClient.getValidateEventStatus(eventId, userId, 1))
+                .willReturn(purchasableEvent(eventId, 2));
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findByCartIdAndEventId(CART_ID, eventId)).willReturn(Optional.empty());
+            given(ticketRepository.countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED)).willReturn(0);
+            given(cartItemRepository.save(any())).willReturn(newItem);
+
+            cartService.save(userId, new CartItemRequest(eventId, 1));
+
+            then(ticketRepository).should()
+                .countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED);
+        }
+    }
+
+    // ── updateTicket — 1인당 한도 검증 ──────────────────────────────────────
+
+    @Nested
+    class updateTicket_한도_검증 {
+
+        @Test
+        void 변경_후_장바구니_수량과_구매_이력_합산이_한도_이내면_성공한다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            Long cartItemId = 10L;
+            CartItem existing = cartItem(eventId, 1); // 기존 1개
+
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findById(cartItemId)).willReturn(Optional.of(existing));
+            // newQuantity = 1(기존) + 1(delta) = 2
+            given(eventClient.getValidateEventStatus(eventId, userId, 2))
+                .willReturn(purchasableEvent(eventId, 3));
+            given(ticketRepository.countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED)).willReturn(1);
+            given(cartItemRepository.save(any())).willReturn(existing);
+
+            // 2(newQty) + 1(issued) = 3 <= 3
+            CartItemQuantityResponse response = cartService.updateTicket(
+                userId, cartItemId, new CartItemQuantityRequest(1));
+
+            assertThat(response).isNotNull();
+        }
+
+        @Test
+        void 변경_후_장바구니_수량과_구매_이력_합산이_한도_초과면_예외를_던진다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            Long cartItemId = 10L;
+            CartItem existing = cartItem(eventId, 1); // 기존 1개
+
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findById(cartItemId)).willReturn(Optional.of(existing));
+            // newQuantity = 1(기존) + 1(delta) = 2
+            given(eventClient.getValidateEventStatus(eventId, userId, 2))
+                .willReturn(purchasableEvent(eventId, 2));
+            given(ticketRepository.countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED)).willReturn(1);
+
+            // 2(newQty) + 1(issued) = 3 > 2
+            assertThatThrownBy(() -> cartService.updateTicket(
+                    userId, cartItemId, new CartItemQuantityRequest(1)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                    .isEqualTo(CartErrorCode.EXCEED_MAX_PURCHASE));
+        }
+
+        @Test
+        void 구매_이력_집계는_ISSUED_상태만_조회한다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            Long cartItemId = 10L;
+            CartItem existing = cartItem(eventId, 1);
+
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findById(cartItemId)).willReturn(Optional.of(existing));
+            given(eventClient.getValidateEventStatus(eventId, userId, 2))
+                .willReturn(purchasableEvent(eventId, 3));
+            given(ticketRepository.countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED)).willReturn(0);
+            given(cartItemRepository.save(any())).willReturn(existing);
+
+            cartService.updateTicket(userId, cartItemId, new CartItemQuantityRequest(1));
+
+            then(ticketRepository).should()
+                .countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED);
+        }
+    }
 }


### PR DESCRIPTION

## 배경

`CartService.save()` 및 `updateTicket()`에서 Event 서비스로부터 받은 `maxQuantity`를 기준으로
1인당 구매 한도를 검증하지만, 기존 코드는 **새로 요청하는 수량만** 검증에 사용했습니다.

이로 인해 이미 장바구니에 담겨 있거나 구매 완료된 티켓 수량을 고려하지 않아,
한도를 초과한 수량을 장바구니에 담을 수 있는 버그가 있었습니다.

## 문제 원인

### `save()` — 기존 코드

```java
// 새로 요청하는 수량(request.quantity())만 Event 서비스에 전달
InternalPurchaseValidationResponse event =
    eventClient.getValidateEventStatus(request.eventId(), userId, request.quantity());
handlePurchaseValidationError(event);
```

Event 서비스의 `validatePurchase`는 전달받은 `requestedQuantity`를 `maxQuantity`와 단순 비교합니다.
기존 장바구니 수량이나 구매 이력은 전달되지 않아, 아래와 같은 케이스를 막을 수 없었습니다.

| 상황 | 장바구니 | 구매 이력 | 새 요청 | 합산 | maxQuantity | 결과 |
|---|---|---|---|---|---|---|
| 버그 발생 | 2 | 0 | 1 | 3 | 2 | 통과 (잘못됨) |
| 버그 발생 | 0 | 2 | 1 | 3 | 2 | 통과 (잘못됨) |




## 변경 사항

### `CartService.java`

**`TicketRepository` 의존성 추가**

```java
private final TicketRepository ticketRepository;
```

**`save()` — 1인당 한도 검증 추가**

```java
int existingCartQty = cartItemRepository.findByCartIdAndEventId(cart.getId(), request.eventId())
    .map(CartItem::getQuantity)
    .orElse(0);
int issuedTicketCount = ticketRepository.countByUserIdAndEventIdAndStatus(
    userId, request.eventId(), TicketStatus.ISSUED);
if (existingCartQty + issuedTicketCount + request.quantity() > event.maxQuantity()) {
    throw new BusinessException(CartErrorCode.EXCEED_MAX_PURCHASE);
}
```

**`updateTicket()` — 동일 기준의 한도 검증 추가**

`newQuantity`는 이미 기존 장바구니 수량을 포함하므로 `existingCartQty` 별도 조회 없이 사용합니다.

```java
int issuedTicketCount = ticketRepository.countByUserIdAndEventIdAndStatus(
    userId, cartItem.getEventId(), TicketStatus.ISSUED);
if (newQuantity + issuedTicketCount > event.maxQuantity()) {
    throw new BusinessException(CartErrorCode.EXCEED_MAX_PURCHASE);
}
```

### `TicketRepository.java` / `TicketJpaRepository.java` / `TicketRepositoryAdapter.java`

`userId + eventId + status` 기준 티켓 수 조회 메서드 추가.
`ISSUED` 상태만 집계하여 환불 완료(`REFUNDED`) 및 환불 진행 중(`CANCELLED`) 티켓은 제외합니다.

```java
int countByUserIdAndEventIdAndStatus(UUID userId, UUID eventId, TicketStatus status);
```

### `CartServiceTest.java`

`save`와 `updateTicket`의 1인당 한도 검증 로직에 대한 단위 테스트 추가 (총 9개).

**`save_한도_검증` (6개)**

| 테스트 | 설명 |
|---|---|
| 장바구니·구매 이력 없을 때 한도 이내면 성공 | 정상 경로 |
| 세 수량 합산이 한도 이내면 성공 | 정상 경로 |
| 장바구니 기존 수량 + 새 요청이 한도 초과 | `EXCEED_MAX_PURCHASE` |
| 구매 완료 수량 + 새 요청이 한도 초과 | `EXCEED_MAX_PURCHASE` |
| 각각은 이내여도 합산이 초과 | `EXCEED_MAX_PURCHASE` |
| 구매 이력 집계는 ISSUED 상태만 조회 | 메서드 호출 인자 검증 |

**`updateTicket_한도_검증` (3개)**

| 테스트 | 설명 |
|---|---|
| 변경 후 수량 + 구매 이력이 한도 이내면 성공 | 정상 경로 |
| 변경 후 수량 + 구매 이력이 한도 초과 | `EXCEED_MAX_PURCHASE` |
| 구매 이력 집계는 ISSUED 상태만 조회 | 메서드 호출 인자 검증 |

## 변경 파일 목록

- `src/main/java/.../cart/application/service/CartService.java`
- `src/main/java/.../ticket/domain/repository/TicketRepository.java`
- `src/main/java/.../ticket/infrastructure/persistence/TicketJpaRepository.java`
- `src/main/java/.../ticket/infrastructure/persistence/TicketRepositoryAdapter.java`
- `src/test/java/.../cart/application/service/CartServiceTest.java`
