### PR TITLE
[Commerce] feat: 주문 상세 응답에 티켓 정보 추가

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -177,7 +177,15 @@ public class OrderService implements OrderUsecase {
         Map<UUID, String> eventTitles = orderToEventClient.getBulkEventInfo(eventIds).stream()
             .collect(Collectors.toMap(InternalEventInfoResponse::eventId, InternalEventInfoResponse::title));
 
-        return OrderDetailResponse.of(order, orderItems, eventTitles);
+        Map<UUID, List<UUID>> ticketIdsByOrderItemId = ticketRepository
+            .findAllByOrderIdAndStatus(order.getId(), com.devticket.commerce.ticket.domain.enums.TicketStatus.ISSUED)
+            .stream()
+            .collect(Collectors.groupingBy(
+                Ticket::getOrderItemId,
+                Collectors.mapping(Ticket::getTicketId, Collectors.toList())
+            ));
+
+        return OrderDetailResponse.of(order, orderItems, eventTitles, ticketIdsByOrderItemId);
     }
 
     @Override

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/OrderService.java
@@ -33,6 +33,7 @@ import com.devticket.commerce.order.presentation.dto.res.InternalOrderItemRespon
 import com.devticket.commerce.order.presentation.dto.res.InternalOrderItemsResponse;
 import com.devticket.commerce.order.presentation.dto.res.InternalSettlementDataResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderCancelResponse;
+import com.devticket.commerce.order.presentation.dto.res.OrderDetailItemResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderDetailResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderListResponse;
 import com.devticket.commerce.order.presentation.dto.res.OrderResponse;
@@ -177,15 +178,15 @@ public class OrderService implements OrderUsecase {
         Map<UUID, String> eventTitles = orderToEventClient.getBulkEventInfo(eventIds).stream()
             .collect(Collectors.toMap(InternalEventInfoResponse::eventId, InternalEventInfoResponse::title));
 
-        Map<UUID, List<UUID>> ticketIdsByOrderItemId = ticketRepository
-            .findAllByOrderIdAndStatus(order.getId(), com.devticket.commerce.ticket.domain.enums.TicketStatus.ISSUED)
+        Map<UUID, List<OrderDetailItemResponse.TicketSummary>> ticketsByOrderItemId = ticketRepository
+            .findAllByOrderId(order.getId())
             .stream()
             .collect(Collectors.groupingBy(
                 Ticket::getOrderItemId,
-                Collectors.mapping(Ticket::getTicketId, Collectors.toList())
+                Collectors.mapping(OrderDetailItemResponse.TicketSummary::from, Collectors.toList())
             ));
 
-        return OrderDetailResponse.of(order, orderItems, eventTitles, ticketIdsByOrderItemId);
+        return OrderDetailResponse.of(order, orderItems, eventTitles, ticketsByOrderItemId);
     }
 
     @Override

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailItemResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailItemResponse.java
@@ -1,6 +1,7 @@
 package com.devticket.commerce.order.presentation.dto.res;
 
 import com.devticket.commerce.order.domain.model.OrderItem;
+import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 
@@ -9,15 +10,17 @@ public record OrderDetailItemResponse(
     UUID eventId,
     String eventTitle,
     int quantity,
-    int price
+    int price,
+    List<UUID> ticketIds
 ) {
 
-    public static OrderDetailItemResponse of(OrderItem orderItem, String eventTitle) {
+    public static OrderDetailItemResponse of(OrderItem orderItem, String eventTitle, List<UUID> ticketIds) {
         return OrderDetailItemResponse.builder()
             .eventId(orderItem.getEventId())
             .eventTitle(eventTitle)
             .quantity(orderItem.getQuantity())
             .price(orderItem.getPrice())
+            .ticketIds(ticketIds)
             .build();
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailItemResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailItemResponse.java
@@ -1,6 +1,8 @@
 package com.devticket.commerce.order.presentation.dto.res;
 
 import com.devticket.commerce.order.domain.model.OrderItem;
+import com.devticket.commerce.ticket.domain.enums.TicketStatus;
+import com.devticket.commerce.ticket.domain.model.Ticket;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
@@ -11,16 +13,22 @@ public record OrderDetailItemResponse(
     String eventTitle,
     int quantity,
     int price,
-    List<UUID> ticketIds
+    List<TicketSummary> tickets
 ) {
 
-    public static OrderDetailItemResponse of(OrderItem orderItem, String eventTitle, List<UUID> ticketIds) {
+    public record TicketSummary(UUID ticketId, TicketStatus status) {
+        public static TicketSummary from(Ticket ticket) {
+            return new TicketSummary(ticket.getTicketId(), ticket.getStatus());
+        }
+    }
+
+    public static OrderDetailItemResponse of(OrderItem orderItem, String eventTitle, List<TicketSummary> tickets) {
         return OrderDetailItemResponse.builder()
             .eventId(orderItem.getEventId())
             .eventTitle(eventTitle)
             .quantity(orderItem.getQuantity())
             .price(orderItem.getPrice())
-            .ticketIds(ticketIds)
+            .tickets(tickets)
             .build();
     }
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailResponse.java
@@ -22,11 +22,17 @@ public record OrderDetailResponse(
     LocalDateTime createdAt
 ) {
 
-    public static OrderDetailResponse of(Order order, List<OrderItem> orderItems, Map<UUID, String> eventTitles) {
+    public static OrderDetailResponse of(
+        Order order,
+        List<OrderItem> orderItems,
+        Map<UUID, String> eventTitles,
+        Map<UUID, List<UUID>> ticketIdsByOrderItemId
+    ) {
         List<OrderDetailItemResponse> itemResponses = orderItems.stream()
             .map(item -> {
                 String title = eventTitles.getOrDefault(item.getEventId(), "알 수 없는 이벤트");
-                return OrderDetailItemResponse.of(item, title);
+                List<UUID> ticketIds = ticketIdsByOrderItemId.getOrDefault(item.getOrderItemId(), List.of());
+                return OrderDetailItemResponse.of(item, title, ticketIds);
             })
             .toList();
 
@@ -40,4 +46,3 @@ public record OrderDetailResponse(
             .build();
     }
 }
-

--- a/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailResponse.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/presentation/dto/res/OrderDetailResponse.java
@@ -4,6 +4,7 @@ import com.devticket.commerce.common.enums.OrderStatus;
 import com.devticket.commerce.common.enums.PaymentMethod;
 import com.devticket.commerce.order.domain.model.Order;
 import com.devticket.commerce.order.domain.model.OrderItem;
+import com.devticket.commerce.order.presentation.dto.res.OrderDetailItemResponse.TicketSummary;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -26,13 +27,13 @@ public record OrderDetailResponse(
         Order order,
         List<OrderItem> orderItems,
         Map<UUID, String> eventTitles,
-        Map<UUID, List<UUID>> ticketIdsByOrderItemId
+        Map<UUID, List<TicketSummary>> ticketsByOrderItemId
     ) {
         List<OrderDetailItemResponse> itemResponses = orderItems.stream()
             .map(item -> {
                 String title = eventTitles.getOrDefault(item.getEventId(), "알 수 없는 이벤트");
-                List<UUID> ticketIds = ticketIdsByOrderItemId.getOrDefault(item.getOrderItemId(), List.of());
-                return OrderDetailItemResponse.of(item, title, ticketIds);
+                List<TicketSummary> tickets = ticketsByOrderItemId.getOrDefault(item.getOrderItemId(), List.of());
+                return OrderDetailItemResponse.of(item, title, tickets);
             })
             .toList();
 


### PR DESCRIPTION
## 작업 내용

마이페이지에서 주문별 티켓을 보고 바로 환불할 수 있도록, `GET /orders/{orderId}` 응답의 각 `OrderDetailItemResponse` 에 발급된 티켓 정보를 함께 내려준다.

## 변경 사항

- `OrderDetailItemResponse` 에 `tickets: List<TicketSummary>` 필드 추가 (`TicketSummary` = `{ ticketId, status }` 중첩 record).
- `OrderDetailResponse.of()` 시그니처에 `Map<UUID /*orderItemId*/, List<TicketSummary>>` 파라미터 추가 → `orderItemId` 기준으로 매핑.
- `OrderService.getOrderDetail()` 에서 `ticketRepository.findAllByOrderId(order.id)` 로 해당 주문의 티켓 전체를 조회하고, `orderItemId` 기준 그룹핑하여 응답에 주입.
- 기존 필드(`orderId`, `status`, `totalAmount`, `orderItems`, `paymentMethod`, `createdAt`)는 그대로 유지 — 추가만 됨.

## 응답 예시

```json
{
  "orderId": "...",
  "status": "PAID",
  "totalAmount": 30000,
  "orderItems": [{
    "eventId": "...",
    "eventTitle": "...",
    "quantity": 3,
    "price": 10000,
    "tickets": [
      { "ticketId": "...", "status": "ISSUED" },
      { "ticketId": "...", "status": "ISSUED" },
      { "ticketId": "...", "status": "REFUNDED" }
    ]
  }],
  "paymentMethod": "CARD",
  "createdAt": "..."
}
```

## 영향 범위

- `OrderDetailResponse` / `OrderDetailItemResponse` 사용처는 `OrderController.getOrderDetail` 단 한 곳 — `GET /orders/{orderId}` 외 다른 API에는 영향 없음.
- 다른 도메인의 `ticketIds` 필드(`TicketIssueFailedEvent`, `RefundRequestedEvent` 등 Kafka 이벤트 페이로드)는 별개의 DTO이고 시그니처 변경 없음.

## 테스트

- `./gradlew test --tests "com.devticket.commerce.order.*" --tests "com.devticket.commerce.ticket.*"` → 83 tests, 0 failures, 0 errors.

## 비고

- 기존 브랜치 `claude/add-tickets-to-order-gfRZ7` 는 권한 문제로 원격에서 직접 삭제하지 못했습니다. 머지 후 정리 부탁드립니다.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyepLgwTRUruut6jeRtcrK)_