### PR TITLE
Add OAuth redirect URI validation to prevent infinite loops

### DIFF
--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthFailureHandler.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthFailureHandler.java
@@ -1,5 +1,6 @@
 package com.devticket.apigateway.infrastructure.oauth;
 
+import jakarta.annotation.PostConstruct;
 import java.net.URI;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,6 +25,11 @@ public class OAuthFailureHandler implements ServerAuthenticationFailureHandler {
 
     public OAuthFailureHandler(@Value("${oauth2.redirect-uri}") String redirectUri) {
         this.redirectUri = redirectUri;
+    }
+
+    @PostConstruct
+    void validateRedirectUri() {
+        OAuthRedirectUriValidator.validate(redirectUri);
     }
 
     @Override

--- a/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthRedirectUriValidator.java
+++ b/apigateway/src/main/java/com/devticket/apigateway/infrastructure/oauth/OAuthRedirectUriValidator.java
@@ -1,0 +1,40 @@
+package com.devticket.apigateway.infrastructure.oauth;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * {@code oauth2.redirect-uri} 값이 Spring Security 의 OAuth2 콜백 경로
+ * (`/login/oauth2/code/*`) 로 잘못 설정되어 무한 리다이렉트 루프가 발생하는
+ * 사고를 방지하기 위한 시작 시점 검증.
+ */
+final class OAuthRedirectUriValidator {
+
+    private static final String OAUTH_CALLBACK_PATH_PREFIX = "/login/oauth2/code/";
+
+    private OAuthRedirectUriValidator() {
+    }
+
+    static void validate(String redirectUri) {
+        if (redirectUri == null || redirectUri.isBlank()) {
+            throw new IllegalStateException(
+                "oauth2.redirect-uri 가 비어 있습니다. 프론트엔드 콜백 URL(예: https://example.com/oauth/callback) 을 설정하세요."
+            );
+        }
+        String path;
+        try {
+            path = new URI(redirectUri).getPath();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(
+                "oauth2.redirect-uri 가 올바른 URI 형식이 아닙니다: " + redirectUri, e
+            );
+        }
+        if (path != null && path.startsWith(OAUTH_CALLBACK_PATH_PREFIX)) {
+            throw new IllegalStateException(
+                "oauth2.redirect-uri 가 Spring Security OAuth2 콜백 경로(" + OAUTH_CALLBACK_PATH_PREFIX
+                    + "*) 로 설정되어 있습니다. 이 경로로 리다이렉트하면 무한 루프가 발생합니다. "
+                    + "프론트엔드 콜백 페이지 URL 로 변경하세요. 현재 값: " + redirectUri
+            );
+        }
+    }
+}

--- a/apigateway/src/test/java/com/devticket/apigateway/infrastructure/oauth/OAuthRedirectUriValidatorTest.java
+++ b/apigateway/src/test/java/com/devticket/apigateway/infrastructure/oauth/OAuthRedirectUriValidatorTest.java
@@ -1,0 +1,39 @@
+package com.devticket.apigateway.infrastructure.oauth;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class OAuthRedirectUriValidatorTest {
+
+    @Test
+    void rejectsBackendOAuthCallbackPath() {
+        assertThatThrownBy(() -> OAuthRedirectUriValidator.validate(
+            "https://devticket.kro.kr/login/oauth2/code/google"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("/login/oauth2/code/");
+    }
+
+    @Test
+    void rejectsBlankValue() {
+        assertThatThrownBy(() -> OAuthRedirectUriValidator.validate(""))
+            .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> OAuthRedirectUriValidator.validate(null))
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void rejectsMalformedUri() {
+        assertThatThrownBy(() -> OAuthRedirectUriValidator.validate("ht!tp://bad uri"))
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void acceptsValidFrontendCallbackUri() {
+        assertThatCode(() -> OAuthRedirectUriValidator.validate(
+            "https://devticket.kro.kr/oauth/callback")).doesNotThrowAnyException();
+        assertThatCode(() -> OAuthRedirectUriValidator.validate(
+            "http://localhost:13000/oauth/callback")).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds startup-time validation for the OAuth2 redirect URI configuration to prevent misconfiguration that could cause infinite redirect loops. The validator ensures the redirect URI is not accidentally set to Spring Security's internal OAuth2 callback path.

## Key Changes
- **New `OAuthRedirectUriValidator` class**: A utility validator that checks:
  - Redirect URI is not null or blank
  - Redirect URI is a valid URI format
  - Redirect URI does not point to Spring Security's OAuth2 callback path (`/login/oauth2/code/*`)
  
- **Integration with `OAuthFailureHandler`**: Added `@PostConstruct` method to validate the configured redirect URI at application startup, failing fast with clear error messages if misconfigured

- **Comprehensive test coverage**: Added `OAuthRedirectUriValidatorTest` with test cases for:
  - Rejection of backend OAuth callback paths
  - Rejection of blank/null values
  - Rejection of malformed URIs
  - Acceptance of valid frontend callback URIs

## Implementation Details
- The validator provides detailed error messages in Korean to guide developers on proper configuration
- Validation occurs at bean initialization time (`@PostConstruct`), ensuring configuration errors are caught immediately on startup rather than at runtime
- The validator is package-private and only used internally by the OAuth infrastructure

https://claude.ai/code/session_01M8kzZ8bqGkBa5FxdBbf1xj