### PR TITLE
[Event] event 배포 develop/event -> devticket-event

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventRecommendationService.java
+++ b/event/src/main/java/com/devticket/event/application/EventRecommendationService.java
@@ -4,8 +4,10 @@ import static java.util.stream.Collectors.toList;
 
 import com.devticket.event.domain.enums.EventStatus;
 import com.devticket.event.domain.model.Event;
+import com.devticket.event.domain.model.EventView;
 import com.devticket.event.infrastructure.client.AiClient;
 import com.devticket.event.infrastructure.persistence.EventRepository;
+import com.devticket.event.infrastructure.persistence.EventViewRepository;
 import com.devticket.event.presentation.dto.EventListContentResponse;
 import com.devticket.event.presentation.dto.RecommendationResponse;
 import java.util.List;
@@ -35,6 +37,7 @@ public class EventRecommendationService {
 
     private final AiClient aiClient;
     private final EventRepository eventRepository;
+    private final EventViewRepository eventViewRepository;
 
     @Transactional(readOnly = true)
     public RecommendationResponse getRecommendations(UUID userId) {
@@ -65,6 +68,12 @@ public class EventRecommendationService {
         Map<UUID, Event> imagesById = eventRepository.findEventImagesByEventIdIn(rankedIds).stream()
             .collect(Collectors.toMap(Event::getEventId, e -> e));
 
+        Map<UUID, Long> viewCountById = eventViewRepository.findAllByEventIdIn(rankedIds).stream()
+            .collect(Collectors.toMap(
+                ev -> ev.getEvent().getEventId(),
+                EventView::getViewCount
+            ));
+
         // AI 랭킹 순서 유지 + 필터링 (deleted_at IS NULL은 @SQLRestriction 처리)
         List<EventListContentResponse> results = rankedIds.stream()
             .map(id -> {
@@ -74,7 +83,7 @@ public class EventRecommendationService {
             })
             .filter(Objects::nonNull)
             .filter(e -> !EXCLUDED_STATUSES.contains(e.getStatus()))
-            .map(event -> EventListContentResponse.from(event, 0L))
+            .map(event -> EventListContentResponse.from(event, viewCountById.getOrDefault(event.getEventId(), 0L)))
             .toList();
 
         return new RecommendationResponse(results);

--- a/event/src/main/java/com/devticket/event/common/exception/GlobalExceptionHandler.java
+++ b/event/src/main/java/com/devticket/event/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.devticket.event.common.exception;
 
 import java.io.IOException;
+import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.http.HttpStatus;
@@ -91,9 +92,14 @@ public class GlobalExceptionHandler {
             if (t instanceof ClientAbortException) {
                 return true;
             }
-            String msg = t.getMessage();
-            if (t instanceof IOException && msg != null && msg.contains("Broken pipe")) {
-                return true;
+            if (t instanceof IOException) {
+                String msg = t.getMessage();
+                if (msg != null) {
+                    String lower = msg.toLowerCase(Locale.ROOT);
+                    if (lower.contains("broken pipe") || lower.contains("connection reset")) {
+                        return true;
+                    }
+                }
             }
             t = t.getCause();
         }

--- a/event/src/main/java/com/devticket/event/common/exception/GlobalExceptionHandler.java
+++ b/event/src/main/java/com/devticket/event/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,17 @@
 package com.devticket.event.common.exception;
 
+import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
@@ -47,6 +51,31 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * 클라이언트가 응답 수신 전 연결을 끊은 경우.
+     * 서버 결함이 아니고 응답 본문도 송신할 수 없으므로 WARN으로만 로깅.
+     */
+    @ExceptionHandler({ClientAbortException.class, AsyncRequestNotUsableException.class})
+    public void handleClientDisconnect(Exception e) {
+        log.warn("ClientDisconnected: {} - {}", e.getClass().getSimpleName(), e.getMessage());
+    }
+
+    /**
+     * 응답 직렬화 단계 예외. cause 체인에 Broken pipe가 있으면 클라이언트 단절로 간주해 WARN,
+     * 그 외(직렬화 실패 등)는 ERROR로 분기.
+     */
+    @ExceptionHandler(HttpMessageNotWritableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotWritable(HttpMessageNotWritableException e) {
+        if (isClientDisconnect(e)) {
+            log.warn("ClientDisconnected (HttpMessageNotWritable): {}", e.getMessage());
+            return null;
+        }
+        log.error("HttpMessageNotWritableException: ", e);
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ErrorResponse.of("COMMON_006", "서버 내부 오류가 발생했습니다.", 500));
+    }
+
+    /**
      * 처리되지 않은 모든 서버 내부 예외 처리
      */
     @ExceptionHandler(Exception.class)
@@ -55,6 +84,20 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ErrorResponse.of("COMMON_006", "서버 내부 오류가 발생했습니다.", 500));
+    }
+
+    private boolean isClientDisconnect(Throwable t) {
+        while (t != null) {
+            if (t instanceof ClientAbortException) {
+                return true;
+            }
+            String msg = t.getMessage();
+            if (t instanceof IOException && msg != null && msg.contains("Broken pipe")) {
+                return true;
+            }
+            t = t.getCause();
+        }
+        return false;
     }
 
     @ExceptionHandler(MissingRequestHeaderException.class)

--- a/event/src/main/java/com/devticket/event/domain/constant/EventPolicyConstants.java
+++ b/event/src/main/java/com/devticket/event/domain/constant/EventPolicyConstants.java
@@ -12,7 +12,7 @@ public final class EventPolicyConstants {
     public static final int EVENT_MIN_CAPACITY = 5;
     public static final int EVENT_MAX_CAPACITY = 9_999;
 
-    public static final int EVENT_MAX_IMAGES = 2;
+    public static final int EVENT_MAX_IMAGES = 1;
 
     public static final int EVENT_REGISTER_DEADLINE_DAYS = 3;
     public static final int EVENT_EDIT_DEADLINE_DAYS = 1;

--- a/event/src/main/java/com/devticket/event/presentation/controller/SellerEventController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/SellerEventController.java
@@ -75,7 +75,7 @@ public class SellerEventController {
     public ResponseEntity<SuccessResponse<SellerEventUpdateResponse>> updateEvent(
         @RequestHeader("X-User-Id") UUID sellerId,
         @PathVariable UUID eventId,
-        @RequestBody SellerEventUpdateRequest request) {
+        @Valid @RequestBody SellerEventUpdateRequest request) {
         return ResponseEntity.ok(SuccessResponse.success(eventService.updateEvent(sellerId, eventId, request)));
     }
 }

--- a/event/src/main/java/com/devticket/event/presentation/dto/SellerEventCreateRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/SellerEventCreateRequest.java
@@ -47,6 +47,6 @@ public record SellerEventCreateRequest(
     @Size(min = 1, max = 5, message = "기술 스택은 1개에서 5개까지 선택 가능합니다.")
     List<Long> techStackIds,
 
-    @Size(max = 2, message = "이미지는 최대 2장까지 업로드 가능합니다.")
+    @Size(max = 1, message = "이미지는 최대 1장까지 업로드 가능합니다.")
     List<String> imageUrls
 ) {}

--- a/event/src/main/java/com/devticket/event/presentation/dto/SellerEventUpdateRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/SellerEventUpdateRequest.java
@@ -7,43 +7,32 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record SellerEventUpdateRequest(
-    @NotBlank(message = "이벤트 제목은 필수입니다.")
     @Size(min = 2, max = 50, message = "이벤트 제목은 2자 이상 50자 이하여야 합니다.")
     String title,
 
-    @NotBlank(message = "상세 설명은 필수입니다.")
     String description,
 
-    @NotBlank(message = "장소는 필수입니다.")
     String location,
 
-    @NotNull(message = "행사 일시는 필수입니다.")
     LocalDateTime eventDateTime,
 
-    @NotNull(message = "판매 시작 시각은 필수입니다.")
     LocalDateTime saleStartAt,
 
-    @NotNull(message = "판매 종료 시각은 필수입니다.")
     LocalDateTime saleEndAt,
 
-    @NotNull(message = "가격은 필수입니다.")
     @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
     @Max(value = 9999999, message = "가격은 9,999,999원 이하여야 합니다.")
     Integer price,
 
-    @NotNull(message = "총 수량은 필수입니다.")
     @Min(value = 5, message = "총 수량은 5명 이상이어야 합니다.")
     @Max(value = 9999, message = "총 수량은 9,999명 이하여야 합니다.")
     Integer totalQuantity,
 
-    @NotNull(message = "인당 최대 구매 수량은 필수입니다.")
     @Min(value = 1, message = "인당 최대 구매 수량은 1 이상이어야 합니다.")
     Integer maxQuantity,
 
-    @NotNull(message = "카테고리는 필수입니다.")
     EventCategory category,
 
-    @NotNull(message = "기술 스택은 1개 이상 선택해야 합니다.")
     @Size(min = 1, max = 5, message = "기술 스택은 1개에서 5개까지 선택 가능합니다.")
     List<Long> techStackIds,
 

--- a/event/src/main/java/com/devticket/event/presentation/dto/SellerEventUpdateRequest.java
+++ b/event/src/main/java/com/devticket/event/presentation/dto/SellerEventUpdateRequest.java
@@ -2,21 +2,53 @@ package com.devticket.event.presentation.dto;
 
 import com.devticket.event.domain.enums.EventCategory;
 import com.devticket.event.domain.enums.EventStatus;
+import jakarta.validation.constraints.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record SellerEventUpdateRequest(
+    @NotBlank(message = "이벤트 제목은 필수입니다.")
+    @Size(min = 2, max = 50, message = "이벤트 제목은 2자 이상 50자 이하여야 합니다.")
     String title,
+
+    @NotBlank(message = "상세 설명은 필수입니다.")
     String description,
+
+    @NotBlank(message = "장소는 필수입니다.")
     String location,
+
+    @NotNull(message = "행사 일시는 필수입니다.")
     LocalDateTime eventDateTime,
+
+    @NotNull(message = "판매 시작 시각은 필수입니다.")
     LocalDateTime saleStartAt,
+
+    @NotNull(message = "판매 종료 시각은 필수입니다.")
     LocalDateTime saleEndAt,
+
+    @NotNull(message = "가격은 필수입니다.")
+    @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+    @Max(value = 9999999, message = "가격은 9,999,999원 이하여야 합니다.")
     Integer price,
+
+    @NotNull(message = "총 수량은 필수입니다.")
+    @Min(value = 5, message = "총 수량은 5명 이상이어야 합니다.")
+    @Max(value = 9999, message = "총 수량은 9,999명 이하여야 합니다.")
     Integer totalQuantity,
+
+    @NotNull(message = "인당 최대 구매 수량은 필수입니다.")
+    @Min(value = 1, message = "인당 최대 구매 수량은 1 이상이어야 합니다.")
     Integer maxQuantity,
+
+    @NotNull(message = "카테고리는 필수입니다.")
     EventCategory category,
+
+    @NotNull(message = "기술 스택은 1개 이상 선택해야 합니다.")
+    @Size(min = 1, max = 5, message = "기술 스택은 1개에서 5개까지 선택 가능합니다.")
     List<Long> techStackIds,
+
+    @Size(max = 1, message = "이미지는 최대 1장까지 업로드 가능합니다.")
     List<String> imageUrls,
+
     EventStatus status
 ) {}

--- a/event/src/test/java/com/devticket/event/common/exception/GlobalExceptionHandlerTest.java
+++ b/event/src/test/java/com/devticket/event/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,156 @@
+package com.devticket.event.common.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.io.IOException;
+import org.apache.catalina.connector.ClientAbortException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
+
+class GlobalExceptionHandlerTest {
+
+    private final FaultyController controller = new FaultyController();
+    private MockMvc mockMvc;
+    private ListAppender<ILoggingEvent> appender;
+    private Logger logger;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+
+        logger = (Logger) LoggerFactory.getLogger(GlobalExceptionHandler.class);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+        controller.toThrow = null;
+    }
+
+    @Test
+    @DisplayName("[1] ClientAbortException 발생 시 WARN 로깅, ERROR 미발생")
+    void clientAbortException_logsWarnOnly() throws Exception {
+        controller.toThrow = new ClientAbortException(new IOException("Broken pipe"));
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
+    @Test
+    @DisplayName("[2] AsyncRequestNotUsableException 발생 시 WARN 로깅, ERROR 미발생")
+    void asyncRequestNotUsableException_logsWarnOnly() throws Exception {
+        controller.toThrow = new AsyncRequestNotUsableException("flush failed");
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
+    @Test
+    @DisplayName("[3] HttpMessageNotWritableException + IOException(Broken pipe) → WARN")
+    void httpMessageNotWritable_withBrokenPipe_logsWarnOnly() throws Exception {
+        controller.toThrow = new HttpMessageNotWritableException(
+            "write failed", new IOException("Broken pipe"));
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
+    @Test
+    @DisplayName("[4] HttpMessageNotWritableException + ClientAbortException → WARN")
+    void httpMessageNotWritable_withClientAbort_logsWarnOnly() throws Exception {
+        controller.toThrow = new HttpMessageNotWritableException(
+            "write failed", new ClientAbortException());
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
+    @Test
+    @DisplayName("[5] HttpMessageNotWritableException 진짜 직렬화 실패 → ERROR + 500")
+    void httpMessageNotWritable_serializationFailure_logsErrorAnd500() throws Exception {
+        controller.toThrow = new HttpMessageNotWritableException(
+            "serialization fail", new RuntimeException("boom"));
+
+        mockMvc.perform(get("/test/fault"))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.code").value("COMMON_006"));
+
+        assertErrorOnly();
+    }
+
+    @Test
+    @DisplayName("[6] catch-all RuntimeException 회귀 → ERROR + 500")
+    void runtimeException_fallsThroughToCatchAll() throws Exception {
+        controller.toThrow = new RuntimeException("boom");
+
+        mockMvc.perform(get("/test/fault"))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.code").value("COMMON_006"));
+
+        assertErrorOnly();
+    }
+
+    @Test
+    @DisplayName("[7] cause 체인 깊이 — RuntimeException 안에 IOException(Broken pipe) → WARN")
+    void httpMessageNotWritable_nestedBrokenPipeInChain_logsWarnOnly() throws Exception {
+        Throwable deepCause = new IOException("Broken pipe");
+        Throwable middle = new RuntimeException("wrap", deepCause);
+        controller.toThrow = new HttpMessageNotWritableException("write failed", middle);
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
+    private void assertWarnOnly() {
+        assertThat(countByLevel(Level.WARN)).as("WARN count").isEqualTo(1);
+        assertThat(countByLevel(Level.ERROR)).as("ERROR count").isZero();
+    }
+
+    private void assertErrorOnly() {
+        assertThat(countByLevel(Level.ERROR)).as("ERROR count").isEqualTo(1);
+        assertThat(countByLevel(Level.WARN)).as("WARN count").isZero();
+    }
+
+    private long countByLevel(Level level) {
+        return appender.list.stream().filter(e -> e.getLevel() == level).count();
+    }
+
+    @RestController
+    static class FaultyController {
+        Exception toThrow;
+
+        @GetMapping("/test/fault")
+        public String fault() throws Exception {
+            if (toThrow != null) {
+                throw toThrow;
+            }
+            return "ok";
+        }
+    }
+}

--- a/event/src/test/java/com/devticket/event/common/exception/GlobalExceptionHandlerTest.java
+++ b/event/src/test/java/com/devticket/event/common/exception/GlobalExceptionHandlerTest.java
@@ -127,6 +127,28 @@ class GlobalExceptionHandlerTest {
         assertWarnOnly();
     }
 
+    @Test
+    @DisplayName("[8] HttpMessageNotWritableException + IOException(Connection reset by peer) → WARN")
+    void httpMessageNotWritable_withConnectionReset_logsWarnOnly() throws Exception {
+        controller.toThrow = new HttpMessageNotWritableException(
+            "write failed", new IOException("Connection reset by peer"));
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
+    @Test
+    @DisplayName("[9] case-insensitive 매칭 — IOException(CONNECTION RESET) → WARN")
+    void httpMessageNotWritable_withUpperCaseMessage_logsWarnOnly() throws Exception {
+        controller.toThrow = new HttpMessageNotWritableException(
+            "write failed", new IOException("CONNECTION RESET"));
+
+        mockMvc.perform(get("/test/fault"));
+
+        assertWarnOnly();
+    }
+
     private void assertWarnOnly() {
         assertThat(countByLevel(Level.WARN)).as("WARN count").isEqualTo(1);
         assertThat(countByLevel(Level.ERROR)).as("ERROR count").isZero();


### PR DESCRIPTION
## 배포 범위

`develop/event` → `devticket-event` 머지 (8 커밋 / 3 PR)

## 포함 PR

### #659 — 추천 이벤트 viewCount 버그 수정
- `3f7fa815` fix(event): 추천 이벤트 목록 viewCount 항상 0 반환 버그 수정

### #670 — 이벤트 수정 API 유효성 검사 정비
- `90416566` fix(event): 이벤트 썸네일 이미지 최대 1장 제한 및 수정 DTO 유효성 검사 추가
- `584a68fd` fix(event): 이벤트 수정 API에 `@Valid` 추가하여 DTO 유효성 검사 활성화
- `caf0407a` fix(event): 이벤트 수정 DTO에서 `@NotNull`/`@NotBlank` 제거하여 판매 중지 요청 검증 오류 수정

### #677 — GlobalExceptionHandler 클라이언트 단절 예외 분리
- `c422418f` fix(event): GlobalExceptionHandler 클라이언트 단절 예외 분리
- `8d3ad977` test(event): GlobalExceptionHandler 클라이언트 단절 예외 핸들러 테스트 추가
- `53a9b5c6` fix(event): isClientDisconnect에 Connection reset 패턴 추가
- `5a43a234` test(event): Connection reset / case-insensitive 매칭 테스트 추가

## 변경 요약

- **버그 수정**: 추천 이벤트 viewCount 0 반환, 이벤트 수정 API 유효성 검사 누락, 판매 중지 요청 검증 오류
- **로깅 개선**: 클라이언트 연결 단절(`ClientAbortException`/`AsyncRequestNotUsableException`/`HttpMessageNotWritableException`+broken pipe·connection reset) ERROR → WARN 강등으로 알람 오염 해소
- **테스트 보강**: `GlobalExceptionHandlerTest` 9케이스 추가

## 테스트

- [x] `develop/event` 기준 CI 통과
- [x] `GlobalExceptionHandlerTest` 9/9 PASS

## 배포 후 확인

- 운영 로그에서 `ClientDisconnected` WARN 정상 발화 / `UnhandledException` ERROR 감소 여부
- 이벤트 수정 API(\`PATCH /seller/events/...\`) 판매 중지 요청 정상 처리
- 추천 이벤트 응답 \`viewCount\` 정상값 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)