### PR TITLE
[Commerce] fix : 장바구니 담기기능_판매자본인의 상품 담기 제한

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/application/service/CartService.java
@@ -62,6 +62,10 @@ public class CartService implements CartUseCase, CartItemUseCase {
             request.eventId(), userId, request.quantity());
         handlePurchaseValidationError(event);
 
+        if (userId.equals(event.sellerId())) {
+            throw new BusinessException(CartErrorCode.SELLER_CANNOT_PURCHASE_OWN_EVENT);
+        }
+
         // Cart와 CartItem -> 객체참조x, 연관관계 매핑 없이 식별자참조.
         Cart cart = findOrCreateCart(userId);
 

--- a/commerce/src/main/java/com/devticket/commerce/cart/domain/exception/CartErrorCode.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/domain/exception/CartErrorCode.java
@@ -17,7 +17,8 @@ public enum CartErrorCode implements ErrorCode {
     EVENT_PURCHASE_VALID_UNAVAILABLE(500, "CART_007", "현재 이벤트 정보를 불러올 수 없어 장바구니 담기가 일시적으로 제한됩니다. 잠시 후 다시 시도해주세요."),
     CART_NOT_FOUND(404, "CART_008", "장바구니를 찾을 수 없습니다."),
     CART_ITEM_NOT_FOUND(404, "CART_009", "선택한 티켓이 장바구니에 없습니다."),
-    DUPLICATE_CART_ITEM_ID(400, "CART_010", "중복된 상품이 포함되어 있습니다.");
+    DUPLICATE_CART_ITEM_ID(400, "CART_010", "중복된 상품이 포함되어 있습니다."),
+    SELLER_CANNOT_PURCHASE_OWN_EVENT(403, "CART_011", "본인이 등록한 이벤트는 구매할 수 없습니다.");
     
     private final int status;
     private final String code;

--- a/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/external/client/dto/InternalPurchaseValidationResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/cart/infrastructure/external/client/dto/InternalPurchaseValidationResponse.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 public record InternalPurchaseValidationResponse(
     UUID eventId,
+    UUID sellerId,
     Boolean purchasable,
     @Nullable String reason,
     Integer maxQuantity,

--- a/commerce/src/test/java/com/devticket/commerce/cart/application/service/CartServiceTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/cart/application/service/CartServiceTest.java
@@ -47,6 +47,7 @@ class CartServiceTest {
     private CartService cartService;
 
     private static final Long CART_ID = 1L;
+    private static final UUID SELLER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
     @BeforeEach
     void setUp() {
@@ -73,7 +74,7 @@ class CartServiceTest {
     }
 
     private InternalPurchaseValidationResponse purchasableEvent(UUID eventId, int maxQuantity) {
-        return new InternalPurchaseValidationResponse(eventId, true, null, maxQuantity, "테스트 이벤트", 10_000);
+        return new InternalPurchaseValidationResponse(eventId, SELLER_ID, true, null, maxQuantity, "테스트 이벤트", 10_000);
     }
 
     // ── save — 1인당 한도 검증 ─────────────────────────────────────────────────
@@ -192,6 +193,47 @@ class CartServiceTest {
 
             then(ticketRepository).should()
                 .countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED);
+        }
+    }
+
+    // ── save — 판매자 본인 이벤트 차단 ────────────────────────────────────────
+
+    @Nested
+    class save_판매자_본인_이벤트_차단 {
+
+        @Test
+        void 본인이_등록한_이벤트는_장바구니에_담을_수_없다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+
+            // sellerId == userId (본인 이벤트)
+            given(eventClient.getValidateEventStatus(eventId, userId, 1))
+                .willReturn(new InternalPurchaseValidationResponse(
+                    eventId, userId, true, null, 2, "테스트 이벤트", 10_000));
+
+            assertThatThrownBy(() -> cartService.save(userId, new CartItemRequest(eventId, 1)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                    .isEqualTo(CartErrorCode.SELLER_CANNOT_PURCHASE_OWN_EVENT));
+        }
+
+        @Test
+        void 다른_판매자의_이벤트는_장바구니에_담을_수_있다() {
+            UUID userId = UUID.randomUUID();
+            UUID eventId = UUID.randomUUID();
+            CartItem newItem = cartItem(eventId, 1);
+
+            // sellerId != userId (타인 이벤트)
+            given(eventClient.getValidateEventStatus(eventId, userId, 1))
+                .willReturn(purchasableEvent(eventId, 2));
+            given(cartRepository.findByUserId(userId)).willReturn(Optional.of(cart(userId)));
+            given(cartItemRepository.findByCartIdAndEventId(CART_ID, eventId)).willReturn(Optional.empty());
+            given(ticketRepository.countByUserIdAndEventIdAndStatus(userId, eventId, TicketStatus.ISSUED)).willReturn(0);
+            given(cartItemRepository.save(any())).willReturn(newItem);
+
+            CartItemResponse response = cartService.save(userId, new CartItemRequest(eventId, 1));
+
+            assertThat(response).isNotNull();
         }
     }
 

--- a/commerce/src/test/java/com/devticket/commerce/integration/ActionLogProducerIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/ActionLogProducerIntegrationTest.java
@@ -310,7 +310,7 @@ class ActionLogProducerIntegrationTest {
     private void stubEventPrice(UUID eventId, int price) {
         given(eventClient.getValidateEventStatus(any(), any(), anyInt()))
                 .willReturn(new InternalPurchaseValidationResponse(
-                        eventId, Boolean.TRUE, null, 10, "테스트-이벤트", price));
+                        eventId, UUID.randomUUID(), Boolean.TRUE, null, 10, "테스트-이벤트", price));
     }
 
     private ActionLogEvent awaitSingleActionLog(UUID expectedUserId) throws Exception {

--- a/commerce/src/test/java/com/devticket/commerce/integration/PaymentCompletedCartIntegrationTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/integration/PaymentCompletedCartIntegrationTest.java
@@ -165,7 +165,7 @@ class PaymentCompletedCartIntegrationTest {
 
         given(eventClient.getValidateEventStatus(any(), any(), anyInt()))
                 .willReturn(new InternalPurchaseValidationResponse(
-                        eventId, Boolean.TRUE, null, 10, "이벤트-race", 10_000));
+                        eventId, UUID.randomUUID(), Boolean.TRUE, null, 10, "이벤트-race", 10_000));
 
         int threadCount = 4;
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);


### PR DESCRIPTION
## 관련이슈
#627 

## 작업내용
- CartService : 판매자 본인의 상품인지 검증 후 장바구담기 제한 처리 추가 
- InternalPurchaseValidationResponse : 이벤트구매가능상태 확인 API의 응답데이터에 sellerId추가
- CartErrorCode : "본인이 등록한 이벤트는 구매할 수 없습니다" 에러 코드 추가