### PR TITLE
[Commerce]: 판매자 이벤트 참여자 목록 조회에서 issued된 티켓 소유자만 조회되도록 수정

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/application/service/TicketService.java
@@ -204,7 +204,7 @@ public class TicketService implements TicketUsecase {
             throw new BusinessException(TicketErrorCode.UNAUTHORIZED_EVENT_ACCESS);
         }
 
-        Page<Ticket> ticketPage = ticketRepository.findAllByEventId(eventId, request);
+        Page<Ticket> ticketPage = ticketRepository.findAllByEventIdAndStatus(eventId, TicketStatus.ISSUED, request);
 
         // 유저별 티켓 그룹핑
         Map<UUID, List<Ticket>> ticketsByUser = ticketPage.getContent().stream()

--- a/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/domain/repository/TicketRepository.java
@@ -21,7 +21,7 @@ public interface TicketRepository {
 
     Optional<Ticket> findByTicketId(UUID ticketId);
 
-    Page<Ticket> findAllByEventId(UUID eventId, SellerEventParticipantListRequest request);
+    Page<Ticket> findAllByEventIdAndStatus(UUID eventId, TicketStatus status, SellerEventParticipantListRequest request);
 
     List<Ticket> findAllByEventIdIn(List<UUID> eventIds);
 

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketJpaRepository.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketJpaRepository.java
@@ -17,8 +17,7 @@ public interface TicketJpaRepository extends JpaRepository<Ticket, Long> {
 
     Optional<Ticket> findByTicketId(UUID ticketId);
 
-    @Query
-    Page<Ticket> findAllByEventId(UUID eventId, Pageable pageable);
+    Page<Ticket> findAllByEventIdAndStatus(UUID eventId, TicketStatus status, Pageable pageable);
 
     List<Ticket> findAllByEventIdIn(List<UUID> eventIds);
 

--- a/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
+++ b/commerce/src/main/java/com/devticket/commerce/ticket/infrastructure/persistence/TicketRepositoryAdapter.java
@@ -45,8 +45,8 @@ public class TicketRepositoryAdapter implements TicketRepository {
     }
 
     @Override
-    public Page<Ticket> findAllByEventId(UUID eventId, SellerEventParticipantListRequest request) {
-        return ticketJpaRepository.findAllByEventId(eventId, request.toPageable());
+    public Page<Ticket> findAllByEventIdAndStatus(UUID eventId, TicketStatus status, SellerEventParticipantListRequest request) {
+        return ticketJpaRepository.findAllByEventIdAndStatus(eventId, status, request.toPageable());
     }
 
     @Override


### PR DESCRIPTION
## 관련 이슈
#642 

## 작업내용
이벤트 참여자 목록 조회 API(GET /api/seller/events/{eventId}/participants)에서 티켓을 환불한 구매자가 목록에 그대로 노출되는 버그 수정

## 원인
TicketJpaRepository.findAllByEventId가 TicketStatus 필터 없이 해당 이벤트의 전체 티켓을 조회하고 있었음
TicketStatus는 ISSUED, CANCELLED, REFUNDED 세 가지이며, 환불(REFUNDED) 및 취소(CANCELLED) 상태의 티켓도 참여자로 포함되는 문제가 발생

## 변경 사항
TicketJpaRepository
  - findAllByEventId 제거
  - findAllByEventIdAndStatus(UUID eventId, TicketStatus status, Pageable pageable) 추가

  TicketRepository (domain interface)
  - findAllByEventId → findAllByEventIdAndStatus 시그니처 변경

  TicketRepositoryAdapter
  - 새 메서드로 위임하도록 구현 변경

  TicketService
  - getParticipantList 내에서 TicketStatus.ISSUED를 전달하도록 수정
  - 환불(REFUNDED), 취소(CANCELLED) 상태 티켓은 참여자 목록에서 제외