### PR TITLE
[Event] fix: GlobalExceptionHandler 클라이언트 단절 예외 분리

### DIFF
--- a/event/src/main/java/com/devticket/event/common/exception/GlobalExceptionHandler.java
+++ b/event/src/main/java/com/devticket/event/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.devticket.event.common.exception;
 
 import java.io.IOException;
+import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.http.HttpStatus;
@@ -91,9 +92,14 @@ public class GlobalExceptionHandler {
             if (t instanceof ClientAbortException) {
                 return true;
             }
-            String msg = t.getMessage();
-            if (t instanceof IOException && msg != null && msg.contains("Broken pipe")) {
-                return true;
+            if (t instanceof IOException) {
+                String msg = t.getMessage();
+                if (msg != null) {
+                    String lower = msg.toLowerCase(Locale.ROOT);
+                    if (lower.contains("broken pipe") || lower.contains("connection reset")) {
+                        return true;
+                    }
+                }
             }
             t = t.getCause();
         }

--- a/event/src/main/java/com/devticket/event/common/exception/GlobalExceptionHandler.java
+++ b/event/src/main/java/com/devticket/event/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,17 @@
 package com.devticket.event.common.exception;
 
+import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
@@ -47,6 +51,31 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * 클라이언트가 응답 수신 전 연결을 끊은 경우.
+     * 서버 결함이 아니고 응답 본문도 송신할 수 없으므로 WARN으로만 로깅.
+     */
+    @ExceptionHandler({ClientAbortException.class, AsyncRequestNotUsableException.class})
+    public void handleClientDisconnect(Exception e) {
+        log.warn("ClientDisconnected: {} - {}", e.getClass().getSimpleName(), e.getMessage());
+    }
+
+    /**
+     * 응답 직렬화 단계 예외. cause 체인에 Broken pipe가 있으면 클라이언트 단절로 간주해 WARN,
+     * 그 외(직렬화 실패 등)는 ERROR로 분기.
+     */
+    @ExceptionHandler(HttpMessageNotWritableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotWritable(HttpMessageNotWritableException e) {
+        if (isClientDisconnect(e)) {
+            log.warn("ClientDisconnected (HttpMessageNotWritable): {}", e.getMessage());
+            return null;
+        }
+        log.error("HttpMessageNotWritableException: ", e);
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ErrorResponse.of("COMMON_006", "서버 내부 오류가 발생했습니다.", 500));
+    }
+
+    /**
      * 처리되지 않은 모든 서버 내부 예외 처리
      */
     @ExceptionHandler(Exception.class)
@@ -55,6 +84,20 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ErrorResponse.of("COMMON_006", "서버 내부 오류가 발생했습니다.", 500));
+    }
+
+    private boolean isClientDisconnect(Throwable t) {
+        while (t != null) {
+            if (t instanceof ClientAbortException) {
+                return true;
+            }
+            String msg = t.getMessage();
+            if (t instanceof IOException && msg != null && msg.contains("Broken pipe")) {
+                return true;
+            }
+            t = t.getCause();
+        }
+        return false;
     }
 
     @ExceptionHandler(MissingRequestHeaderException.class)

--- a/event/src/test/java/com/devticket/event/common/exception/GlobalExceptionHandlerTest.java
+++ b/event/src/test/java/com/devticket/event/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,156 @@
+package com.devticket.event.common.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.io.IOException;
+import org.apache.catalina.connector.ClientAbortException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
+
+class GlobalExceptionHandlerTest {
+
+    private final FaultyController controller = new FaultyController();
+    private MockMvc mockMvc;
+    private ListAppender<ILoggingEvent> appender;
+    private Logger logger;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+
+        logger = (Logger) LoggerFactory.getLogger(GlobalExceptionHandler.class);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+        controller.toThrow = null;
+    }
+
+    @Test
+    @DisplayName("[1] ClientAbortException 발생 시 WARN 로깅, ERROR 미발생")
+    void clientAbortException_logsWarnOnly() throws Exception {
+        controller.toThrow = new ClientAbortException(new IOException("Broken pipe"));
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
+    @Test
+    @DisplayName("[2] AsyncRequestNotUsableException 발생 시 WARN 로깅, ERROR 미발생")
+    void asyncRequestNotUsableException_logsWarnOnly() throws Exception {
+        controller.toThrow = new AsyncRequestNotUsableException("flush failed");
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
+    @Test
+    @DisplayName("[3] HttpMessageNotWritableException + IOException(Broken pipe) → WARN")
+    void httpMessageNotWritable_withBrokenPipe_logsWarnOnly() throws Exception {
+        controller.toThrow = new HttpMessageNotWritableException(
+            "write failed", new IOException("Broken pipe"));
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
+    @Test
+    @DisplayName("[4] HttpMessageNotWritableException + ClientAbortException → WARN")
+    void httpMessageNotWritable_withClientAbort_logsWarnOnly() throws Exception {
+        controller.toThrow = new HttpMessageNotWritableException(
+            "write failed", new ClientAbortException());
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
+    @Test
+    @DisplayName("[5] HttpMessageNotWritableException 진짜 직렬화 실패 → ERROR + 500")
+    void httpMessageNotWritable_serializationFailure_logsErrorAnd500() throws Exception {
+        controller.toThrow = new HttpMessageNotWritableException(
+            "serialization fail", new RuntimeException("boom"));
+
+        mockMvc.perform(get("/test/fault"))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.code").value("COMMON_006"));
+
+        assertErrorOnly();
+    }
+
+    @Test
+    @DisplayName("[6] catch-all RuntimeException 회귀 → ERROR + 500")
+    void runtimeException_fallsThroughToCatchAll() throws Exception {
+        controller.toThrow = new RuntimeException("boom");
+
+        mockMvc.perform(get("/test/fault"))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.code").value("COMMON_006"));
+
+        assertErrorOnly();
+    }
+
+    @Test
+    @DisplayName("[7] cause 체인 깊이 — RuntimeException 안에 IOException(Broken pipe) → WARN")
+    void httpMessageNotWritable_nestedBrokenPipeInChain_logsWarnOnly() throws Exception {
+        Throwable deepCause = new IOException("Broken pipe");
+        Throwable middle = new RuntimeException("wrap", deepCause);
+        controller.toThrow = new HttpMessageNotWritableException("write failed", middle);
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
+    private void assertWarnOnly() {
+        assertThat(countByLevel(Level.WARN)).as("WARN count").isEqualTo(1);
+        assertThat(countByLevel(Level.ERROR)).as("ERROR count").isZero();
+    }
+
+    private void assertErrorOnly() {
+        assertThat(countByLevel(Level.ERROR)).as("ERROR count").isEqualTo(1);
+        assertThat(countByLevel(Level.WARN)).as("WARN count").isZero();
+    }
+
+    private long countByLevel(Level level) {
+        return appender.list.stream().filter(e -> e.getLevel() == level).count();
+    }
+
+    @RestController
+    static class FaultyController {
+        Exception toThrow;
+
+        @GetMapping("/test/fault")
+        public String fault() throws Exception {
+            if (toThrow != null) {
+                throw toThrow;
+            }
+            return "ok";
+        }
+    }
+}

--- a/event/src/test/java/com/devticket/event/common/exception/GlobalExceptionHandlerTest.java
+++ b/event/src/test/java/com/devticket/event/common/exception/GlobalExceptionHandlerTest.java
@@ -127,6 +127,28 @@ class GlobalExceptionHandlerTest {
         assertWarnOnly();
     }
 
+    @Test
+    @DisplayName("[8] HttpMessageNotWritableException + IOException(Connection reset by peer) → WARN")
+    void httpMessageNotWritable_withConnectionReset_logsWarnOnly() throws Exception {
+        controller.toThrow = new HttpMessageNotWritableException(
+            "write failed", new IOException("Connection reset by peer"));
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
+    @Test
+    @DisplayName("[9] case-insensitive 매칭 — IOException(CONNECTION RESET) → WARN")
+    void httpMessageNotWritable_withUpperCaseMessage_logsWarnOnly() throws Exception {
+        controller.toThrow = new HttpMessageNotWritableException(
+            "write failed", new IOException("CONNECTION RESET"));
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
     private void assertWarnOnly() {
         assertThat(countByLevel(Level.WARN)).as("WARN count").isEqualTo(1);
         assertThat(countByLevel(Level.ERROR)).as("ERROR count").isZero();


### PR DESCRIPTION
## 요약

응답 송신 전 클라이언트가 연결을 끊을 때 발생하는 `ClientAbortException` / `AsyncRequestNotUsableException` / `HttpMessageNotWritableException(Broken pipe)`이 `GlobalExceptionHandler`의 catch-all 핸들러에서 ERROR로 로깅되어 ERROR 알람을 오염시키던 문제 수정.

## 운영 로그 (2026-04-30 15:43~16:04 KST 다수 발생)

```
ERROR c.d.e.c.e.GlobalExceptionHandler : UnhandledException:
  org.springframework.web.context.request.async.AsyncRequestNotUsableException:
    ServletResponse failed to flushBuffer: java.io.IOException: Broken pipe
Caused by: org.apache.catalina.connector.ClientAbortException
Caused by: java.io.IOException: Broken pipe
```

## 변경

### `event/.../GlobalExceptionHandler.java`
- `ClientAbortException`, `AsyncRequestNotUsableException` 전용 핸들러 추가
  - WARN 레벨, `void` 반환 (응답 본문 송신 불가)
- `HttpMessageNotWritableException` 핸들러 추가
  - cause 체인에서 `ClientAbortException` 또는 `IOException("Broken pipe")` 검출 시 WARN
  - 그 외(직렬화 실패 등)는 기존대로 ERROR + 500 응답
- `isClientDisconnect(Throwable)` 헬퍼로 cause 체인 walk

### `event/.../GlobalExceptionHandlerTest.java` (신규)
MockMvc + Logback `ListAppender`로 7개 케이스 통합 검증:

| # | 시나리오 | 기대 |
|---|---|---|
| 1 | `ClientAbortException` | WARN 1, ERROR 0 |
| 2 | `AsyncRequestNotUsableException` | WARN 1, ERROR 0 |
| 3 | `HttpMessageNotWritableException` + `IOException("Broken pipe")` | WARN 1, ERROR 0 |
| 4 | `HttpMessageNotWritableException` + `ClientAbortException` | WARN 1, ERROR 0 |
| 5 | `HttpMessageNotWritableException` 진짜 직렬화 실패 | ERROR 1, 500 |
| 6 | catch-all `RuntimeException` 회귀 | ERROR 1, 500 |
| 7 | cause 체인 깊이 (중간 `RuntimeException` 안에 `IOException`) | WARN 1, ERROR 0 |

## 테스트

- [x] `./gradlew compileJava --rerun-tasks` 통과
- [x] `./gradlew test --tests GlobalExceptionHandlerTest` → **7/7 PASS** (1.846s)

## 참고

`commerce/.../GlobalExceptionHandler.java`도 동일 패턴(`Exception.class` catch-all → ERROR 로깅)으로 같은 이슈 잠재. 별도 레포라 본 PR 범위 외 — commerce 측 별도 PR로 동일 패치 검토 필요.

## 관련

FORCE_CANCELLED 작업 중 발견.

🤖 Generated with [Claude Code](https://claude.com/claude-code)