### PR TITLE
[Settlement] chore: yml설정파일 수정_배치자동실행 끔, 배치수동실행 API 엔드포인트 주소 변경

### DIFF
--- a/settlement/src/main/java/com/devticket/settlement/presentation/controller/BatchController.java
+++ b/settlement/src/main/java/com/devticket/settlement/presentation/controller/BatchController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Batch", description = "배치 수동 실행 API")
 @Slf4j
 @RestController
-@RequestMapping("/internal/batch")
+@RequestMapping("/api/admin/settlements")
 public class BatchController {
 
     private final JobOperator jobOperator;

--- a/settlement/src/main/java/com/devticket/settlement/presentation/controller/BatchController.java
+++ b/settlement/src/main/java/com/devticket/settlement/presentation/controller/BatchController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Batch", description = "배치 수동 실행 API")
 @Slf4j
 @RestController
-@RequestMapping("/api/admin/settlements")
+@RequestMapping("/api/admin/settlements/batch")
 public class BatchController {
 
     private final JobOperator jobOperator;

--- a/settlement/src/main/resources/application.yml
+++ b/settlement/src/main/resources/application.yml
@@ -3,6 +3,12 @@ spring:
     name: devticket-settlement
   profiles:
     active: local
+  batch:
+    job:
+      enabled: false # 앱 시작 시 모든 Job 자동 실행 방지
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.batch.autoconfigure.BatchJobLauncherAutoConfiguration
 
 server:
   port: 8085


### PR DESCRIPTION
## 관련이슈 
#680 

## 작업내용 
- application.yml 설정 추가
  -  BatchJobLauncherAutoConfiguration 자체를 제외해서 JobLauncherApplicationRunner 빈이 아예 생성되지 않도록 처리.
  - JobRepository, JobOperator 등 배치 핵심 인프라는 BatchAutoConfiguration에서 별도로 관리되므로 정상 동작합니다.  
```
  batch:
    job:
      enabled: false # 앱 시작 시 모든 Job 자동 실행 방지
  autoconfigure:
    exclude:
      - org.springframework.boot.batch.autoconfigure.BatchJobLauncherAutoConfiguration
```

- 배치작업 수동 API 엔드포인트경로 수정 : /api/admin/settlements/batch