### PR TITLE
[Admin] fix: forceCancel 호출 시 X-User-Id 헤더 전달

### DIFF
--- a/admin/src/main/java/com/devticket/admin/application/service/AdminEventServiceImpl.java
+++ b/admin/src/main/java/com/devticket/admin/application/service/AdminEventServiceImpl.java
@@ -37,7 +37,7 @@ public class AdminEventServiceImpl implements AdminEventService {
     @Override
     @Transactional
     public void forceCancel(UUID adminId, UUID eventId) {
-        eventInternalClient.forceCancel(eventId);
+        eventInternalClient.forceCancel(adminId, eventId);
         adminActionRepository.save(
             AdminActionHistory.builder()
                 .adminId(adminId)

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/EventInternalClient.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/EventInternalClient.java
@@ -6,5 +6,5 @@ import java.util.UUID;
 
 public interface EventInternalClient {
     InternalAdminEventPageResponse getEvents(AdminEventSearchRequest condition);
-    void forceCancel(UUID eventId);
+    void forceCancel(UUID adminId, UUID eventId);
 }

--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImpl.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImpl.java
@@ -43,9 +43,10 @@ public class RestClientEventInternalClientImpl implements EventInternalClient {
     }
 
     @Override
-    public void forceCancel(UUID eventId) {
+    public void forceCancel(UUID adminId, UUID eventId) {
         restClient.patch()
             .uri(eventServerUrl + "/internal/events/{eventId}/force-cancel", eventId)
+            .header("X-User-Id", adminId.toString())
             .contentType(MediaType.APPLICATION_JSON)
             .body(new InternalEventForceCancelRequest("관리자 강제 취소"))
             .retrieve()

--- a/admin/src/test/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImplTest.java
+++ b/admin/src/test/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImplTest.java
@@ -46,18 +46,20 @@ class RestClientEventInternalClientImplTest {
     class ForceCancel {
 
         @Test
-        @DisplayName("PATCH 메서드와 reason 본문을 포함해 event-svc 의 internal 강제취소 엔드포인트를 호출한다")
+        @DisplayName("PATCH 메서드와 reason 본문, X-User-Id 헤더를 포함해 event-svc 의 internal 강제취소 엔드포인트를 호출한다")
         void shouldCallEventInternalForceCancelWithPatchAndReasonBody() {
+            UUID adminId = UUID.fromString("22222222-2222-2222-2222-222222222222");
             UUID eventId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 
             server.expect(requestTo(EVENT_SERVER_URL + "/internal/events/" + eventId + "/force-cancel"))
                 .andExpect(method(HttpMethod.PATCH))
+                .andExpect(header("X-User-Id", adminId.toString()))
                 .andExpect(header("Content-Type", MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.reason").value("관리자 강제 취소"))
                 .andRespond(withNoContent());
 
-            sut.forceCancel(eventId);
+            sut.forceCancel(adminId, eventId);
 
             server.verify();
         }
@@ -65,13 +67,14 @@ class RestClientEventInternalClientImplTest {
         @Test
         @DisplayName("event-svc 가 5xx 응답하면 HttpServerErrorException 을 그대로 전파한다")
         void shouldPropagateHttpServerErrorExceptionWhenEventReturns5xx() {
+            UUID adminId = UUID.randomUUID();
             UUID eventId = UUID.randomUUID();
 
             server.expect(requestTo(EVENT_SERVER_URL + "/internal/events/" + eventId + "/force-cancel"))
                 .andExpect(method(HttpMethod.PATCH))
                 .andRespond(withServerError());
 
-            assertThatThrownBy(() -> sut.forceCancel(eventId))
+            assertThatThrownBy(() -> sut.forceCancel(adminId, eventId))
                 .isInstanceOf(HttpServerErrorException.class);
 
             server.verify();
@@ -80,13 +83,14 @@ class RestClientEventInternalClientImplTest {
         @Test
         @DisplayName("event-svc 가 4xx 응답하면 HttpClientErrorException 을 그대로 전파한다")
         void shouldPropagateHttpClientErrorExceptionWhenEventReturns4xx() {
+            UUID adminId = UUID.randomUUID();
             UUID eventId = UUID.randomUUID();
 
             server.expect(requestTo(EVENT_SERVER_URL + "/internal/events/" + eventId + "/force-cancel"))
                 .andExpect(method(HttpMethod.PATCH))
                 .andRespond(withStatus(HttpStatus.BAD_REQUEST));
 
-            assertThatThrownBy(() -> sut.forceCancel(eventId))
+            assertThatThrownBy(() -> sut.forceCancel(adminId, eventId))
                 .isInstanceOf(HttpClientErrorException.class);
 
             server.verify();

--- a/admin/src/test/java/com/devticket/admin/service/AdminEventServiceImplTest.java
+++ b/admin/src/test/java/com/devticket/admin/service/AdminEventServiceImplTest.java
@@ -113,7 +113,7 @@ class AdminEventServiceImplTest {
             adminEventService.forceCancel(adminId, eventId);
 
             // then
-            then(eventInternalClient).should().forceCancel(eventId);
+            then(eventInternalClient).should().forceCancel(adminId, eventId);
 
             ArgumentCaptor<AdminActionHistory> captor = ArgumentCaptor.forClass(AdminActionHistory.class);
             then(adminActionRepository).should().save(captor.capture());


### PR DESCRIPTION
## 작업 내용

`AdminEventController.cancelEvent` → `AdminEventServiceImpl.forceCancel` → `RestClientEventInternalClientImpl.forceCancel` 흐름에서 admin 이 받은 `X-User-Id`(adminId) 가 event-svc 의 internal 강제취소 엔드포인트로 전달되지 않아 다음과 같은 400 에러가 발생하던 것을 수정합니다.

```
HttpClientErrorException$BadRequest: 400 :
{"code":"COMMON_001","message":"필수 헤더가 누락되었습니다: X-User-Id", ...}
  at RestClientEventInternalClientImpl.forceCancel(...:52)
  at AdminEventServiceImpl.forceCancel(...:40)
  at AdminEventController.cancelEvent(...:45)
```

## 변경 사항

- `EventInternalClient#forceCancel` 시그니처에 `adminId` 파라미터 추가
- `RestClientEventInternalClientImpl#forceCancel` 에서 RestClient 호출 시 `X-User-Id` 헤더로 `adminId` 를 전달
- `AdminEventServiceImpl#forceCancel` 에서 컨트롤러로부터 받은 `adminId` 를 클라이언트로 그대로 전달
- 변경된 시그니처와 헤더 검증을 반영해 단위 테스트(`RestClientEventInternalClientImplTest`, `AdminEventServiceImplTest`) 갱신

## 테스트

- [x] `./gradlew test --tests "...RestClientEventInternalClientImplTest" --tests "...AdminEventServiceImplTest" --rerun-tasks` 통과 (4건)
- [x] MockRestServiceServer 로 `X-User-Id` 헤더가 실제로 전달되는지 검증

## 영향 범위

- admin → event-svc internal `/internal/events/{eventId}/force-cancel` 호출 경로만 변경
- `EventInternalClient` 인터페이스 시그니처 변경 — admin 모듈 내부에서만 사용되므로 다른 서비스 영향 없음

https://claude.ai/code/session_01KF3pNXrBasgAFbY3nCZtbF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KF3pNXrBasgAFbY3nCZtbF)_