### PR TITLE
[Event] fix : 검색키워드 없는 경우 이벤트 목록 판매시작일 기준으로 정렬

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -50,6 +50,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -475,7 +476,7 @@ public class EventService {
             doc.put("techStacks", techStackNames);
             doc.put("status", event.getStatus().name());
             doc.put("sellerId", event.getSellerId().toString());
-            // mapping의 date_hour_minute_second 형식에 맞춤 (나노초 제외)
+            doc.put("saleStartAt", event.getSaleStartAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")));
             doc.put("indexedAt", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")));
 
             float[] vector = openAiEmbeddingClient.embed(embeddingText);
@@ -564,6 +565,10 @@ public class EventService {
         queryBuilder
             .withFilter(Query.of(q -> q.bool(filterQuery.build())))
             .withPageable(pageable);
+
+        if (request.keyword() == null || request.keyword().isBlank()) {
+            queryBuilder.withSort(Sort.by(Sort.Direction.DESC, "saleStartAt"));
+        }
 
         return queryBuilder.build();
     }

--- a/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/search/EventDocument.java
@@ -51,11 +51,14 @@ public class EventDocument {
     private List<Float> embedding;
 
     @Field(type = FieldType.Date, format = {}, pattern = "yyyy-MM-dd'T'HH:mm:ss[.SSSSSS]")
+    private LocalDateTime saleStartAt;
+
+    @Field(type = FieldType.Date, format = {}, pattern = "yyyy-MM-dd'T'HH:mm:ss[.SSSSSS]")
     private LocalDateTime indexedAt;
 
     @Builder
     private EventDocument(String id, String eventId, String title, String category, List<String> techStacks,
-        String status, String sellerId, LocalDateTime indexedAt) {
+        String status, String sellerId, LocalDateTime saleStartAt, LocalDateTime indexedAt) {
         this.id = id;
         this.eventId = eventId;
         this.title = title;
@@ -63,6 +66,7 @@ public class EventDocument {
         this.techStacks = techStacks;
         this.status = status;
         this.sellerId = sellerId;
+        this.saleStartAt = saleStartAt;
         this.indexedAt = indexedAt;
     }
 
@@ -79,6 +83,7 @@ public class EventDocument {
             .techStacks(techStackNames)
             .status(event.getStatus().name())
             .sellerId(event.getSellerId().toString())
+            .saleStartAt(event.getSaleStartAt())
             .indexedAt(LocalDateTime.now().truncatedTo(java.time.temporal.ChronoUnit.SECONDS))
             .build();
     }

--- a/event/src/main/resources/elasticsearch/event-mapping.json
+++ b/event/src/main/resources/elasticsearch/event-mapping.json
@@ -24,6 +24,9 @@
       "index": true,
       "similarity": "cosine"
     },
+    "saleStartAt": {
+      "type": "date"
+    },
     "indexedAt": {
       "type": "date"
     }


### PR DESCRIPTION
## 관련이슈
#638 

## 작업내용 
- 현재 키워드가 있을 때는 kNN 벡터 검색 사용, 키워드가 없을 때만 saleStartAt DESC 정렬 적용 
- EventService.syncToElasticsearch() : doc.put("saleStartAt", ...) 추가
- EventService.buildSearchQuery() : 키워드 없을 때 saleStartAt DESC 정렬 추가
- EventDocument : saleStartAt 필드, 빌더 파라미터, from() 매핑 추가 
- event-mapping.json  : saleStartAt: {type: date} 추가   

## 참고사항 
- 운영 환경에서 재색인작업 필요합니다.

