### PR TITLE
[Commerce] fix: 장바구니 아이템 식별자 PathVariable을 Long → UUID로 통일

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
@@ -130,11 +130,11 @@ public class CartService implements CartUseCase, CartItemUseCase {
     // 장바구니 아이템 갯수 증감
     @Override
     @Transactional
-    public CartItemQuantityResponse updateTicket(UUID userId, Long cartItemId, CartItemQuantityRequest request) {
+    public CartItemQuantityResponse updateTicket(UUID userId, UUID cartItemId, CartItemQuantityRequest request) {
         // 장바구니 가져오기 — Cart 없으면 ITEM_NOT_FOUND (#416)
         Cart cart = getCartOrThrowItemNotFound(userId);
         // 장바구니 아이템 가져오기
-        CartItem cartItem = getCartItemById(cartItemId);
+        CartItem cartItem = getCartItemByCartItemId(cartItemId);
 
         // 변경 후 수량
         int newQuantity = cartItem.getQuantity() + request.quantity();
@@ -175,11 +175,11 @@ public class CartService implements CartUseCase, CartItemUseCase {
     // 장바구니 아이템 삭제
     @Override
     @Transactional
-    public CartItemDeleteResponse deleteTicket(UUID userId, Long cartItemId) {
+    public CartItemDeleteResponse deleteTicket(UUID userId, UUID cartItemId) {
         // 장바구니 가져오기 — Cart 없으면 ITEM_NOT_FOUND (#416)
         Cart cart = getCartOrThrowItemNotFound(userId);
         // 장바구니 아이템 가져오기
-        CartItem cartItem = getCartItemById(cartItemId);
+        CartItem cartItem = getCartItemByCartItemId(cartItemId);
 
         // 장바구니 아이템이 유저의 장바구니 아이템인가 확인 예외
         if (!cartItem.getCartId().equals(cart.getId())) {
@@ -295,9 +295,9 @@ public class CartService implements CartUseCase, CartItemUseCase {
             .orElseThrow(() -> new BusinessException(CartErrorCode.ITEM_NOT_FOUND));
     }
 
-    // 장바구니 아이템 존재 유무 확인
-    private CartItem getCartItemById(Long cartItemId) {
-        return cartItemRepository.findById(cartItemId)
+    // 장바구니 아이템 존재 유무 확인 — 외부 노출 식별자(UUID) 기준 조회
+    private CartItem getCartItemByCartItemId(UUID cartItemId) {
+        return cartItemRepository.findByCartItemId(cartItemId)
             .orElseThrow(() -> new BusinessException(CartErrorCode.ITEM_NOT_FOUND));
     }
 

--- a/commerce/src/main/java/com/devticket/commerce/cart/application/usecase/CartItemUseCase.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/usecase/CartItemUseCase.java
@@ -8,8 +8,8 @@ import java.util.UUID;
 public interface CartItemUseCase {
 
     // 장바구니 티켓 수량 변경
-    CartItemQuantityResponse updateTicket(UUID userId, Long cartItemId, CartItemQuantityRequest request);
+    CartItemQuantityResponse updateTicket(UUID userId, UUID cartItemId, CartItemQuantityRequest request);
 
-    CartItemDeleteResponse deleteTicket(UUID userId, Long cartItemId);
+    CartItemDeleteResponse deleteTicket(UUID userId, UUID cartItemId);
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/domain/repository/CartItemRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/domain/repository/CartItemRepository.java
@@ -26,4 +26,7 @@ public interface CartItemRepository {
 
     // 장바구니 아이템 조회
     Optional<CartItem> findById(Long cartItemId);
+
+    // 외부 식별자(UUID)로 장바구니 아이템 조회
+    Optional<CartItem> findByCartItemId(UUID cartItemId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemJpaRepository.java
@@ -21,4 +21,6 @@ public interface CartItemJpaRepository extends JpaRepository<CartItem, Long> {
     Optional<CartItem> findByCartIdAndEventId(Long cartId, UUID eventId);
 
     List<CartItem> findAllByCartId(Long cartId);
+
+    Optional<CartItem> findByCartItemId(UUID cartItemId);
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/persistence/CartItemRepositoryAdapter.java
@@ -53,4 +53,9 @@ public class CartItemRepositoryAdapter implements CartItemRepository {
     public Optional<CartItem> findById(Long cartItemId) {
         return cartItemJpaRepository.findById(cartItemId);
     }
+
+    @Override
+    public Optional<CartItem> findByCartItemId(UUID cartItemId) {
+        return cartItemJpaRepository.findByCartItemId(cartItemId);
+    }
 }

--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/controller/CartController.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/controller/CartController.java
@@ -61,7 +61,7 @@ public class CartController {
     @Operation(description = "장바구니 아이템 증감")
     public ResponseEntity<CartItemQuantityResponse> updateCartItemQuantity(
         @RequestHeader("X-User-Id") UUID userId,
-        @PathVariable Long cartItemId,
+        @PathVariable UUID cartItemId,
         @RequestBody CartItemQuantityRequest request
     ) {
         CartItemQuantityResponse response = cartItemUseCase.updateTicket(userId, cartItemId, request);
@@ -74,7 +74,7 @@ public class CartController {
     @DeleteMapping("/items/{cartItemId}")
     @Operation(description = "장바구니 아이템 삭제")
     public ResponseEntity<CartItemDeleteResponse> deleteCartItem(
-        @PathVariable Long cartItemId,
+        @PathVariable UUID cartItemId,
         @RequestHeader("X-User-Id") UUID userId
     ) {
         CartItemDeleteResponse response = cartItemUseCase.deleteTicket(userId, cartItemId);

--- a/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemQuantityResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/presentation/dto/res/CartItemQuantityResponse.java
@@ -1,19 +1,20 @@
 package com.devticket.commerce.cart.presentation.dto.res;
 
 import com.devticket.commerce.cart.domain.model.CartItem;
+import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record CartItemQuantityResponse(
 
-    String cartItemId,
+    UUID cartItemId,
     int quantity
 
 ) {
 
     public static CartItemQuantityResponse of(CartItem cartItem) {
         return CartItemQuantityResponse.builder()
-            .cartItemId(String.valueOf(cartItem.getId()))
+            .cartItemId(cartItem.getCartItemId())
             .quantity(cartItem.getQuantity())
             .build();
     }

--- a/commerce/src/test/java/com/devticket/commerce/cart/application/service/CartServiceTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/cart/application/service/CartServiceTest.java
@@ -204,11 +204,11 @@ class CartServiceTest {
         void 변경_후_장바구니_수량과_구매_이력_합산이_한도_이내면_성공한다() {
             UUID userId = UUID.randomUUID();
             UUID eventId = UUID.randomUUID();
-            Long cartItemId = 10L;
             CartItem existing = cartItem(eventId, 1); // 기존 1개
+            UUID cartItemId = existing.getCartItemId();
 
             given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
-            given(cartItemRepository.findById(cartItemId)).willReturn(Optional.of(existing));
+            given(cartItemRepository.findByCartItemId(cartItemId)).willReturn(Optional.of(existing));
             // newQuantity = 1(기존) + 1(delta) = 2
             given(eventClient.getValidateEventStatus(eventId, userId, 2))
                 .willReturn(purchasableEvent(eventId, 3));
@@ -226,11 +226,11 @@ class CartServiceTest {
         void 변경_후_장바구니_수량과_구매_이력_합산이_한도_초과면_예외를_던진다() {
             UUID userId = UUID.randomUUID();
             UUID eventId = UUID.randomUUID();
-            Long cartItemId = 10L;
             CartItem existing = cartItem(eventId, 1); // 기존 1개
+            UUID cartItemId = existing.getCartItemId();
 
             given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
-            given(cartItemRepository.findById(cartItemId)).willReturn(Optional.of(existing));
+            given(cartItemRepository.findByCartItemId(cartItemId)).willReturn(Optional.of(existing));
             // newQuantity = 1(기존) + 1(delta) = 2
             given(eventClient.getValidateEventStatus(eventId, userId, 2))
                 .willReturn(purchasableEvent(eventId, 2));
@@ -248,11 +248,11 @@ class CartServiceTest {
         void 구매_이력_집계는_ISSUED_상태만_조회한다() {
             UUID userId = UUID.randomUUID();
             UUID eventId = UUID.randomUUID();
-            Long cartItemId = 10L;
             CartItem existing = cartItem(eventId, 1);
+            UUID cartItemId = existing.getCartItemId();
 
             given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
-            given(cartItemRepository.findById(cartItemId)).willReturn(Optional.of(existing));
+            given(cartItemRepository.findByCartItemId(cartItemId)).willReturn(Optional.of(existing));
             given(eventClient.getValidateEventStatus(eventId, userId, 2))
                 .willReturn(purchasableEvent(eventId, 3));
             given(ticketRepository.countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED)).willReturn(0);

--- a/commerce/src/test/java/com/devticket/commerce/integration/ActionLogProducerIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/ActionLogProducerIntegrationTest.java
@@ -162,7 +162,7 @@ class ActionLogProducerIntegrationTest {
         stubEventPrice(eventId, 8_000);
 
         // when
-        cartItemUseCase.deleteTicket(userId, item.getId());
+        cartItemUseCase.deleteTicket(userId, item.getCartItemId());
 
         // then
         ActionLogEvent event = awaitSingleActionLog(userId);
@@ -227,7 +227,7 @@ class ActionLogProducerIntegrationTest {
         CartItem item = cartItemRepository.save(CartItem.create(cart.getId(), eventId, 1));
         stubEventPrice(eventId, 3_000);
 
-        cartItemUseCase.updateTicket(userId, item.getId(), new CartItemQuantityRequest(2));
+        cartItemUseCase.updateTicket(userId, item.getCartItemId(), new CartItemQuantityRequest(2));
 
         ActionLogEvent event = awaitSingleActionLog(userId);
         assertThat(event.actionType()).isEqualTo(ActionType.CART_ADD);
@@ -245,7 +245,7 @@ class ActionLogProducerIntegrationTest {
         CartItem item = cartItemRepository.save(CartItem.create(cart.getId(), eventId, 5));
         stubEventPrice(eventId, 4_000);
 
-        cartItemUseCase.updateTicket(userId, item.getId(), new CartItemQuantityRequest(-2));
+        cartItemUseCase.updateTicket(userId, item.getCartItemId(), new CartItemQuantityRequest(-2));
 
         ActionLogEvent event = awaitSingleActionLog(userId);
         assertThat(event.actionType()).isEqualTo(ActionType.CART_REMOVE);
@@ -263,7 +263,7 @@ class ActionLogProducerIntegrationTest {
         CartItem item = cartItemRepository.save(CartItem.create(cart.getId(), eventId, 1));
         stubEventPrice(eventId, 5_000);
 
-        cartItemUseCase.updateTicket(userId, item.getId(), new CartItemQuantityRequest(0));
+        cartItemUseCase.updateTicket(userId, item.getCartItemId(), new CartItemQuantityRequest(0));
 
         assertNoActionLogFor(userId, Duration.ofSeconds(3));
     }
@@ -296,7 +296,7 @@ class ActionLogProducerIntegrationTest {
         given(eventClient.getValidateEventStatus(any(), any(), anyInt()))
                 .willThrow(new RuntimeException("event-service down"));
 
-        cartItemUseCase.deleteTicket(userId, item.getId());
+        cartItemUseCase.deleteTicket(userId, item.getCartItemId());
 
         ActionLogEvent event = awaitSingleActionLog(userId);
         assertThat(event.actionType()).isEqualTo(ActionType.CART_REMOVE);

--- a/commerce/src/test/java/com/devticket/commerce/integration/CartFlowIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/CartFlowIntegrationTest.java
@@ -84,7 +84,7 @@ class CartFlowIntegrationTest {
         UUID userId = UUID.randomUUID();
         CartItemQuantityRequest request = new CartItemQuantityRequest(1);
 
-        assertThatThrownBy(() -> cartItemUseCase.updateTicket(userId, 1L, request))
+        assertThatThrownBy(() -> cartItemUseCase.updateTicket(userId, UUID.randomUUID(), request))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(CartErrorCode.ITEM_NOT_FOUND);
@@ -95,7 +95,7 @@ class CartFlowIntegrationTest {
     void deleteTicketThrowsItemNotFoundForNewUser() {
         UUID userId = UUID.randomUUID();
 
-        assertThatThrownBy(() -> cartItemUseCase.deleteTicket(userId, 1L))
+        assertThatThrownBy(() -> cartItemUseCase.deleteTicket(userId, UUID.randomUUID()))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(CartErrorCode.ITEM_NOT_FOUND);


### PR DESCRIPTION
## 관련 이슈
- close #

## 작업 내용
- 장바구니 아이템 PATCH/DELETE 엔드포인트의 `cartItemId` 타입을 내부 PK(`Long`)에서 외부 식별자(`UUID`)로 통일
- FE가 `GET /api/cart` 응답에 노출된 `cartItemId(UUID)`를 그대로 PATCH/DELETE 호출에 사용해도 동작하도록 정합성 확보

## 변경 사항

### `CartController.java`
- `PATCH /api/cart/items/{cartItemId}` / `DELETE /api/cart/items/{cartItemId}` 의 `@PathVariable` 타입을 `Long → UUID` 로 변경

### `CartItemUseCase.java` / `CartService.java`
- `updateTicket` / `deleteTicket` 시그니처를 `UUID cartItemId` 로 변경
- 조회 메서드를 `findById(Long) → findByCartItemId(UUID)` 로 교체
- private 헬퍼 `getCartItemById(Long)` → `getCartItemByCartItemId(UUID)` 로 리네이밍

### `CartItemRepository.java` / `CartItemJpaRepository.java` / `CartItemRepositoryAdapter.java`
- `Optional<CartItem> findByCartItemId(UUID cartItemId)` 추가 — 도메인 외부 식별자(`cart_item.cart_item_id` UUID 컬럼) 기준 조회

### `CartItemQuantityResponse.java`
- 응답 필드 `cartItemId` 타입을 `String(=Long)` → `UUID` 로 변경
- `CartItemDetail` 응답이 이미 `UUID`로 노출하던 것과 일치 (FE 응답 일관성 확보)

### 테스트
- `CartServiceTest`: `updateTicket_한도_검증` 3개 케이스를 `findByCartItemId` 기반으로 동기화
- `CartFlowIntegrationTest`: `1L` 더미 인자 → `UUID.randomUUID()`
- `ActionLogProducerIntegrationTest`: `item.getId()` → `item.getCartItemId()` (5개 호출 지점)

## 배경

`GET /api/cart` 응답은 `CartItemDetail.cartItemId` 를 UUID로 노출하지만, 같은 자원을 가리키는 `PATCH /api/cart/items/{cartItemId}` / `DELETE /api/cart/items/{cartItemId}` 는 내부 PK(Long)를 받도록 선언되어 있어 식별자 체계가 분리되어 있었음.

FE 가 GET 응답의 UUID를 그대로 PATCH 에 사용하면 다음과 같이 Spring 의 타입 변환에서 실패:

```
MethodArgumentTypeMismatchException: Method parameter 'cartItemId':
Failed to convert value of type 'java.lang.String' to required type 'java.lang.Long';
For input string: "3b465a8c-450d-4b90-82bd-4cd8afa9738a"
```

내부 PK(Long)는 외부에 노출하지 않고 `cart_item.cart_item_id`(UUID 컬럼)을 단일 외부 식별자로 사용하는 방향으로 통일.

## 테스트
- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `./gradlew test --tests CartServiceTest` 그린
- [ ] FE 연동 수동 검증: `PATCH /api/cart/items/{uuid}` 200 응답 확인
- [ ] FE 연동 수동 검증: `DELETE /api/cart/items/{uuid}` 200 응답 확인

## 참고 사항
- 외부 API 의 식별자 표현이 `Long` 문자열 → `UUID` 로 변경되어 응답 호환성에 영향 — FE 도 UUID를 그대로 사용하면 되므로 추가 변환 코드 불필요
- `CartItem.id (Long PK)` 는 그대로 유지, 외부 노출만 UUID 로 통일
- DB 스키마 변경 없음 (`cart_item.cart_item_id` UUID 컬럼은 기존부터 존재, UNIQUE 제약 그대로 활용)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VL2hHEwtmyBtvaS3g8AaEw)_