### PR TITLE
[Admin] fix: forceCancel X-User-Role 헤더 누락 수정

### DIFF
--- a/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImpl.java
+++ b/admin/src/main/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImpl.java
@@ -47,6 +47,7 @@ public class RestClientEventInternalClientImpl implements EventInternalClient {
         restClient.patch()
             .uri(eventServerUrl + "/internal/events/{eventId}/force-cancel", eventId)
             .header("X-User-Id", adminId.toString())
+            .header("X-User-Role", "ADMIN")
             .contentType(MediaType.APPLICATION_JSON)
             .body(new InternalEventForceCancelRequest("관리자 강제 취소"))
             .retrieve()

--- a/admin/src/test/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImplTest.java
+++ b/admin/src/test/java/com/devticket/admin/infrastructure/external/client/RestClientEventInternalClientImplTest.java
@@ -46,7 +46,7 @@ class RestClientEventInternalClientImplTest {
     class ForceCancel {
 
         @Test
-        @DisplayName("PATCH 메서드와 reason 본문, X-User-Id 헤더를 포함해 event-svc 의 internal 강제취소 엔드포인트를 호출한다")
+        @DisplayName("PATCH 메서드와 reason 본문, X-User-Id·X-User-Role 헤더를 포함해 event-svc 의 internal 강제취소 엔드포인트를 호출한다")
         void shouldCallEventInternalForceCancelWithPatchAndReasonBody() {
             UUID adminId = UUID.fromString("22222222-2222-2222-2222-222222222222");
             UUID eventId = UUID.fromString("11111111-1111-1111-1111-111111111111");
@@ -54,6 +54,7 @@ class RestClientEventInternalClientImplTest {
             server.expect(requestTo(EVENT_SERVER_URL + "/internal/events/" + eventId + "/force-cancel"))
                 .andExpect(method(HttpMethod.PATCH))
                 .andExpect(header("X-User-Id", adminId.toString()))
+                .andExpect(header("X-User-Role", "ADMIN"))
                 .andExpect(header("Content-Type", MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.reason").value("관리자 강제 취소"))


### PR DESCRIPTION
## Summary
- event-svc internal 강제취소 엔드포인트가 `X-User-Role` 헤더를 필수로 요구하여 `400 COMMON_001 ("필수 헤더가 누락되었습니다: X-User-Role")` 응답이 그대로 `HttpClientErrorException$BadRequest`로 전파되던 문제를 수정합니다.
- `RestClientEventInternalClientImpl#forceCancel`에서 기존 `X-User-Id`에 더해 `X-User-Role: ADMIN` 헤더를 함께 전송하도록 변경했습니다.

## 변경 사항
- `admin/src/main/java/.../RestClientEventInternalClientImpl.java`: `forceCancel` 호출 시 `X-User-Role: ADMIN` 헤더 추가
- `admin/src/test/java/.../RestClientEventInternalClientImplTest.java`: `X-User-Role` 헤더 전송 검증 추가

## Test plan
- [x] `RestClientEventInternalClientImplTest` 단위 테스트 통과 확인 (`./gradlew test --tests RestClientEventInternalClientImplTest`)
- [ ] 관리자 강제취소 API 수동 호출 시 event-svc 가 200/204 로 응답하는지 확인


---
_Generated by [Claude Code](https://claude.ai/code/session_01X76rffNHUN4jmxk9cPpmX1)_