### PR TITLE
[Event] fix: ENDED 이벤트 재고 복구 시 예외 대신 정책적 스킵 처리

### DIFF
--- a/event/src/main/java/com/devticket/event/application/OrderCancelledService.java
+++ b/event/src/main/java/com/devticket/event/application/OrderCancelledService.java
@@ -55,9 +55,10 @@ public class OrderCancelledService {
                         + ", orderId=" + event.orderId());
             }
 
-            // Step 2. EventStatus 검증 — CANCELLED/FORCE_CANCELLED면 정책적 스킵
+            // Step 2. EventStatus 검증 — CANCELLED/FORCE_CANCELLED/ENDED면 정책적 스킵
             if (targetEvent.getStatus() == EventStatus.CANCELLED
-                || targetEvent.getStatus() == EventStatus.FORCE_CANCELLED) {
+                || targetEvent.getStatus() == EventStatus.FORCE_CANCELLED
+                || targetEvent.getStatus() == EventStatus.ENDED) {
                 log.warn("[정책적 스킵] order.cancelled 재고 복구 생략 — eventId={}, status={}, orderId={}",
                     item.eventId(), targetEvent.getStatus(), event.orderId());
                 continue;

--- a/event/src/main/java/com/devticket/event/application/RefundStockRestoreService.java
+++ b/event/src/main/java/com/devticket/event/application/RefundStockRestoreService.java
@@ -73,7 +73,8 @@ public class RefundStockRestoreService {
             }
 
             if (target.getStatus() == EventStatus.CANCELLED
-                || target.getStatus() == EventStatus.FORCE_CANCELLED) {
+                || target.getStatus() == EventStatus.FORCE_CANCELLED
+                || target.getStatus() == EventStatus.ENDED) {
                 log.warn("[정책적 스킵] refund 재고 복구 — eventId={}, status={}, refundId={}",
                     item.eventId(), target.getStatus(), event.refundId());
                 continue;

--- a/event/src/main/java/com/devticket/event/application/StockRestoreService.java
+++ b/event/src/main/java/com/devticket/event/application/StockRestoreService.java
@@ -59,7 +59,8 @@ public class StockRestoreService {
 
             // Step 2. EventStatus 검증 — CANCELLED/FORCE_CANCELLED면 정책적 스킵
             if (targetEvent.getStatus() == EventStatus.CANCELLED
-                || targetEvent.getStatus() == EventStatus.FORCE_CANCELLED) {
+                || targetEvent.getStatus() == EventStatus.FORCE_CANCELLED
+                || targetEvent.getStatus() == EventStatus.ENDED) {
                 log.warn("[정책적 스킵] payment.failed 재고 복구 생략 — eventId={}, status={}, orderId={}",
                     item.eventId(), targetEvent.getStatus(), event.orderId());
                 continue;


### PR DESCRIPTION
## 관련 이슈
close #619 

## 작업 내용
- `StockRestoreService`, `OrderCancelledService`, `RefundStockRestoreService` 정책적 스킵 조건에 `EventStatus.ENDED` 추가
- `restoreStock()` 도메인 레벨 예외는 유지, 소비자 레이어에서 사전 스킵으로 방어

## 변경 파일
- `StockRestoreService.java`
- `OrderCancelledService.java`
- `RefundStockRestoreService.java`