### PR TITLE
[Event] fix: 이벤트 썸네일 이미지 최대 업로드 수 제한 및 수정 DTO 유효성 검사 추가

### DIFF
--- a/event/src/main/java/com/devticket/event/domain/constant/EventPolicyConstants.java
+++ b/event/src/main/java/com/devticket/event/domain/constant/EventPolicyConstants.java
@@ -12,7 +12,7 @@ public final class EventPolicyConstants {
     public static final int EVENT_MIN_CAPACITY = 5;
     public static final int EVENT_MAX_CAPACITY = 9_999;
 
-    public static final int EVENT_MAX_IMAGES = 2;
+    public static final int EVENT_MAX_IMAGES = 1;
 
     public static final int EVENT_REGISTER_DEADLINE_DAYS = 3;
     public static final int EVENT_EDIT_DEADLINE_DAYS = 1;

--- a/event/src/main/java/com/devticket/event/presentation/controller/SellerEventController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/SellerEventController.java
@@ -75,7 +75,7 @@ public class SellerEventController {
     public ResponseEntity<SuccessResponse<SellerEventUpdateResponse>> updateEvent(
         @RequestHeader("X-User-Id") UUID sellerId,
         @PathVariable UUID eventId,
-        @RequestBody SellerEventUpdateRequest request) {
+        @Valid @RequestBody SellerEventUpdateRequest request) {
         return ResponseEntity.ok(SuccessResponse.success(eventService.updateEvent(sellerId, eventId, request)));
     }
 }

--- a/event/src/main/java/com/devticket/event/presentation/dto/SellerEventCreateRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/SellerEventCreateRequest.java
@@ -47,6 +47,6 @@ public record SellerEventCreateRequest(
     @Size(min = 1, max = 5, message = "기술 스택은 1개에서 5개까지 선택 가능합니다.")
     List<Long> techStackIds,
 
-    @Size(max = 2, message = "이미지는 최대 2장까지 업로드 가능합니다.")
+    @Size(max = 1, message = "이미지는 최대 1장까지 업로드 가능합니다.")
     List<String> imageUrls
 ) {}

--- a/event/src/main/java/com/devticket/event/presentation/dto/SellerEventUpdateRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/SellerEventUpdateRequest.java
@@ -7,43 +7,32 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record SellerEventUpdateRequest(
-    @NotBlank(message = "이벤트 제목은 필수입니다.")
     @Size(min = 2, max = 50, message = "이벤트 제목은 2자 이상 50자 이하여야 합니다.")
     String title,
 
-    @NotBlank(message = "상세 설명은 필수입니다.")
     String description,
 
-    @NotBlank(message = "장소는 필수입니다.")
     String location,
 
-    @NotNull(message = "행사 일시는 필수입니다.")
     LocalDateTime eventDateTime,
 
-    @NotNull(message = "판매 시작 시각은 필수입니다.")
     LocalDateTime saleStartAt,
 
-    @NotNull(message = "판매 종료 시각은 필수입니다.")
     LocalDateTime saleEndAt,
 
-    @NotNull(message = "가격은 필수입니다.")
     @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
     @Max(value = 9999999, message = "가격은 9,999,999원 이하여야 합니다.")
     Integer price,
 
-    @NotNull(message = "총 수량은 필수입니다.")
     @Min(value = 5, message = "총 수량은 5명 이상이어야 합니다.")
     @Max(value = 9999, message = "총 수량은 9,999명 이하여야 합니다.")
     Integer totalQuantity,
 
-    @NotNull(message = "인당 최대 구매 수량은 필수입니다.")
     @Min(value = 1, message = "인당 최대 구매 수량은 1 이상이어야 합니다.")
     Integer maxQuantity,
 
-    @NotNull(message = "카테고리는 필수입니다.")
     EventCategory category,
 
-    @NotNull(message = "기술 스택은 1개 이상 선택해야 합니다.")
     @Size(min = 1, max = 5, message = "기술 스택은 1개에서 5개까지 선택 가능합니다.")
     List<Long> techStackIds,
 

--- a/event/src/main/java/com/devticket/event/presentation/dto/SellerEventUpdateRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/SellerEventUpdateRequest.java
@@ -2,21 +2,53 @@ package com.devticket.event.presentation.dto;
 
 import com.devticket.event.domain.enums.EventCategory;
 import com.devticket.event.domain.enums.EventStatus;
+import jakarta.validation.constraints.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record SellerEventUpdateRequest(
+    @NotBlank(message = "이벤트 제목은 필수입니다.")
+    @Size(min = 2, max = 50, message = "이벤트 제목은 2자 이상 50자 이하여야 합니다.")
     String title,
+
+    @NotBlank(message = "상세 설명은 필수입니다.")
     String description,
+
+    @NotBlank(message = "장소는 필수입니다.")
     String location,
+
+    @NotNull(message = "행사 일시는 필수입니다.")
     LocalDateTime eventDateTime,
+
+    @NotNull(message = "판매 시작 시각은 필수입니다.")
     LocalDateTime saleStartAt,
+
+    @NotNull(message = "판매 종료 시각은 필수입니다.")
     LocalDateTime saleEndAt,
+
+    @NotNull(message = "가격은 필수입니다.")
+    @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+    @Max(value = 9999999, message = "가격은 9,999,999원 이하여야 합니다.")
     Integer price,
+
+    @NotNull(message = "총 수량은 필수입니다.")
+    @Min(value = 5, message = "총 수량은 5명 이상이어야 합니다.")
+    @Max(value = 9999, message = "총 수량은 9,999명 이하여야 합니다.")
     Integer totalQuantity,
+
+    @NotNull(message = "인당 최대 구매 수량은 필수입니다.")
+    @Min(value = 1, message = "인당 최대 구매 수량은 1 이상이어야 합니다.")
     Integer maxQuantity,
+
+    @NotNull(message = "카테고리는 필수입니다.")
     EventCategory category,
+
+    @NotNull(message = "기술 스택은 1개 이상 선택해야 합니다.")
+    @Size(min = 1, max = 5, message = "기술 스택은 1개에서 5개까지 선택 가능합니다.")
     List<Long> techStackIds,
+
+    @Size(max = 1, message = "이미지는 최대 1장까지 업로드 가능합니다.")
     List<String> imageUrls,
+
     EventStatus status
 ) {}


### PR DESCRIPTION
## 관련 이슈
- close #548 

## 작업 내용
- 이벤트 썸네일 이미지 최대 업로드 수를 2장에서 1장으로 변경
- 이벤트 수정 DTO(SellerEventUpdateRequest)에 등록 DTO와 동일한 유효성 검사 어노테이션 추가

## 변경 사항
- `EventPolicyConstants.java` — EVENT_MAX_IMAGES 상수 2 → 1
- `SellerEventCreateRequest.java` — imageUrls @Size(max=1) 및 에러 메시지 수정
- `SellerEventUpdateRequest.java` — jakarta.validation 어노테이션 전체 추가 (CreateRequest 형식 통일)