### PR TITLE
[Payment] fix: 사후 보정 readOnly TX 분리 및 환불 saga 부정합 즉시 DLT 분류

### DIFF
--- a/payment/src/main/java/com/devticket/payment/common/config/KafkaConsumerConfig.java
+++ b/payment/src/main/java/com/devticket/payment/common/config/KafkaConsumerConfig.java
@@ -1,5 +1,6 @@
 package com.devticket.payment.common.config;
 
+import com.devticket.payment.refund.domain.exception.RefundInconsistencyException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -56,7 +57,10 @@ public class KafkaConsumerConfig {
 
         ExponentialBackOff backOff = new ExponentialBackOff(2000L, 2.0); // 2→4→8초
         backOff.setMaxAttempts(3); // 최대 3회 재시도
-        return new DefaultErrorHandler(recoverer, backOff);
+        DefaultErrorHandler handler = new DefaultErrorHandler(recoverer, backOff);
+        // 부정합(REFUND_NOT_FOUND 등)은 재시도해도 결과가 바뀌지 않으므로 즉시 DLT 이동
+        handler.addNotRetryableExceptions(RefundInconsistencyException.class);
+        return handler;
     }
 
     @Bean

--- a/payment/src/main/java/com/devticket/payment/refund/domain/exception/RefundInconsistencyException.java
+++ b/payment/src/main/java/com/devticket/payment/refund/domain/exception/RefundInconsistencyException.java
@@ -1,0 +1,33 @@
+package com.devticket.payment.refund.domain.exception;
+
+/**
+ * Saga 진행 중 Refund / SagaState 레코드 부정합이 감지됐을 때 발생.
+ *
+ * 재시도해도 결과가 바뀌지 않으므로 KafkaConsumerConfig 에서 not-retryable 로 등록되어 즉시 DLT 이동한다.
+ * 발생 시 [Saga.Inconsistency] 마커 로그가 함께 출력되어 알람/대시보드 트리거에 사용된다.
+ */
+public class RefundInconsistencyException extends RuntimeException {
+
+    private final String topic;
+    private final String messageId;
+    private final String payloadSnapshot;
+
+    public RefundInconsistencyException(String topic, String messageId, String payloadSnapshot, Throwable cause) {
+        super("환불 saga 부정합 — topic=" + topic + ", messageId=" + messageId, cause);
+        this.topic = topic;
+        this.messageId = messageId;
+        this.payloadSnapshot = payloadSnapshot;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public String getPayloadSnapshot() {
+        return payloadSnapshot;
+    }
+}

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/RefundSagaConsumer.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/RefundSagaConsumer.java
@@ -10,6 +10,9 @@ import com.devticket.payment.refund.application.saga.event.RefundStockDoneEvent;
 import com.devticket.payment.refund.application.saga.event.RefundStockFailedEvent;
 import com.devticket.payment.refund.application.saga.event.RefundTicketDoneEvent;
 import com.devticket.payment.refund.application.saga.event.RefundTicketFailedEvent;
+import com.devticket.payment.refund.domain.exception.RefundErrorCode;
+import com.devticket.payment.refund.domain.exception.RefundException;
+import com.devticket.payment.refund.domain.exception.RefundInconsistencyException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
@@ -25,6 +28,8 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class RefundSagaConsumer {
+
+    private static final int PAYLOAD_SNAPSHOT_MAX_LEN = 2_000;
 
     private final RefundSagaHandler handler;
     private final MessageDeduplicationService deduplicationService;
@@ -46,8 +51,7 @@ public class RefundSagaConsumer {
             handler.startAndMark(event, messageId, record.topic());
             ack.acknowledge();
         } catch (Exception e) {
-            log.error("[Saga.Consumer] refund.requested 처리 실패 — messageId={}", messageId, e);
-            throw new RuntimeException("refund.requested 처리 실패", e);
+            handleConsumeFailure(record, messageId, e);
         }
     }
 
@@ -67,8 +71,7 @@ public class RefundSagaConsumer {
             handler.onOrderDoneAndMark(event, messageId, record.topic());
             ack.acknowledge();
         } catch (Exception e) {
-            log.error("[Saga.Consumer] refund.order.done 처리 실패 — messageId={}", messageId, e);
-            throw new RuntimeException("refund.order.done 처리 실패", e);
+            handleConsumeFailure(record, messageId, e);
         }
     }
 
@@ -88,8 +91,7 @@ public class RefundSagaConsumer {
             handler.onOrderFailedAndMark(event, messageId, record.topic());
             ack.acknowledge();
         } catch (Exception e) {
-            log.error("[Saga.Consumer] refund.order.failed 처리 실패 — messageId={}", messageId, e);
-            throw new RuntimeException("refund.order.failed 처리 실패", e);
+            handleConsumeFailure(record, messageId, e);
         }
     }
 
@@ -109,8 +111,7 @@ public class RefundSagaConsumer {
             handler.onTicketDoneAndMark(event, messageId, record.topic());
             ack.acknowledge();
         } catch (Exception e) {
-            log.error("[Saga.Consumer] refund.ticket.done 처리 실패 — messageId={}", messageId, e);
-            throw new RuntimeException("refund.ticket.done 처리 실패", e);
+            handleConsumeFailure(record, messageId, e);
         }
     }
 
@@ -130,8 +131,7 @@ public class RefundSagaConsumer {
             handler.onTicketFailedAndMark(event, messageId, record.topic());
             ack.acknowledge();
         } catch (Exception e) {
-            log.error("[Saga.Consumer] refund.ticket.failed 처리 실패 — messageId={}", messageId, e);
-            throw new RuntimeException("refund.ticket.failed 처리 실패", e);
+            handleConsumeFailure(record, messageId, e);
         }
     }
 
@@ -151,8 +151,7 @@ public class RefundSagaConsumer {
             handler.onStockDoneAndMark(event, messageId, record.topic());
             ack.acknowledge();
         } catch (Exception e) {
-            log.error("[Saga.Consumer] refund.stock.done 처리 실패 — messageId={}", messageId, e);
-            throw new RuntimeException("refund.stock.done 처리 실패", e);
+            handleConsumeFailure(record, messageId, e);
         }
     }
 
@@ -172,9 +171,46 @@ public class RefundSagaConsumer {
             handler.onStockFailedAndMark(event, messageId, record.topic());
             ack.acknowledge();
         } catch (Exception e) {
-            log.error("[Saga.Consumer] refund.stock.failed 처리 실패 — messageId={}", messageId, e);
-            throw new RuntimeException("refund.stock.failed 처리 실패", e);
+            handleConsumeFailure(record, messageId, e);
         }
+    }
+
+    /**
+     * 컨슈머 공통 실패 처리.
+     * - REFUND_NOT_FOUND 가 원인이면 부정합으로 분류 → 마커 로그 + 페이로드 스냅샷 + 재시도 없이 DLT
+     * - 그 외 일반 처리 실패는 기존대로 재시도 후 DLT
+     */
+    private void handleConsumeFailure(ConsumerRecord<String, String> record, String messageId, Exception e) {
+        if (isRefundNotFound(e)) {
+            String snapshot = truncatePayload(record.value());
+            log.error("[Saga.Inconsistency] {} — Refund/SagaState 레코드 미발견. "
+                    + "messageId={}, partition={}, offset={}, payload={}",
+                record.topic(), messageId, record.partition(), record.offset(), snapshot, e);
+            throw new RefundInconsistencyException(record.topic(), messageId, snapshot, e);
+        }
+
+        log.error("[Saga.Consumer] {} 처리 실패 — messageId={}", record.topic(), messageId, e);
+        throw new RuntimeException(record.topic() + " 처리 실패", e);
+    }
+
+    private static boolean isRefundNotFound(Throwable e) {
+        Throwable cur = e;
+        while (cur != null) {
+            if (cur instanceof RefundException re && re.getErrorCode() == RefundErrorCode.REFUND_NOT_FOUND) {
+                return true;
+            }
+            cur = cur.getCause();
+        }
+        return false;
+    }
+
+    private static String truncatePayload(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.length() <= PAYLOAD_SNAPSHOT_MAX_LEN
+            ? value
+            : value.substring(0, PAYLOAD_SNAPSHOT_MAX_LEN) + "...(truncated)";
     }
 
     private String extractMessageId(ConsumerRecord<String, String> record) {

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/WalletServiceImpl.java
@@ -375,11 +375,16 @@ public class WalletServiceImpl implements WalletService {
     /**
      * 스케줄러가 넘겨준 chargeId 한 건을 복구한다.
      * 비관적 락 구간을 최소화하기 위해 선점 → PG 조회 → 결과 반영으로 분리.
+     *
+     * 클래스 레벨 readOnly=true 컨텍스트가 SELECT FOR UPDATE 와 충돌하므로,
+     * 본 메서드는 트랜잭션 없이 실행하고 실제 락/쓰기는 WalletChargeTransactionService 의
+     * @Transactional 메서드로 위임한다(타 빈 호출이라 프록시 적용).
      */
     @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void recoverStalePendingCharge(UUID chargeId) {
         // ── 1단계: 비관적 락으로 선점 (PENDING → PROCESSING) ──
-        if (!claimChargeForRecovery(chargeId)) {
+        if (!walletChargeTransactionService.claimChargeForRecovery(chargeId)) {
             return; // 이미 처리됐거나 찾을 수 없음
         }
 
@@ -388,90 +393,14 @@ public class WalletServiceImpl implements WalletService {
         try {
             pgStatusOpt = pgPaymentClient.findPaymentByOrderId(chargeId.toString());
         } catch (Exception e) {
-            log.warn("[Recovery] PG 상태 조회 실패 — chargeId={}, PROCESSING 상태 유지 후 다음 주기 재시도. error={}",
+            log.warn("[Recovery] PG 상태 조회 실패 — chargeId={}, PENDING 으로 원복 후 다음 주기 재시도. error={}",
                 chargeId, e.getMessage());
-            revertTopending(chargeId);
+            walletChargeTransactionService.revertToPending(chargeId);
             return;
         }
 
         // ── 3단계: 새 트랜잭션에서 결과 반영 ──
-        applyRecoveryResult(chargeId, pgStatusOpt);
-    }
-
-    /**
-     * 복구용 선점: PENDING → PROCESSING. 이미 처리됐으면 false 반환.
-     */
-    @Transactional
-    public boolean claimChargeForRecovery(UUID chargeId) {
-        WalletCharge walletCharge = walletChargeRepository.findByChargeIdForUpdate(chargeId)
-            .orElse(null);
-
-        if (walletCharge == null || !walletCharge.isPending()) {
-            return false;
-        }
-
-        walletCharge.markProcessing();
-        return true;
-    }
-
-    /**
-     * PG 조회 실패 시 PROCESSING → PENDING 원복 (다음 스케줄에서 재시도 가능하도록).
-     */
-    @Transactional
-    public void revertTopending(UUID chargeId) {
-        WalletCharge walletCharge = walletChargeRepository.findByChargeId(chargeId).orElse(null);
-        if (walletCharge != null && walletCharge.isProcessing()) {
-            walletCharge.revertToPending();
-        }
-    }
-
-    /**
-     * PG 조회 결과에 따라 COMPLETED 또는 FAILED 처리.
-     */
-    @Transactional
-    public void applyRecoveryResult(UUID chargeId, Optional<TossPaymentStatusResponse> pgStatusOpt) {
-        WalletCharge walletCharge = walletChargeRepository.findByChargeId(chargeId)
-            .orElse(null);
-        if (walletCharge == null) {
-            return;
-        }
-
-        if (pgStatusOpt.isEmpty()) {
-            walletCharge.fail();
-            log.info("[Recovery] Toss 미도달(404) — chargeId={} → FAILED", chargeId);
-            return;
-        }
-
-        TossPaymentStatusResponse pgStatus = pgStatusOpt.get();
-
-        if ("DONE".equals(pgStatus.status())) {
-            String transactionKey = "CHARGE:" + pgStatus.paymentKey();
-
-            if (walletTransactionRepository.existsByTransactionKey(transactionKey)) {
-                walletCharge.complete(pgStatus.paymentKey());
-                log.info("[Recovery] 거래 기록 중복 확인 — chargeId={} → COMPLETED (잔액 반영 생략)", chargeId);
-                return;
-            }
-
-            walletCharge.complete(pgStatus.paymentKey());
-            walletRepository.chargeBalanceAtomic(walletCharge.getUserId(), walletCharge.getAmount());
-
-            Wallet wallet = walletRepository.findByUserId(walletCharge.getUserId())
-                .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
-
-            WalletTransaction tx = WalletTransaction.createCharge(
-                wallet.getId(), walletCharge.getUserId(),
-                transactionKey, walletCharge.getAmount(), wallet.getBalance()
-            );
-            walletTransactionRepository.save(tx);
-
-            log.info("[Recovery] PG DONE 감지 — chargeId={}, amount={}, balance={} → COMPLETED",
-                chargeId, walletCharge.getAmount(), wallet.getBalance());
-
-        } else {
-            walletCharge.fail();
-            log.info("[Recovery] PG 상태 '{}' — chargeId={} → FAILED", pgStatus.status(), chargeId);
-        }
+        walletChargeTransactionService.applyRecoveryResult(chargeId, pgStatusOpt);
     }
 
     // =====================================================================

--- a/payment/src/main/java/com/devticket/payment/wallet/application/service/support/WalletChargeTransactionService.java
+++ b/payment/src/main/java/com/devticket/payment/wallet/application/service/support/WalletChargeTransactionService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.devticket.payment.payment.application.dto.PgPaymentConfirmResult;
+import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentStatusResponse;
 import com.devticket.payment.wallet.domain.WalletPolicyConstants;
 import com.devticket.payment.wallet.domain.exception.WalletErrorCode;
 import com.devticket.payment.wallet.domain.exception.WalletException;
@@ -132,5 +133,79 @@ public class WalletChargeTransactionService {
             walletCharge.getChargeId().toString(), walletCharge.getAmount(),
             wallet.getBalance(), walletCharge.getStatus().name(), walletTransaction.getCreatedAt()
         );
+    }
+
+    // =====================================================================
+    // 사후 보정 (Self-healing) — WalletChargeRecoveryScheduler에서 호출
+    // =====================================================================
+
+    // 복구용 선점: 비관적 락으로 PENDING → PROCESSING. 이미 처리됐거나 찾을 수 없으면 false.
+    @Transactional
+    public boolean claimChargeForRecovery(UUID chargeId) {
+        WalletCharge walletCharge = walletChargeRepository.findByChargeIdForUpdate(chargeId)
+            .orElse(null);
+
+        if (walletCharge == null || !walletCharge.isPending()) {
+            return false;
+        }
+
+        walletCharge.markProcessing();
+        return true;
+    }
+
+    // PG 조회 실패 시 PROCESSING → PENDING 원복 (다음 스케줄에서 재시도 가능하도록).
+    @Transactional
+    public void revertToPending(UUID chargeId) {
+        WalletCharge walletCharge = walletChargeRepository.findByChargeId(chargeId).orElse(null);
+        if (walletCharge != null && walletCharge.isProcessing()) {
+            walletCharge.revertToPending();
+        }
+    }
+
+    // PG 조회 결과에 따라 COMPLETED 또는 FAILED 처리.
+    @Transactional
+    public void applyRecoveryResult(UUID chargeId, Optional<TossPaymentStatusResponse> pgStatusOpt) {
+        WalletCharge walletCharge = walletChargeRepository.findByChargeId(chargeId)
+            .orElse(null);
+        if (walletCharge == null) {
+            return;
+        }
+
+        if (pgStatusOpt.isEmpty()) {
+            walletCharge.fail();
+            log.info("[Recovery] Toss 미도달(404) — chargeId={} → FAILED", chargeId);
+            return;
+        }
+
+        TossPaymentStatusResponse pgStatus = pgStatusOpt.get();
+
+        if ("DONE".equals(pgStatus.status())) {
+            String transactionKey = "CHARGE:" + pgStatus.paymentKey();
+
+            if (walletTransactionRepository.existsByTransactionKey(transactionKey)) {
+                walletCharge.complete(pgStatus.paymentKey());
+                log.info("[Recovery] 거래 기록 중복 확인 — chargeId={} → COMPLETED (잔액 반영 생략)", chargeId);
+                return;
+            }
+
+            walletCharge.complete(pgStatus.paymentKey());
+            walletRepository.chargeBalanceAtomic(walletCharge.getUserId(), walletCharge.getAmount());
+
+            Wallet wallet = walletRepository.findByUserId(walletCharge.getUserId())
+                .orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
+
+            WalletTransaction tx = WalletTransaction.createCharge(
+                wallet.getId(), walletCharge.getUserId(),
+                transactionKey, walletCharge.getAmount(), wallet.getBalance()
+            );
+            walletTransactionRepository.save(tx);
+
+            log.info("[Recovery] PG DONE 감지 — chargeId={}, amount={}, balance={} → COMPLETED",
+                chargeId, walletCharge.getAmount(), wallet.getBalance());
+
+        } else {
+            walletCharge.fail();
+            log.info("[Recovery] PG 상태 '{}' — chargeId={} → FAILED", pgStatus.status(), chargeId);
+        }
     }
 }

--- a/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/WalletServiceTest.java
@@ -812,158 +812,75 @@ class WalletServiceTest {
     // =====================================================================
 
     @Nested
-    @DisplayName("사후 보정 (recoverStalePendingCharge)")
+    @DisplayName("사후 보정 (recoverStalePendingCharge) — 오케스트레이션")
     class RecoverStalePendingCharge {
 
+        // 락/쓰기 동작은 WalletChargeTransactionServiceTest 에서 검증.
+        // 본 블록은 WalletServiceImpl 오케스트레이션 책임(선점 → PG 호출 → 결과 반영)만 검증한다.
+
         @Test
-        void chargeId_없으면_PG_조회_없이_조기_반환() {
+        void 선점_실패시_PG_조회_없이_조기_반환() {
+            // given: claim 단계에서 false (이미 처리됐거나 미존재)
+            UUID chargeId = UUID.randomUUID();
+            given(walletChargeTransactionService.claimChargeForRecovery(chargeId)).willReturn(false);
+
+            // when
+            walletService.recoverStalePendingCharge(chargeId);
+
+            // then: PG 조회 / 결과 반영 모두 호출 없음
+            then(pgPaymentClient).should(never()).findPaymentByOrderId(any());
+            then(walletChargeTransactionService).should(never()).applyRecoveryResult(any(), any());
+            then(walletChargeTransactionService).should(never()).revertToPending(any());
+        }
+
+        @Test
+        void 선점_성공_PG_정상응답_결과반영_위임() {
             // given
             UUID chargeId = UUID.randomUUID();
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.empty());
+            TossPaymentStatusResponse pgResp = new TossPaymentStatusResponse(
+                "pk-1", chargeId.toString(), "DONE", 10_000, "2024-01-01T12:00:00");
+            given(walletChargeTransactionService.claimChargeForRecovery(chargeId)).willReturn(true);
+            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
+                .willReturn(Optional.of(pgResp));
 
             // when
             walletService.recoverStalePendingCharge(chargeId);
 
-            // then: PG 조회 없이 종료
-            then(pgPaymentClient).should(never()).findPaymentByOrderId(any());
+            // then: 결과 반영 메서드에 동일 응답 위임
+            then(walletChargeTransactionService).should(times(1))
+                .applyRecoveryResult(eq(chargeId), eq(Optional.of(pgResp)));
+            then(walletChargeTransactionService).should(never()).revertToPending(any());
         }
 
         @Test
-        void 이미_처리된_건은_PG_조회_없이_조기_반환() {
-            // given: COMPLETED 상태
+        void 선점_성공_PG_404_빈_Optional_위임() {
+            // given: Toss에 결제 자체가 없음
             UUID chargeId = UUID.randomUUID();
-            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            walletCharge.complete("already-done-key");
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
+            given(walletChargeTransactionService.claimChargeForRecovery(chargeId)).willReturn(true);
+            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString())).willReturn(Optional.empty());
 
             // when
             walletService.recoverStalePendingCharge(chargeId);
 
-            // then
-            then(pgPaymentClient).should(never()).findPaymentByOrderId(any());
+            // then: 빈 Optional 그대로 위임 (서비스 측에서 FAILED 처리)
+            then(walletChargeTransactionService).should(times(1))
+                .applyRecoveryResult(eq(chargeId), eq(Optional.empty()));
         }
 
         @Test
-        void PG_조회_예외시_상태_변경_없이_스킵() {
-            // given: PG 네트워크 오류 등
+        void 선점_성공_PG_조회_예외시_revertToPending_호출_및_조기종료() {
+            // given: PG 호출 자체에서 예외
             UUID chargeId = UUID.randomUUID();
-            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
-            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(walletCharge));
+            given(walletChargeTransactionService.claimChargeForRecovery(chargeId)).willReturn(true);
             given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
                 .willThrow(new RuntimeException("PG timeout"));
 
             // when
             walletService.recoverStalePendingCharge(chargeId);
 
-            // then: 상태 변경 없음, 다음 주기에 재시도
-            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.PENDING);
-            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
-        }
-
-        @Test
-        void Toss_404_미도달_PENDING_to_FAILED() {
-            // given: Toss에서 해당 orderId 결제 없음 (결제창 진입 전 중단)
-            UUID chargeId = UUID.randomUUID();
-            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
-            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(walletCharge));
-            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString())).willReturn(Optional.empty());
-
-            // when
-            walletService.recoverStalePendingCharge(chargeId);
-
-            // then
-            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.FAILED);
-            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
-        }
-
-        @Test
-        void PG_DONE_잔액_반영_및_거래기록_생성_후_COMPLETED() {
-            // given: Toss 결제 승인 완료, WalletTransaction 미존재
-            UUID chargeId = UUID.randomUUID();
-            String paymentKey = "pk-recovery-123";
-            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            Wallet wallet = walletWithBalance(60_000); // 충전 후 잔액
-
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
-            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(walletCharge));
-            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
-                .willReturn(Optional.of(new TossPaymentStatusResponse(
-                    paymentKey, chargeId.toString(), "DONE", 10_000, "2024-01-01T12:00:00")));
-            given(walletTransactionRepository.existsByTransactionKey("CHARGE:" + paymentKey)).willReturn(false);
-            given(walletRepository.chargeBalanceAtomic(USER_ID, 10_000)).willReturn(1);
-            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(wallet));
-            given(walletTransactionRepository.save(any())).willReturn(
-                WalletTransaction.createCharge(1L, USER_ID, "CHARGE:" + paymentKey, 10_000, 60_000));
-
-            // when
-            walletService.recoverStalePendingCharge(chargeId);
-
-            // then
-            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.COMPLETED);
-            then(walletRepository).should(times(1)).chargeBalanceAtomic(USER_ID, 10_000);
-            then(walletTransactionRepository).should(times(1)).save(any(WalletTransaction.class));
-        }
-
-        @Test
-        void PG_DONE_거래기록_이미_존재_잔액_반영_생략_COMPLETED() {
-            // given: Toss DONE이지만 WalletTransaction이 이미 존재 (부분 실패 후 재시도 케이스)
-            UUID chargeId = UUID.randomUUID();
-            String paymentKey = "pk-already-recorded";
-            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
-            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(walletCharge));
-            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
-                .willReturn(Optional.of(new TossPaymentStatusResponse(
-                    paymentKey, chargeId.toString(), "DONE", 10_000, "2024-01-01T12:00:00")));
-            given(walletTransactionRepository.existsByTransactionKey("CHARGE:" + paymentKey)).willReturn(true);
-
-            // when
-            walletService.recoverStalePendingCharge(chargeId);
-
-            // then: WalletCharge만 COMPLETED, 잔액 반영 및 거래기록 생성 생략
-            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.COMPLETED);
-            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
-            then(walletTransactionRepository).should(never()).save(any());
-        }
-
-        @Test
-        void PG_CANCELED_PENDING_to_FAILED() {
-            // given
-            UUID chargeId = UUID.randomUUID();
-            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
-            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(walletCharge));
-            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
-                .willReturn(Optional.of(new TossPaymentStatusResponse(
-                    null, chargeId.toString(), "CANCELED", 10_000, null)));
-
-            // when
-            walletService.recoverStalePendingCharge(chargeId);
-
-            // then
-            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.FAILED);
-            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
-        }
-
-        @Test
-        void PG_ABORTED_PENDING_to_FAILED() {
-            // given
-            UUID chargeId = UUID.randomUUID();
-            WalletCharge walletCharge = pendingCharge(chargeId, USER_ID, 10_000);
-            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(walletCharge));
-            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(walletCharge));
-            given(pgPaymentClient.findPaymentByOrderId(chargeId.toString()))
-                .willReturn(Optional.of(new TossPaymentStatusResponse(
-                    null, chargeId.toString(), "ABORTED", 10_000, null)));
-
-            // when
-            walletService.recoverStalePendingCharge(chargeId);
-
-            // then
-            assertThat(walletCharge.getStatus()).isEqualTo(WalletChargeStatus.FAILED);
+            // then: 원복 호출, 결과 반영 없음
+            then(walletChargeTransactionService).should(times(1)).revertToPending(chargeId);
+            then(walletChargeTransactionService).should(never()).applyRecoveryResult(any(), any());
         }
     }
 

--- a/payment/src/test/java/com/devticket/payment/application/service/support/WalletChargeTransactionServiceTest.java
+++ b/payment/src/test/java/com/devticket/payment/application/service/support/WalletChargeTransactionServiceTest.java
@@ -1,0 +1,221 @@
+package com.devticket.payment.application.service.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentStatusResponse;
+import com.devticket.payment.wallet.application.service.support.WalletChargeTransactionService;
+import com.devticket.payment.wallet.domain.enums.WalletChargeStatus;
+import com.devticket.payment.wallet.domain.model.Wallet;
+import com.devticket.payment.wallet.domain.model.WalletCharge;
+import com.devticket.payment.wallet.domain.model.WalletTransaction;
+import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
+import com.devticket.payment.wallet.domain.repository.WalletRepository;
+import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WalletChargeTransactionService — 사후 보정 트랜잭션 단위")
+class WalletChargeTransactionServiceTest {
+
+    @Mock private WalletRepository walletRepository;
+    @Mock private WalletChargeRepository walletChargeRepository;
+    @Mock private WalletTransactionRepository walletTransactionRepository;
+
+    @InjectMocks
+    private WalletChargeTransactionService service;
+
+    private static final UUID USER_ID = UUID.randomUUID();
+
+    @Nested
+    @DisplayName("claimChargeForRecovery — 비관락으로 PENDING → PROCESSING 선점")
+    class ClaimChargeForRecovery {
+
+        @Test
+        void chargeId_없으면_false() {
+            UUID chargeId = UUID.randomUUID();
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.empty());
+
+            assertThat(service.claimChargeForRecovery(chargeId)).isFalse();
+        }
+
+        @Test
+        void 이미_PROCESSING_또는_COMPLETED_상태면_false() {
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge charge = pendingCharge(chargeId, USER_ID, 10_000);
+            charge.complete("already-done-key");
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(charge));
+
+            assertThat(service.claimChargeForRecovery(chargeId)).isFalse();
+        }
+
+        @Test
+        void PENDING_이면_PROCESSING_으로_전이_후_true() {
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge charge = pendingCharge(chargeId, USER_ID, 10_000);
+            given(walletChargeRepository.findByChargeIdForUpdate(chargeId)).willReturn(Optional.of(charge));
+
+            assertThat(service.claimChargeForRecovery(chargeId)).isTrue();
+            assertThat(charge.getStatus()).isEqualTo(WalletChargeStatus.PROCESSING);
+        }
+    }
+
+    @Nested
+    @DisplayName("revertToPending — PG 조회 실패 시 PROCESSING → PENDING 원복")
+    class RevertToPending {
+
+        @Test
+        void PROCESSING_이면_PENDING_원복() {
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge charge = pendingCharge(chargeId, USER_ID, 10_000);
+            charge.markProcessing();
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(charge));
+
+            service.revertToPending(chargeId);
+
+            assertThat(charge.getStatus()).isEqualTo(WalletChargeStatus.PENDING);
+        }
+
+        @Test
+        void PROCESSING_이_아니면_상태_불변() {
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge charge = pendingCharge(chargeId, USER_ID, 10_000);
+            // PENDING 그대로
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(charge));
+
+            service.revertToPending(chargeId);
+
+            assertThat(charge.getStatus()).isEqualTo(WalletChargeStatus.PENDING);
+        }
+
+        @Test
+        void chargeId_없으면_조용히_종료() {
+            UUID chargeId = UUID.randomUUID();
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.empty());
+
+            service.revertToPending(chargeId); // no exception
+        }
+    }
+
+    @Nested
+    @DisplayName("applyRecoveryResult — PG 응답으로 COMPLETED/FAILED 처리")
+    class ApplyRecoveryResult {
+
+        @Test
+        void chargeId_없으면_조용히_종료() {
+            UUID chargeId = UUID.randomUUID();
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.empty());
+
+            service.applyRecoveryResult(chargeId, Optional.empty());
+
+            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
+            then(walletTransactionRepository).should(never()).save(any());
+        }
+
+        @Test
+        void Toss_404_빈응답_FAILED() {
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge charge = pendingCharge(chargeId, USER_ID, 10_000);
+            charge.markProcessing();
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(charge));
+
+            service.applyRecoveryResult(chargeId, Optional.empty());
+
+            assertThat(charge.getStatus()).isEqualTo(WalletChargeStatus.FAILED);
+            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
+        }
+
+        @Test
+        void PG_DONE_거래기록_미존재_잔액_반영_및_거래_저장_후_COMPLETED() {
+            UUID chargeId = UUID.randomUUID();
+            String paymentKey = "pk-recovery-1";
+            WalletCharge charge = pendingCharge(chargeId, USER_ID, 10_000);
+            charge.markProcessing();
+            Wallet wallet = walletWithBalance(60_000);
+
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(charge));
+            given(walletTransactionRepository.existsByTransactionKey("CHARGE:" + paymentKey)).willReturn(false);
+            given(walletRepository.chargeBalanceAtomic(USER_ID, 10_000)).willReturn(1);
+            given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(wallet));
+
+            service.applyRecoveryResult(chargeId, Optional.of(new TossPaymentStatusResponse(
+                paymentKey, chargeId.toString(), "DONE", 10_000, "2024-01-01T12:00:00")));
+
+            assertThat(charge.getStatus()).isEqualTo(WalletChargeStatus.COMPLETED);
+            then(walletRepository).should(times(1)).chargeBalanceAtomic(USER_ID, 10_000);
+            then(walletTransactionRepository).should(times(1)).save(any(WalletTransaction.class));
+        }
+
+        @Test
+        void PG_DONE_거래기록_이미_존재시_잔액_반영_생략_COMPLETED() {
+            UUID chargeId = UUID.randomUUID();
+            String paymentKey = "pk-already-recorded";
+            WalletCharge charge = pendingCharge(chargeId, USER_ID, 10_000);
+            charge.markProcessing();
+
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(charge));
+            given(walletTransactionRepository.existsByTransactionKey("CHARGE:" + paymentKey)).willReturn(true);
+
+            service.applyRecoveryResult(chargeId, Optional.of(new TossPaymentStatusResponse(
+                paymentKey, chargeId.toString(), "DONE", 10_000, "2024-01-01T12:00:00")));
+
+            assertThat(charge.getStatus()).isEqualTo(WalletChargeStatus.COMPLETED);
+            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
+            then(walletTransactionRepository).should(never()).save(any());
+        }
+
+        @Test
+        void PG_CANCELED_FAILED() {
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge charge = pendingCharge(chargeId, USER_ID, 10_000);
+            charge.markProcessing();
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(charge));
+
+            service.applyRecoveryResult(chargeId, Optional.of(new TossPaymentStatusResponse(
+                null, chargeId.toString(), "CANCELED", 10_000, null)));
+
+            assertThat(charge.getStatus()).isEqualTo(WalletChargeStatus.FAILED);
+            then(walletRepository).should(never()).chargeBalanceAtomic(any(), anyInt());
+        }
+
+        @Test
+        void PG_ABORTED_FAILED() {
+            UUID chargeId = UUID.randomUUID();
+            WalletCharge charge = pendingCharge(chargeId, USER_ID, 10_000);
+            charge.markProcessing();
+            given(walletChargeRepository.findByChargeId(chargeId)).willReturn(Optional.of(charge));
+
+            service.applyRecoveryResult(chargeId, Optional.of(new TossPaymentStatusResponse(
+                null, chargeId.toString(), "ABORTED", 10_000, null)));
+
+            assertThat(charge.getStatus()).isEqualTo(WalletChargeStatus.FAILED);
+        }
+    }
+
+    private Wallet walletWithBalance(int balance) {
+        Wallet wallet = Wallet.create(USER_ID);
+        ReflectionTestUtils.setField(wallet, "id", 1L);
+        ReflectionTestUtils.setField(wallet, "balance", balance);
+        return wallet;
+    }
+
+    private WalletCharge pendingCharge(UUID chargeId, UUID userId, int amount) {
+        WalletCharge charge = WalletCharge.create(1L, userId, amount, UUID.randomUUID().toString());
+        ReflectionTestUtils.setField(charge, "chargeId", chargeId);
+        return charge;
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/integration/WalletChargeRecoveryIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/integration/WalletChargeRecoveryIntegrationTest.java
@@ -1,0 +1,324 @@
+package com.devticket.payment.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
+import com.devticket.payment.payment.infrastructure.external.dto.TossPaymentStatusResponse;
+import com.devticket.payment.wallet.application.scheduler.WalletChargeRecoveryScheduler;
+import com.devticket.payment.wallet.application.service.WalletService;
+import com.devticket.payment.wallet.domain.enums.WalletChargeStatus;
+import com.devticket.payment.wallet.domain.model.Wallet;
+import com.devticket.payment.wallet.domain.model.WalletCharge;
+import com.devticket.payment.wallet.domain.model.WalletTransaction;
+import com.devticket.payment.wallet.domain.repository.WalletChargeRepository;
+import com.devticket.payment.wallet.domain.repository.WalletRepository;
+import com.devticket.payment.wallet.domain.repository.WalletTransactionRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Wallet 사후 보정 통합 테스트.
+ *
+ * 실제 PostgreSQL(Testcontainers) 사용 — readOnly 트랜잭션에서의 SELECT FOR UPDATE 거부(SQLState 25006)는
+ * H2 PostgreSQL 호환 모드가 정확히 흉내내지 않으므로 PG 컨테이너로만 회귀를 잡을 수 있다.
+ *
+ * 검증 항목:
+ *  A1) readOnly TX 회귀 가드
+ *  A2) 스케줄러 → DB end-to-end (PENDING 3건 → COMPLETED + 잔액 반영)
+ *  A3) PG 조회 예외 시 PROCESSING → PENDING 원복
+ *  A4) PG DONE + WalletTransaction 이미 존재 시 잔액 중복 반영 없음
+ *  A5) 같은 chargeId 동시 처리 시 한쪽만 PROCESSING 선점 (FOR UPDATE 락)
+ */
+@SpringBootTest
+@Testcontainers
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class WalletChargeRecoveryIntegrationTest {
+
+    @Container
+    @SuppressWarnings("resource")
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        try (java.sql.Connection conn = java.sql.DriverManager.getConnection(
+                postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+             java.sql.Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE SCHEMA IF NOT EXISTS payment");
+            stmt.execute("CREATE SCHEMA IF NOT EXISTS refund");
+            stmt.execute("""
+                CREATE TABLE IF NOT EXISTS payment.shedlock (
+                    name       VARCHAR(64)  NOT NULL PRIMARY KEY,
+                    lock_until TIMESTAMP    NOT NULL,
+                    locked_at  TIMESTAMP    NOT NULL,
+                    locked_by  VARCHAR(255) NOT NULL
+                )""");
+        } catch (Exception e) {
+            throw new RuntimeException("PostgreSQL 스키마 초기화 실패", e);
+        }
+
+        registry.add("spring.datasource.url",
+            () -> postgres.getJdbcUrl() + "&currentSchema=payment");
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+        registry.add("spring.datasource.hikari.maximum-pool-size", () -> "30");
+        registry.add("spring.datasource.hikari.connection-init-sql",
+            () -> "SET search_path TO payment");
+        registry.add("spring.jpa.database-platform",
+            () -> "org.hibernate.dialect.PostgreSQLDialect");
+        registry.add("spring.jpa.properties.hibernate.dialect",
+            () -> "org.hibernate.dialect.PostgreSQLDialect");
+        registry.add("spring.jpa.properties.hibernate.default_schema", () -> "payment");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.jpa.show-sql", () -> "false");
+        registry.add("spring.main.allow-bean-definition-overriding", () -> "true");
+        registry.add("spring.kafka.bootstrap-servers", () -> "localhost:9093");
+        registry.add("spring.kafka.consumer.group-id", () -> "devticket-payment");
+        registry.add("spring.kafka.consumer.auto-offset-reset", () -> "earliest");
+        registry.add("spring.kafka.consumer.key-deserializer",
+            () -> "org.apache.kafka.common.serialization.StringDeserializer");
+        registry.add("spring.kafka.consumer.value-deserializer",
+            () -> "org.apache.kafka.common.serialization.StringDeserializer");
+        registry.add("spring.kafka.producer.key-serializer",
+            () -> "org.apache.kafka.common.serialization.StringSerializer");
+        registry.add("spring.kafka.producer.value-serializer",
+            () -> "org.apache.kafka.common.serialization.StringSerializer");
+        registry.add("kafka-producer.max-block-ms", () -> "3000");
+        registry.add("kafka-producer.request-timeout-ms", () -> "5000");
+        registry.add("kafka-producer.delivery-timeout-ms", () -> "8000");
+        registry.add("kafka-producer.send-timeout-ms", () -> "10000");
+        registry.add("jwt.secret-key", () -> "test-jwt-secret-key");
+        registry.add("jwt.access-token-ttl", () -> "1800000");
+        registry.add("jwt.refresh-token-ttl", () -> "604800000");
+        registry.add("internal.commerce.base-url", () -> "http://localhost:8085");
+        registry.add("internal.event.base-url", () -> "http://localhost:8085");
+        registry.add("pg.toss.base-url", () -> "https://api.tosspayments.com");
+        registry.add("pg.toss.secret-key", () -> "secret-key-dummy");
+        registry.add("server.port", () -> "8085");
+    }
+
+    @Autowired private WalletChargeRecoveryScheduler scheduler;
+    @Autowired private WalletService walletService;
+    @Autowired private WalletRepository walletRepository;
+    @Autowired private WalletChargeRepository walletChargeRepository;
+    @Autowired private WalletTransactionRepository walletTransactionRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean private PgPaymentClient pgPaymentClient;
+
+    private UUID userId;
+    private Wallet wallet;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        wallet = walletRepository.save(Wallet.create(userId));
+    }
+
+    // =====================================================================
+    // A1: readOnly TX 회귀 가드
+    //
+    // WalletServiceImpl 클래스 레벨 @Transactional(readOnly=true) 컨텍스트가 새어
+    // SELECT FOR NO KEY UPDATE 가 거부되면 SQLState 25006 으로 InvalidDataAccessApiUsageException 발생.
+    // 본 테스트는 호출이 정상 종료되고 상태가 COMPLETED 로 전이됨을 검증한다.
+    // =====================================================================
+    @Test
+    @DisplayName("[A1] readOnly TX 컨텍스트 누수 없음 — recoverStalePendingCharge 가 SQLState 25006 없이 성공")
+    void readOnly_TX_회귀_가드() {
+        // given
+        WalletCharge pending = walletChargeRepository.save(
+            WalletCharge.create(wallet.getId(), userId, 10_000, "key-" + UUID.randomUUID()));
+        given(pgPaymentClient.findPaymentByOrderId(anyString()))
+            .willReturn(Optional.of(new TossPaymentStatusResponse(
+                "pk-a1", pending.getChargeId().toString(), "DONE", 10_000, "2024-01-01T00:00:00")));
+
+        // when & then: 회귀 발생 시 InvalidDataAccessApiUsageException 던짐
+        assertThatCode(() -> walletService.recoverStalePendingCharge(pending.getChargeId()))
+            .doesNotThrowAnyException();
+
+        WalletCharge after = walletChargeRepository.findByChargeId(pending.getChargeId()).orElseThrow();
+        assertThat(after.getStatus()).isEqualTo(WalletChargeStatus.COMPLETED);
+    }
+
+    // =====================================================================
+    // A2: 스케줄러 → DB end-to-end
+    // =====================================================================
+    @Test
+    @DisplayName("[A2] 스케줄러 → 3건 모두 COMPLETED + 잔액 반영 + WalletTransaction 3건 생성")
+    void 스케줄러_E2E_DONE_반영() {
+        // given: 35분 전 PENDING 3건
+        List<UUID> chargeIds = create3StalePending(10_000);
+        chargeIds.forEach(id ->
+            given(pgPaymentClient.findPaymentByOrderId(id.toString()))
+                .willReturn(Optional.of(new TossPaymentStatusResponse(
+                    "pk-" + id, id.toString(), "DONE", 10_000, "2024-01-01T00:00:00"))));
+
+        // when
+        scheduler.recoverStalePendingCharges();
+
+        // then
+        chargeIds.forEach(id -> assertThat(
+            walletChargeRepository.findByChargeId(id).orElseThrow().getStatus())
+            .isEqualTo(WalletChargeStatus.COMPLETED));
+
+        Wallet w = walletRepository.findByUserId(userId).orElseThrow();
+        assertThat(w.getBalance()).isEqualTo(30_000);
+
+        chargeIds.forEach(id -> assertThat(
+            walletTransactionRepository.existsByTransactionKey("CHARGE:pk-" + id)).isTrue());
+    }
+
+    // =====================================================================
+    // A3: PG 조회 예외 → 원복
+    // =====================================================================
+    @Test
+    @DisplayName("[A3] PG 조회 예외 시 PENDING 으로 원복하여 다음 주기 재시도 가능")
+    void PG_조회_예외_원복() {
+        // given
+        WalletCharge pending = walletChargeRepository.save(
+            WalletCharge.create(wallet.getId(), userId, 10_000, "key-" + UUID.randomUUID()));
+        given(pgPaymentClient.findPaymentByOrderId(anyString()))
+            .willThrow(new RuntimeException("PG timeout"));
+
+        // when
+        walletService.recoverStalePendingCharge(pending.getChargeId());
+
+        // then: 잔액 변동 없음, 상태 PENDING
+        WalletCharge after = walletChargeRepository.findByChargeId(pending.getChargeId()).orElseThrow();
+        assertThat(after.getStatus()).isEqualTo(WalletChargeStatus.PENDING);
+
+        Wallet w = walletRepository.findByUserId(userId).orElseThrow();
+        assertThat(w.getBalance()).isZero();
+    }
+
+    // =====================================================================
+    // A4: PG DONE + WalletTransaction 이미 존재 → 잔액 중복 반영 방지
+    // =====================================================================
+    @Test
+    @DisplayName("[A4] PG DONE 인데 거래기록 이미 존재 시 잔액 중복 반영 없음")
+    void DONE_거래기록_존재_중복_미반영() {
+        // given: 이전 부분 실패로 거래기록은 이미 존재 + 잔액도 이미 반영된 상태
+        String paymentKey = "pk-already-recorded";
+        String txKey = "CHARGE:" + paymentKey;
+        jdbcTemplate.update("UPDATE payment.wallet SET balance = 60000 WHERE user_id = ?", userId);
+        WalletTransaction preExist = WalletTransaction.createCharge(
+            wallet.getId(), userId, txKey, 10_000, 60_000);
+        walletTransactionRepository.saveAndFlush(preExist);
+
+        WalletCharge pending = walletChargeRepository.save(
+            WalletCharge.create(wallet.getId(), userId, 10_000, "key-" + UUID.randomUUID()));
+        given(pgPaymentClient.findPaymentByOrderId(anyString()))
+            .willReturn(Optional.of(new TossPaymentStatusResponse(
+                paymentKey, pending.getChargeId().toString(), "DONE", 10_000, "2024-01-01T00:00:00")));
+
+        // when
+        walletService.recoverStalePendingCharge(pending.getChargeId());
+
+        // then: 상태는 COMPLETED, 잔액 변동 없음(60_000 그대로)
+        WalletCharge after = walletChargeRepository.findByChargeId(pending.getChargeId()).orElseThrow();
+        assertThat(after.getStatus()).isEqualTo(WalletChargeStatus.COMPLETED);
+
+        Wallet w = walletRepository.findByUserId(userId).orElseThrow();
+        assertThat(w.getBalance()).isEqualTo(60_000);
+    }
+
+    // =====================================================================
+    // A5: 동시 두 인스턴스가 같은 chargeId 처리 → 한쪽만 PROCESSING 선점
+    // =====================================================================
+    @Test
+    @DisplayName("[A5] 같은 chargeId 동시 두 호출 → 한쪽만 PG 호출, COMPLETED 1회만 반영")
+    void 동시_recoverStale_한쪽만_선점() throws InterruptedException {
+        // given: PENDING 1건 + PG 응답에 의도적 지연을 주어 두 스레드 경합 유도
+        WalletCharge pending = walletChargeRepository.save(
+            WalletCharge.create(wallet.getId(), userId, 10_000, "key-" + UUID.randomUUID()));
+
+        AtomicInteger pgCallCount = new AtomicInteger(0);
+        given(pgPaymentClient.findPaymentByOrderId(anyString())).willAnswer(inv -> {
+            pgCallCount.incrementAndGet();
+            Thread.sleep(300); // 다른 스레드가 진입해 락 경합하도록 시간 확보
+            return Optional.of(new TossPaymentStatusResponse(
+                "pk-a5", pending.getChargeId().toString(), "DONE", 10_000, "2024-01-01T00:00:00"));
+        });
+
+        int threadCount = 2;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+        AtomicInteger errorCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    start.await();
+                    walletService.recoverStalePendingCharge(pending.getChargeId());
+                } catch (Exception e) {
+                    errorCount.incrementAndGet();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        // when
+        start.countDown();
+        boolean finished = done.await(15, TimeUnit.SECONDS);
+
+        // then
+        assertThat(finished).isTrue();
+        assertThat(errorCount.get()).isZero();
+        // PG 호출은 단 1회 — 한쪽이 PENDING→PROCESSING 선점하면 다른 쪽은 isPending()=false 로 false 반환
+        assertThat(pgCallCount.get()).isEqualTo(1);
+
+        WalletCharge after = walletChargeRepository.findByChargeId(pending.getChargeId()).orElseThrow();
+        assertThat(after.getStatus()).isEqualTo(WalletChargeStatus.COMPLETED);
+
+        Wallet w = walletRepository.findByUserId(userId).orElseThrow();
+        // 한 번만 잔액 반영
+        assertThat(w.getBalance()).isEqualTo(10_000);
+
+        executor.shutdown();
+    }
+
+    // =====================================================================
+    // helpers
+    // =====================================================================
+
+    private List<UUID> create3StalePending(int amount) {
+        List<UUID> ids = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            WalletCharge wc = walletChargeRepository.save(
+                WalletCharge.create(wallet.getId(), userId, amount, "key-" + UUID.randomUUID()));
+            ids.add(wc.getChargeId());
+        }
+        // STALE_THRESHOLD_MINUTES(30) 통과하도록 35분 전으로 backdating
+        jdbcTemplate.update(
+            "UPDATE payment.wallet_charge SET created_at = ? WHERE user_id = ?",
+            LocalDateTime.now().minusMinutes(35), userId);
+        return Collections.unmodifiableList(ids);
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/refund/integration/RefundSagaInconsistencyIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/integration/RefundSagaInconsistencyIntegrationTest.java
@@ -1,0 +1,271 @@
+package com.devticket.payment.refund.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+
+import com.devticket.payment.common.messaging.KafkaTopics;
+import com.devticket.payment.refund.application.saga.event.RefundOrderDoneEvent;
+import com.devticket.payment.refund.domain.exception.RefundErrorCode;
+import com.devticket.payment.refund.domain.exception.RefundException;
+import com.devticket.payment.refund.presentation.consumer.RefundSagaHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.LinkedBlockingQueue;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * 환불 saga 부정합(REFUND_NOT_FOUND) 흐름 통합 테스트.
+ *
+ *  B1) 부정합 메시지 → 재시도 0회로 즉시 DLT 이동
+ *  B2) DLT 메시지에 원본 페이로드 + X-Message-Id 헤더 보존
+ *  B3) 일반 실패는 기존대로 3회 재시도 후 DLT (회귀 가드)
+ *  B4) 정상 처리된 messageId 재발행 시 dedup 동작 (부정합 분류가 dedup 경로를 깨지 않음)
+ *
+ * RefundSagaHandler 를 MockitoBean 으로 교체해 핸들러 시점에서 원하는 예외를 주입한다.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(
+    partitions = 1,
+    topics = {
+        KafkaTopics.REFUND_ORDER_DONE,
+        KafkaTopics.REFUND_ORDER_DONE + ".DLT"
+    }
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class RefundSagaInconsistencyIntegrationTest {
+
+    @Autowired private KafkaTemplate<String, String> kafkaTemplate;
+    @Autowired private EmbeddedKafkaBroker broker;
+
+    @MockitoBean private RefundSagaHandler refundSagaHandler;
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    private KafkaConsumer<String, String> dltConsumer;
+    private final LinkedBlockingQueue<ConsumerRecord<String, String>> dltRecords = new LinkedBlockingQueue<>();
+
+    @BeforeEach
+    void subscribeDlt() {
+        Map<String, Object> props = KafkaTestUtils.consumerProps(
+            "dlt-test-" + UUID.randomUUID(), "true", broker);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        Properties javaProps = new Properties();
+        javaProps.putAll(props);
+        dltConsumer = new KafkaConsumer<>(javaProps);
+        dltConsumer.subscribe(List.of(KafkaTopics.REFUND_ORDER_DONE + ".DLT"));
+        dltRecords.clear();
+    }
+
+    @AfterEach
+    void closeDlt() {
+        if (dltConsumer != null) {
+            dltConsumer.close();
+        }
+    }
+
+    // =====================================================================
+    // B1: REFUND_NOT_FOUND → 재시도 0회로 즉시 DLT 이동
+    // =====================================================================
+    @Test
+    @DisplayName("[B1] REFUND_NOT_FOUND 발생 시 재시도 없이 5초 내 DLT 도달")
+    void 부정합_즉시_DLT() throws Exception {
+        // given: 핸들러가 REFUND_NOT_FOUND 던지도록 주입
+        willThrow(new RefundException(RefundErrorCode.REFUND_NOT_FOUND))
+            .given(refundSagaHandler).onOrderDoneAndMark(any(), anyString(), anyString());
+
+        UUID refundId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        String messageId = UUID.randomUUID().toString();
+        String wrappedPayload = wrapOutboxPayload(messageId, refundId, orderId);
+
+        // when: 메시지 발행
+        Instant publishedAt = Instant.now();
+        kafkaTemplate.send(buildRecord(messageId, wrappedPayload)).get();
+
+        // then: 같은 messageId 의 DLT 메시지가 5초 내 도달 (재시도 backoff 없이)
+        ConsumerRecord<String, String> dlt = waitForDlt(messageId, Duration.ofSeconds(7));
+        assertThat(dlt).as("DLT 메시지 미수신").isNotNull();
+        Duration elapsed = Duration.between(publishedAt, Instant.now());
+        assertThat(elapsed).as("재시도 없이 즉시 DLT 이동해야 함")
+            .isLessThan(Duration.ofSeconds(5));
+
+        // 핸들러는 정확히 1회만 호출됨 (재시도 0회)
+        then(refundSagaHandler).should(times(1))
+            .onOrderDoneAndMark(any(), anyString(), anyString());
+    }
+
+    // =====================================================================
+    // B2: DLT 메시지의 원본 페이로드 / X-Message-Id 보존
+    // =====================================================================
+    @Test
+    @DisplayName("[B2] DLT 메시지에 원본 페이로드와 X-Message-Id 헤더 보존")
+    void DLT_페이로드_헤더_보존() throws Exception {
+        willThrow(new RefundException(RefundErrorCode.REFUND_NOT_FOUND))
+            .given(refundSagaHandler).onOrderDoneAndMark(any(), anyString(), anyString());
+
+        UUID refundId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        String messageId = UUID.randomUUID().toString();
+        String wrappedPayload = wrapOutboxPayload(messageId, refundId, orderId);
+
+        kafkaTemplate.send(buildRecord(messageId, wrappedPayload)).get();
+
+        ConsumerRecord<String, String> dlt = waitForDlt(messageId, Duration.ofSeconds(7));
+        assertThat(dlt).isNotNull();
+
+        // 페이로드 동일
+        assertThat(dlt.value()).isEqualTo(wrappedPayload);
+
+        // X-Message-Id 헤더 보존
+        var header = dlt.headers().lastHeader("X-Message-Id");
+        assertThat(header).as("X-Message-Id 헤더").isNotNull();
+        assertThat(new String(header.value(), StandardCharsets.UTF_8)).isEqualTo(messageId);
+    }
+
+    // =====================================================================
+    // B3: 일반 실패는 3회 재시도 후 DLT (회귀 가드)
+    // =====================================================================
+    @Test
+    @DisplayName("[B3] 일반 실패(REFUND_INVALID_REQUEST)는 backoff 후 DLT 도착, 핸들러 4회 호출")
+    void 일반실패_3회재시도_후_DLT() throws Exception {
+        // given: 부정합이 아닌 일반 RefundException
+        willThrow(new RefundException(RefundErrorCode.REFUND_INVALID_REQUEST))
+            .given(refundSagaHandler).onOrderDoneAndMark(any(), anyString(), anyString());
+
+        UUID refundId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        String messageId = UUID.randomUUID().toString();
+        String wrappedPayload = wrapOutboxPayload(messageId, refundId, orderId);
+
+        // when
+        Instant publishedAt = Instant.now();
+        kafkaTemplate.send(buildRecord(messageId, wrappedPayload)).get();
+
+        // then: 핸들러는 1(최초) + 3(재시도) = 총 4회 호출됨, backoff 2+4+8=14s
+        // DefaultErrorHandler maxAttempts=3 = 재시도 3회
+        then(refundSagaHandler).should(timeout(Duration.ofSeconds(25).toMillis()).times(4))
+            .onOrderDoneAndMark(any(), anyString(), anyString());
+
+        // DLT 도착 확인 — 즉시(<5s) 도착하면 회귀
+        ConsumerRecord<String, String> dlt = waitForDlt(messageId, Duration.ofSeconds(25));
+        assertThat(dlt).isNotNull();
+        Duration elapsed = Duration.between(publishedAt, Instant.now());
+        assertThat(elapsed).as("일반 실패는 backoff 후에야 DLT 도달")
+            .isGreaterThan(Duration.ofSeconds(5));
+    }
+
+    // =====================================================================
+    // B4: 정상 처리 회귀 가드
+    //
+    // 부정합 분류 도입이 정상 경로(예외 없음 → ack → DLT 미도달)를 깨지 않는지 회귀 가드.
+    // (DB-기반 dedup 자체 검증은 별도 단위 테스트 대상)
+    // =====================================================================
+    @Test
+    @DisplayName("[B4] 정상 처리는 ack 되고 DLT 미도달 (회귀 가드)")
+    void 정상_처리_DLT_미도달() throws Exception {
+        // given: 핸들러가 예외 없이 정상 반환
+        willDoNothing().given(refundSagaHandler).onOrderDoneAndMark(any(), anyString(), anyString());
+
+        UUID refundId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        String messageId = UUID.randomUUID().toString();
+        String wrappedPayload = wrapOutboxPayload(messageId, refundId, orderId);
+
+        // when
+        kafkaTemplate.send(buildRecord(messageId, wrappedPayload)).get();
+
+        // then: 핸들러 1회 호출
+        then(refundSagaHandler).should(timeout(Duration.ofSeconds(5).toMillis()).times(1))
+            .onOrderDoneAndMark(any(), anyString(), anyString());
+
+        // 같은 messageId 의 DLT 도달 없음
+        ConsumerRecord<String, String> dlt = waitForDlt(messageId, Duration.ofSeconds(3));
+        assertThat(dlt).as("정상 처리 시 DLT 도달 없어야 함").isNull();
+
+        // 다른 토픽 핸들러는 호출되지 않음
+        then(refundSagaHandler).should(never()).startAndMark(any(), anyString(), anyString());
+    }
+
+    // =====================================================================
+    // helpers
+    // =====================================================================
+
+    private ProducerRecord<String, String> buildRecord(String messageId, String wrappedPayload) {
+        ProducerRecord<String, String> r = new ProducerRecord<>(
+            KafkaTopics.REFUND_ORDER_DONE, /*partition*/ null, "key-" + messageId, wrappedPayload);
+        r.headers().add("X-Message-Id", messageId.getBytes(StandardCharsets.UTF_8));
+        return r;
+    }
+
+    private String wrapOutboxPayload(String messageId, UUID refundId, UUID orderId) throws Exception {
+        String inner = objectMapper.writeValueAsString(
+            new RefundOrderDoneEvent(refundId, orderId, Instant.now()));
+        Map<String, Object> wrapper = new HashMap<>();
+        wrapper.put("messageId", messageId);
+        wrapper.put("eventType", "refund.order.done");
+        wrapper.put("topic", KafkaTopics.REFUND_ORDER_DONE);
+        wrapper.put("partitionKey", orderId.toString());
+        wrapper.put("payload", inner);
+        wrapper.put("timestamp", Instant.now().toString());
+        return objectMapper.writeValueAsString(wrapper);
+    }
+
+    /**
+     * DLT 토픽을 폴링해 지정된 messageId 의 메시지가 도착할 때까지 대기.
+     * 다른 테스트 메시지의 늦은 도달은 무시(테스트 간 격리).
+     */
+    private ConsumerRecord<String, String> waitForDlt(String expectedMessageId, Duration timeout) {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            ConsumerRecords<String, String> polled = dltConsumer.poll(Duration.ofMillis(500));
+            for (ConsumerRecord<String, String> r : polled) {
+                var h = r.headers().lastHeader("X-Message-Id");
+                if (h != null && expectedMessageId.equals(new String(h.value(), StandardCharsets.UTF_8))) {
+                    dltRecords.add(r);
+                    return r;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/refund/presentation/consumer/RefundSagaConsumerTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/presentation/consumer/RefundSagaConsumerTest.java
@@ -1,0 +1,169 @@
+package com.devticket.payment.refund.presentation.consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.devticket.payment.common.messaging.KafkaTopics;
+import com.devticket.payment.common.messaging.MessageDeduplicationService;
+import com.devticket.payment.refund.domain.exception.RefundErrorCode;
+import com.devticket.payment.refund.domain.exception.RefundException;
+import com.devticket.payment.refund.domain.exception.RefundInconsistencyException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.UUID;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RefundSagaConsumer — 부정합/일반 실패 분기")
+class RefundSagaConsumerTest {
+
+    @Mock private RefundSagaHandler handler;
+    @Mock private MessageDeduplicationService deduplicationService;
+    @Mock private Acknowledgment ack;
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @InjectMocks
+    private RefundSagaConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        // ObjectMapper 는 @InjectMocks 가 잡지 못하므로 직접 주입
+        org.springframework.test.util.ReflectionTestUtils.setField(
+            consumer, "objectMapper", objectMapper);
+    }
+
+    @Test
+    void REFUND_NOT_FOUND_은_RefundInconsistencyException_으로_변환되어_throw() throws Exception {
+        // given: order.done 메시지 도착, 핸들러가 REFUND_NOT_FOUND 던짐
+        UUID refundId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        String payload = wrapOutboxPayload(orderDonePayload(refundId, orderId));
+        ConsumerRecord<String, String> record = recordOf(KafkaTopics.REFUND_ORDER_DONE, payload);
+
+        given(deduplicationService.isDuplicate(anyString())).willReturn(false);
+        willThrow(new RefundException(RefundErrorCode.REFUND_NOT_FOUND))
+            .given(handler).onOrderDoneAndMark(any(), anyString(), eq(KafkaTopics.REFUND_ORDER_DONE));
+
+        // when & then: 부정합 예외로 래핑되어 던져짐 (KafkaConsumerConfig 가 not-retryable 로 인식)
+        assertThatThrownBy(() -> consumer.consumeOrderDone(record, ack))
+            .isInstanceOf(RefundInconsistencyException.class)
+            .satisfies(ex -> {
+                RefundInconsistencyException ie = (RefundInconsistencyException) ex;
+                assertThat(ie.getTopic()).isEqualTo(KafkaTopics.REFUND_ORDER_DONE);
+                assertThat(ie.getMessageId()).isNotBlank();
+                assertThat(ie.getPayloadSnapshot()).isEqualTo(payload);
+                assertThat(ie.getCause()).isInstanceOf(RefundException.class);
+            });
+
+        then(ack).should(never()).acknowledge();
+    }
+
+    @Test
+    void 원인체인에서_REFUND_NOT_FOUND_탐색_가능() throws Exception {
+        // given: 핸들러가 wrapping 한 RuntimeException 안에 REFUND_NOT_FOUND 가 들어 있어도 감지돼야 함
+        UUID refundId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        String payload = wrapOutboxPayload(orderDonePayload(refundId, orderId));
+        ConsumerRecord<String, String> record = recordOf(KafkaTopics.REFUND_ORDER_DONE, payload);
+
+        RuntimeException wrapped = new RuntimeException(
+            "outer", new RefundException(RefundErrorCode.REFUND_NOT_FOUND));
+        given(deduplicationService.isDuplicate(anyString())).willReturn(false);
+        willThrow(wrapped).given(handler).onOrderDoneAndMark(any(), anyString(), anyString());
+
+        // when & then
+        assertThatThrownBy(() -> consumer.consumeOrderDone(record, ack))
+            .isInstanceOf(RefundInconsistencyException.class);
+    }
+
+    @Test
+    void 일반_처리실패는_RuntimeException_그대로_재시도_경로() throws Exception {
+        // given: REFUND_NOT_FOUND 가 아닌 일반 예외 → 기존 동작(재시도 후 DLT) 유지
+        UUID refundId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        String payload = wrapOutboxPayload(orderDonePayload(refundId, orderId));
+        ConsumerRecord<String, String> record = recordOf(KafkaTopics.REFUND_ORDER_DONE, payload);
+
+        given(deduplicationService.isDuplicate(anyString())).willReturn(false);
+        willThrow(new RefundException(RefundErrorCode.REFUND_INVALID_REQUEST))
+            .given(handler).onOrderDoneAndMark(any(), anyString(), anyString());
+
+        // when & then: 부정합이 아니므로 일반 RuntimeException
+        assertThatThrownBy(() -> consumer.consumeOrderDone(record, ack))
+            .isInstanceOf(RuntimeException.class)
+            .isNotInstanceOf(RefundInconsistencyException.class);
+    }
+
+    @Test
+    void 정상_처리시_핸들러_호출_및_ack() throws Exception {
+        UUID refundId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        String payload = wrapOutboxPayload(orderDonePayload(refundId, orderId));
+        ConsumerRecord<String, String> record = recordOf(KafkaTopics.REFUND_ORDER_DONE, payload);
+
+        given(deduplicationService.isDuplicate(anyString())).willReturn(false);
+
+        consumer.consumeOrderDone(record, ack);
+
+        then(handler).should(times(1)).onOrderDoneAndMark(any(), anyString(), eq(KafkaTopics.REFUND_ORDER_DONE));
+        then(ack).should(times(1)).acknowledge();
+    }
+
+    @Test
+    void 중복_메시지는_핸들러_미호출_즉시_ack() {
+        ConsumerRecord<String, String> record = recordOf(KafkaTopics.REFUND_ORDER_DONE, "{}");
+        given(deduplicationService.isDuplicate(anyString())).willReturn(true);
+
+        consumer.consumeOrderDone(record, ack);
+
+        then(handler).should(never()).onOrderDoneAndMark(any(), anyString(), anyString());
+        then(ack).should(times(1)).acknowledge();
+    }
+
+    // ===========================================================
+    // helpers
+    // ===========================================================
+
+    private ConsumerRecord<String, String> recordOf(String topic, String value) {
+        ConsumerRecord<String, String> r = new ConsumerRecord<>(
+            topic, 0, 8L, "key", value);
+        // X-Message-Id 헤더 부착(없어도 fallback 으로 채워지지만 명시적으로 둠)
+        r.headers().add("X-Message-Id",
+            UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+        return r;
+    }
+
+    private String orderDonePayload(UUID refundId, UUID orderId) throws Exception {
+        return objectMapper.writeValueAsString(new com.devticket.payment.refund.application.saga.event.RefundOrderDoneEvent(
+            refundId, orderId, Instant.now()));
+    }
+
+    private String wrapOutboxPayload(String inner) throws Exception {
+        // OutboxPayloadExtractor 가 fallback 으로 직접 파싱하므로 래핑 없이도 통과 가능.
+        // 운영 메시지처럼 보이도록 wrapper 구조를 흉내낸다.
+        return objectMapper.writeValueAsString(new OutboxWrapper(
+            UUID.randomUUID().toString(), "refund.order.done", inner, Instant.now().toString()));
+    }
+
+    private record OutboxWrapper(String messageId, String eventType, String payload, String timestamp) {}
+}


### PR DESCRIPTION
## Summary

운영 로그(2026-04-30 KST)에서 동시에 관찰된 두 가지 안정성 이슈를 한 번에 수정.

- **WalletChargeRecoveryScheduler** — 클래스 레벨 `@Transactional(readOnly=true)` 누수 + `@Transactional` self-invocation 우회로 `SELECT FOR NO KEY UPDATE` 가 거부(SQLState 25006)되어 동일 chargeId 3건이 영구 실패.
- **RefundSagaConsumer** — `REFUND_NOT_FOUND` 발생 시 단순 RuntimeException → 3회 재시도 → DLT 흐름. 부정합은 재시도 의미 없으므로 즉시 DLT 분류 + 마커 로그/페이로드 스냅샷 도입.

## Changes

### 2-1. Wallet 사후 보정 readOnly TX 분리
- `claimChargeForRecovery` / `revertToPending` / `applyRecoveryResult` 를 `WalletChargeTransactionService` 로 이동(타 빈 호출이라 프록시 적용).
- `WalletServiceImpl.recoverStalePendingCharge` 에 `Propagation.NOT_SUPPORTED` 부착해 클래스 레벨 readOnly 상속 차단.
- 메서드명 오타 `revertTopending` → `revertToPending` 정정.

### 2-2. Refund saga 부정합 즉시 DLT
- `RefundInconsistencyException` 도입 (topic / messageId / payloadSnapshot 보존).
- `RefundSagaConsumer` 공통 `handleConsumeFailure` 에서 원인 체인을 따라 `RefundException(REFUND_NOT_FOUND)` 감지 → `[Saga.Inconsistency]` 마커 로그 + 페이로드 스냅샷(2KB 절단) + 신규 예외로 throw.
- `KafkaConsumerConfig` `addNotRetryableExceptions(RefundInconsistencyException.class)` 등록 → 재시도 0회 즉시 DLT.

## Tests

### 단위
- `WalletChargeTransactionServiceTest` (신규, 12 케이스): 사후 보정 헬퍼 동작 검증.
- `WalletServiceTest.RecoverStalePendingCharge` (수정): 헬퍼 위임 후 오케스트레이션 검증.
- `RefundSagaConsumerTest` (신규, 5 케이스): 부정합/원인체인/일반실패/정상/중복.

### 통합
- `WalletChargeRecoveryIntegrationTest` (신규, PostgreSQL Testcontainers, A1-A5)
  - **A1** readOnly TX 회귀 가드 — H2 로는 잡히지 않는 SQLState 25006 회귀를 직접 재현.
  - **A2** 스케줄러 → COMPLETED + 잔액 반영 + WalletTransaction 3건.
  - **A3** PG 예외 시 PROCESSING → PENDING 원복.
  - **A4** PG DONE + 거래기록 선존재 시 잔액 중복 반영 없음.
  - **A5** 같은 chargeId 동시 두 호출 → PG 호출 1회 / 잔액 1회 반영(FOR UPDATE 락).
- `RefundSagaInconsistencyIntegrationTest` (신규, EmbeddedKafka, B1-B4)
  - **B1** REFUND_NOT_FOUND → 5초 내 DLT 도달, 핸들러 1회만 호출.
  - **B2** DLT 메시지 페이로드 + X-Message-Id 헤더 보존.
  - **B3** 일반 실패는 backoff(>5s) 후 DLT, 핸들러 4회 호출 — 회귀 가드.
  - **B4** 정상 처리는 DLT 미도달 — 회귀 가드.

## Test plan

- [x] `./gradlew test` 전체 통과
- [x] 기존 통합 테스트 회귀 없음 (`RefundSagaIntegrationTest`, `WalletChargeConcurrencyIntegrationTest` 등)
- [ ] 운영 영향 chargeId 3건(`cd452bc4-…`, `f4e5d7ce-…`, `f4555c8e-…`) 배포 후 자동 복구 확인
- [ ] DLT 토픽(`refund.order.done.DLT`) lag/메시지수 모니터링

## Notes

운영 항목(영향 chargeId 재처리, DLT 메시지 페이로드 분석, DLT 재처리 절차 문서화)은 코드 범위 밖 — 별도 운영 노트로 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)