### PR TITLE
[Settlement] Settlement 배포 develop/settlement -> devticket-settlement

### DIFF
--- a/.github/workflows/ci-settlement.yml
+++ b/.github/workflows/ci-settlement.yml
@@ -32,5 +32,12 @@ jobs:
         env:
           SPRING_PROFILES_ACTIVE: test
 
-      - name: 5. Gradle Build
-        run: cd settlement && ./gradlew build -x test
+      - name: 5. Gradle Build & SpotBugs
+        run: cd settlement && ./gradlew build spotbugsMain -x test
+
+      - name: 6. Upload SpotBugs Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spotbugs-report-settlement
+          path: settlement/build/reports/spotbugs/

--- a/settlement/build.gradle
+++ b/settlement/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '4.0.4'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'com.github.spotbugs' version '6.0.9'
 }
 
 group = 'com.devticket'
@@ -44,4 +45,17 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+spotbugs {
+    ignoreFailures = true
+    effort = 'max'
+    reportLevel = 'medium'
+    excludeFilter = file('spotbugs-exclude.xml')
+}
+
+spotbugsMain {
+    reports {
+        html { required = true }
+    }
 }

--- a/settlement/spotbugs-exclude.xml
+++ b/settlement/spotbugs-exclude.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!-- Lombok 생성 코드 제외 -->
+  <Match>
+    <Class name="~.*\$Builder" />
+  </Match>
+  <!-- 테스트 코드 제외 -->
+  <Match>
+    <Class name="~.*Test" />
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## 주요 변경 내역

### 🐛 SpotBugs 정적 분석 도입 (#599)
- `settlement/build.gradle`에 SpotBugs 플러그인(`com.github.spotbugs:6.0.9`) 추가
  - `effort = 'max'`, `reportLevel = 'medium'` 으로 분석 강도 설정
  - `ignoreFailures = true` — 빌드는 실패시키지 않고 리포트만 생성
  - HTML 리포트 출력 활성화 (`spotbugsMain`)
- `settlement/spotbugs-exclude.xml` 신규 추가
  - Lombok 생성 코드(`*$Builder`) 제외
  - 테스트 코드(`*Test`) 제외

### ⚙️ CI 워크플로우 업데이트
- `.github/workflows/ci-settlement.yml`
  - Gradle 빌드 단계에 `spotbugsMain` 태스크 통합 (`./gradlew build spotbugsMain -x test`)
  - SpotBugs 리포트를 `actions/upload-artifact@v4`로 업로드 (`spotbugs-report-settlement`)
  - `if: always()` 조건으로 빌드 실패 시에도 리포트 확인 가능

### 📝 문서
- `README.md` 팀원 섹션 추가

## 테스트 / 확인 사항
- [ ] CI에서 `spotbugsMain` 태스크 정상 수행 확인
- [ ] SpotBugs 리포트 아티팩트 다운로드 가능 여부 확인
- [ ] 기존 빌드 파이프라인 영향 없음 확인