### PR TITLE
[Event] fix : eventList category 반환하도록 수정

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventRecommendationService.java
+++ b/event/src/main/java/com/devticket/event/application/EventRecommendationService.java
@@ -1,5 +1,7 @@
 package com.devticket.event.application;
 
+import static java.util.stream.Collectors.toList;
+
 import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.domain.model.Event;
 import com.devticket.event.infrastructure.client.AiClient;
@@ -72,7 +74,7 @@ public class EventRecommendationService {
             })
             .filter(Objects::nonNull)
             .filter(e -> !EXCLUDED_STATUSES.contains(e.getStatus()))
-            .map(EventListContentResponse::from)
+            .map(event -> EventListContentResponse.from(event, 0L))
             .toList();
 
         return new RecommendationResponse(results);

--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -222,13 +222,22 @@ public class EventService {
         Map<UUID, Event> imagesById = eventRepository.findEventImagesByEventIdIn(pageEventIds).stream()
             .collect(Collectors.toMap(Event::getEventId, e -> e));
 
+
+        // viewCount 조회
+        Map<UUID, Long> viewCountById = eventViewRepository.findAllByEventIdIn(pageEventIds).stream()
+            .collect(Collectors.toMap(
+                ev -> ev.getEvent().getEventId(),
+                EventView::getViewCount
+            ));
+
         // ES 결과 순서 유지
         List<EventListContentResponse> content = pageEventIds.stream()
             .map(id -> {
                 Event hydrated = hydratedById.get(id);
                 if (hydrated == null) return null;
                 Event withImages = imagesById.getOrDefault(id, hydrated);
-                return EventListContentResponse.from(withImages);
+                Long viewCount = viewCountById.getOrDefault(id, 0L);
+                return EventListContentResponse.from(withImages, viewCount);
             })
             .filter(Objects::nonNull)
             .toList();

--- a/event/src/main/java/com/devticket/event/infrastructure/persistence/EventViewRepository.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/persistence/EventViewRepository.java
@@ -4,6 +4,7 @@ import com.devticket.event.domain.model.Event;
 import com.devticket.event.domain.model.EventView;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,4 +16,8 @@ public interface EventViewRepository extends JpaRepository<EventView, Long> {
 
     @Query("SELECT ev.event FROM EventView ev WHERE ev.event.status = com.devticket.event.domain.enums.EventStatus.ON_SALE ORDER BY ev.viewCount DESC LIMIT :limit")
     List<Event> findTopByViewCount(@Param("limit") int limit);
+
+
+    @Query("SELECT ev FROM EventView ev WHERE ev.event.eventId IN :eventIds")
+    List<EventView> findAllByEventIdIn(@Param("eventIds") List<UUID> eventIds);
 }

--- a/event/src/main/java/com/devticket/event/presentation/dto/EventListContentResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/EventListContentResponse.java
@@ -22,9 +22,10 @@ public record EventListContentResponse(
     LocalDateTime saleEndAt,
     Integer totalQuantity,
     Integer remainingQuantity,
-    String category
+    String category,
+    Long viewCount
 ) {
-    public static EventListContentResponse from(Event event) {
+    public static EventListContentResponse from(Event event, Long viewCount) {
         String thumbnailUrl = event.getEventImages().stream()
             .min(Comparator.comparingInt(EventImage::getSortOrder))
             .map(EventImage::getImageUrl)
@@ -44,7 +45,8 @@ public record EventListContentResponse(
             event.getSaleEndAt(),
             event.getTotalQuantity(),
             event.getRemainingQuantity(),
-            event.getCategory().name()
+            event.getCategory().name(),
+            viewCount
         );
     }
 

--- a/event/src/main/java/com/devticket/event/presentation/dto/EventListContentResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/EventListContentResponse.java
@@ -21,7 +21,8 @@ public record EventListContentResponse(
     List<String> techStacks,
     LocalDateTime saleEndAt,
     Integer totalQuantity,
-    Integer remainingQuantity
+    Integer remainingQuantity,
+    String category
 ) {
     public static EventListContentResponse from(Event event) {
         String thumbnailUrl = event.getEventImages().stream()
@@ -42,7 +43,8 @@ public record EventListContentResponse(
             techStacks,
             event.getSaleEndAt(),
             event.getTotalQuantity(),
-            event.getRemainingQuantity()
+            event.getRemainingQuantity(),
+            event.getCategory().name()
         );
     }
 

--- a/event/src/main/java/com/devticket/event/presentation/dto/EventListResponse.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/EventListResponse.java
@@ -13,7 +13,7 @@ public record EventListResponse(
 ) {
     public static EventListResponse of(Page<Event> page) {
         List<EventListContentResponse> content = page.getContent().stream()
-            .map(EventListContentResponse::from)
+            .map(event -> EventListContentResponse.from(event, 0L))
             .toList();
 
         return new EventListResponse(


### PR DESCRIPTION
관련 이슈

close #643

작업 내용

EventListContentResponse에 category 필드 추가
GET /events 응답에 category 포함되어 프론트엔드 이벤트 카드 카테고리 정상 노출

변경 사항

EventListContentResponse: category 필드 추가 및 from() 매핑 추가

테스트

 단위 테스트 통과
 통합 테스트 통과 (해당 시)
 Swagger 동작 확인