### PR TITLE
[Commerce] refactor: 결제 완료/실패 http 엔드포인트 및 동기 처리 메서드 제거

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -213,27 +213,6 @@ public class OrderService implements OrderUsecase {
     }
 
     @Override
-    @Transactional
-    public void failOrder(UUID orderId) {
-        Order order = orderRepository.findByOrderId(orderId)
-            .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
-        order.failPayment();
-    }
-
-    @Override
-    @Transactional
-    public void completeOrder(UUID orderId) {
-        //order조회
-        Order order = orderRepository.findByOrderId(orderId)
-            .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
-        //order상태값 변경
-        order.completePayment();
-        //Ticket발행
-        TicketRequest request = new TicketRequest(order.getId());
-        ticketUsecase.createTicket(request);
-    }
-
-    @Override
     public InternalSettlementDataResponse getSettlementData(UUID sellerId, String periodStart, String periodEnd) {
         try {
             log.info("[Settlement Debug] 시작 - sellerId: {}, period: {} ~ {}", sellerId, periodStart, periodEnd);

--- a/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/usecase/OrderUsecase.java
@@ -33,10 +33,6 @@ public interface OrderUsecase {
 
     InternalOrderItemsResponse getOrderListForSettlement(Long id);
 
-    void completeOrder(UUID orderId);
-
-    void failOrder(UUID orderId);
-
     InternalSettlementDataResponse getSettlementData(UUID sellerId, String periodStart, String periodEnd);
 
     InternalOrderItemResponse getOrderItemByTicketId(UUID ticketId);

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/InternalOrderController.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/controller/InternalOrderController.java
@@ -13,9 +13,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -55,20 +53,6 @@ public class InternalOrderController {
 
         InternalSettlementDataResponse response = orderUsecase.getSettlementData(sellerId, periodStart, periodEnd);
         return ResponseEntity.ok(response);
-    }
-
-    //Payment -> Commerce : 결제 완료 후 Order상태 PAID로 변경, Ticket발행
-    @PostMapping("/orders/{orderId}/payment-completed")
-    public ResponseEntity<Void> completeOrder(@PathVariable UUID orderId) {
-        orderUsecase.completeOrder(orderId);
-        return ResponseEntity.ok().build();
-    }
-
-    //Payment -> Commerce : 결제 실패 후 Order상태 FAILED로 변경
-    @PatchMapping("/orders/{orderId}/payment-failed")
-    public ResponseEntity<Void> failOrder(@PathVariable UUID orderId) {
-        orderUsecase.failOrder(orderId);
-        return ResponseEntity.ok().build();
     }
 
     //Ticket -> Commerce : ticketId(PK)로 해당 OrderItem 전체 정보 조회


### PR DESCRIPTION
## 관련 이슈
#603 

## 배경

결제 완료·실패 처리는 Kafka Consumer 기반 비동기 방식으로 전환되어 있습니다.

- `payment.completed` → `PaymentCompletedConsumer` → `OrderService.processPaymentCompleted`
- `payment.failed` → `PaymentCompletedConsumer` → `OrderService.processPaymentFailed`

HTTP 동기 엔드포인트(`POST /payment-completed`, `PATCH /payment-failed`)와 이를 지원하던
서비스 메서드(`completeOrder`, `failOrder`)는 더 이상 호출되지 않는 dead code였습니다.

## 변경 사항

### `InternalOrderController.java`

엔드포인트 2개 제거 및 미사용 import 정리.

| 제거 항목 | 경로 |
|---|---|
| `POST /internal/orders/{orderId}/payment-completed` | `:61-65` |
| `PATCH /internal/orders/{orderId}/payment-failed` | `:68-72` |
| `@PostMapping`, `@PatchMapping` import | |

### `OrderUsecase.java`

인터페이스 메서드 선언 2개 제거.

```java
// 제거
void completeOrder(UUID orderId);
void failOrder(UUID orderId);
```

### `OrderService.java`

서비스 구현 메서드 2개 제거.

```java
// 제거
public void failOrder(UUID orderId) { ... }      // :217-221
public void completeOrder(UUID orderId) { ... }  // :225-234
```

## 변경 파일 목록

- `src/main/java/.../order/presentation/controller/InternalOrderController.java`
- `src/main/java/.../order/application/usecase/OrderUsecase.java`
- `src/main/java/.../order/application/service/OrderService.java`