### PR TITLE
[Event] fix : 구매 가능 여부 검증 API의 응답데이터에 sellerId추가

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventInternalService.java
+++ b/event/src/main/java/com/devticket/event/application/EventInternalService.java
@@ -108,13 +108,13 @@ public class EventInternalService {
 
         if (event.isPurchasable(requestedQuantity)) {
             return InternalPurchaseValidationResponse.success(
-                event.getEventId(), event.getMaxQuantity(), event.getTitle(), event.getPrice()
+                event.getEventId(), event.getSellerId(), event.getMaxQuantity(), event.getTitle(), event.getPrice()
             );
         }
 
         PurchaseUnavailableReason reason = resolveReason(event, requestedQuantity);
         return InternalPurchaseValidationResponse.failure(
-            event.getEventId(), reason, event.getMaxQuantity(), event.getTitle(), event.getPrice()
+            event.getEventId(), event.getSellerId(), reason, event.getMaxQuantity(), event.getTitle(), event.getPrice()
         );
     }
 

--- a/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalPurchaseValidationResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/internal/InternalPurchaseValidationResponse.java
@@ -5,20 +5,21 @@ import java.util.UUID;
 
 public record InternalPurchaseValidationResponse(
     UUID eventId,  // Long id → UUID eventId
+    UUID sellerId,
     boolean purchasable,
     PurchaseUnavailableReason reason,
     Integer maxQuantity,
     String title,
     Integer price
 ) {
-    public static InternalPurchaseValidationResponse success(UUID eventId, Integer maxQuantity, String title, Integer price) {
-        return new InternalPurchaseValidationResponse(eventId, true, null, maxQuantity, title, price);
+    public static InternalPurchaseValidationResponse success(UUID eventId, UUID sellerId, Integer maxQuantity, String title, Integer price) {
+        return new InternalPurchaseValidationResponse(eventId, sellerId, true, null, maxQuantity, title, price);
     }
 
     public static InternalPurchaseValidationResponse failure(
-        UUID eventId, PurchaseUnavailableReason reason,
+        UUID eventId, UUID sellerId, PurchaseUnavailableReason reason,
         Integer maxQuantity, String title, Integer price) {
         Objects.requireNonNull(reason);
-        return new InternalPurchaseValidationResponse(eventId, false, reason, maxQuantity, title, price);
+        return new InternalPurchaseValidationResponse(eventId, sellerId, false, reason, maxQuantity, title, price);
     }
 }


### PR DESCRIPTION
## 관련이슈 
#627 

## 작업내용 
- Commerce에서 호출하는 이벤트구매가능 상태 검증 API의 응답데이터에 sellerId 추가 