### PR TITLE
[Payment] fix: Commerce fan-out 환불 saga 부정합 해결 + RefundRequestedEvent 자체완결화

### DIFF
--- a/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
@@ -7,6 +7,8 @@ import com.devticket.payment.payment.application.dto.PgPaymentCancelResult;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
+import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
+import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderInfoResponse;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.refund.application.saga.event.RefundOrderCancelEvent;
 import com.devticket.payment.refund.application.saga.event.RefundOrderCompensateEvent;
@@ -56,6 +58,7 @@ public class RefundSagaOrchestrator {
     private final OutboxService outboxService;
     private final PgPaymentClient pgPaymentClient;
     private final WalletService walletService;
+    private final CommerceInternalClient commerceInternalClient;
 
     /**
      * Saga 진입점 — refund.requested 수신 또는 ticket.issue-failed 수신 시 호출. SagaState 생성 + refund.order.cancel 발행.
@@ -456,10 +459,6 @@ public class RefundSagaOrchestrator {
     /**
      * Commerce fan-out 경로에서 누락되는 Refund/OrderRefund/RefundTicket 을 멱등 upsert.
      * 사용자 직접 환불 경로는 RefundServiceImpl 가 미리 만들어두므로 여기서 모두 스킵된다.
-     *
-     * <p>TODO: 다중 이벤트 주문(한 order 에 여러 event 의 티켓이 섞인 경우) 부분 강제취소 시
-     * totalTickets 가 실제 주문 전체 티켓 수보다 작게 잡힐 수 있다. 단일 이벤트 주문(대부분의 케이스)에서는
-     * wholeOrder=true 로 ticketIds.size() == orderTickets.size() 가 성립해 정확하다.
      */
     private void provisionRefundRecords(RefundRequestedEvent event) {
         if (refundRepository.findByRefundId(event.refundId()).isPresent()) {
@@ -469,10 +468,6 @@ public class RefundSagaOrchestrator {
         Payment payment = paymentRepository.findByPaymentId(event.paymentId())
             .orElseThrow(() -> new RefundException(RefundErrorCode.PAYMENT_NOT_FOUND));
 
-        int totalTickets = (event.ticketIds() != null && !event.ticketIds().isEmpty())
-            ? event.ticketIds().size()
-            : 1;
-
         OrderRefund ledger = orderRefundRepository.findByOrderId(event.orderId())
             .orElseGet(() -> orderRefundRepository.save(
                 OrderRefund.create(
@@ -481,7 +476,7 @@ public class RefundSagaOrchestrator {
                     event.paymentId(),
                     event.paymentMethod(),
                     payment.getAmount(),
-                    totalTickets
+                    inferOrderTotalTickets(event)
                 )
             ));
 
@@ -506,5 +501,28 @@ public class RefundSagaOrchestrator {
         log.info("[Saga] Refund 레코드 프로비저닝 — refundId={}, orderId={}, amount={}, tickets={}",
             event.refundId(), event.orderId(), event.refundAmount(),
             event.ticketIds() == null ? 0 : event.ticketIds().size());
+    }
+
+    /**
+     * 주문의 전체 티켓 수 — 다중 이벤트 주문 부분 강제취소 시에도 OrderRefund 원장이
+     * 정확하도록 Commerce 에서 OrderItem.quantity 합계를 조회한다.
+     * Commerce 호출이 실패하거나 응답이 비면 이벤트의 ticketIds 크기로 폴백.
+     */
+    private int inferOrderTotalTickets(RefundRequestedEvent event) {
+        try {
+            InternalOrderInfoResponse info = commerceInternalClient.getOrderInfo(event.orderId());
+            if (info != null && info.orderItems() != null && !info.orderItems().isEmpty()) {
+                int sum = info.orderItems().stream()
+                    .mapToInt(InternalOrderInfoResponse.OrderItem::quantity)
+                    .sum();
+                if (sum > 0) {
+                    return sum;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("[Saga] Commerce order info 조회 실패 — orderId={}, fallback ticketIds.size()", event.orderId(), e);
+        }
+        int fallback = event.ticketIds() == null ? 0 : event.ticketIds().size();
+        return Math.max(fallback, 1);
     }
 }

--- a/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
@@ -7,8 +7,6 @@ import com.devticket.payment.payment.application.dto.PgPaymentCancelResult;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
-import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
-import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderInfoResponse;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.refund.application.saga.event.RefundOrderCancelEvent;
 import com.devticket.payment.refund.application.saga.event.RefundOrderCompensateEvent;
@@ -58,7 +56,6 @@ public class RefundSagaOrchestrator {
     private final OutboxService outboxService;
     private final PgPaymentClient pgPaymentClient;
     private final WalletService walletService;
-    private final CommerceInternalClient commerceInternalClient;
 
     /**
      * Saga 진입점 — refund.requested 수신 또는 ticket.issue-failed 수신 시 호출. SagaState 생성 + refund.order.cancel 발행.
@@ -476,7 +473,7 @@ public class RefundSagaOrchestrator {
                     event.paymentId(),
                     event.paymentMethod(),
                     payment.getAmount(),
-                    inferOrderTotalTickets(event)
+                    resolveTotalOrderTickets(event)
                 )
             ));
 
@@ -504,23 +501,12 @@ public class RefundSagaOrchestrator {
     }
 
     /**
-     * 주문의 전체 티켓 수 — 다중 이벤트 주문 부분 강제취소 시에도 OrderRefund 원장이
-     * 정확하도록 Commerce 에서 OrderItem.quantity 합계를 조회한다.
-     * Commerce 호출이 실패하거나 응답이 비면 이벤트의 ticketIds 크기로 폴백.
+     * 이벤트의 totalOrderTickets 우선 사용. 0 이하(구버전 in-flight 메시지 호환) 인 경우만
+     * ticketIds 크기로 폴백. OrderRefund.create 의 totalTickets > 0 제약을 위해 최소 1 보장.
      */
-    private int inferOrderTotalTickets(RefundRequestedEvent event) {
-        try {
-            InternalOrderInfoResponse info = commerceInternalClient.getOrderInfo(event.orderId());
-            if (info != null && info.orderItems() != null && !info.orderItems().isEmpty()) {
-                int sum = info.orderItems().stream()
-                    .mapToInt(InternalOrderInfoResponse.OrderItem::quantity)
-                    .sum();
-                if (sum > 0) {
-                    return sum;
-                }
-            }
-        } catch (Exception e) {
-            log.warn("[Saga] Commerce order info 조회 실패 — orderId={}, fallback ticketIds.size()", event.orderId(), e);
+    private int resolveTotalOrderTickets(RefundRequestedEvent event) {
+        if (event.totalOrderTickets() > 0) {
+            return event.totalOrderTickets();
         }
         int fallback = event.ticketIds() == null ? 0 : event.ticketIds().size();
         return Math.max(fallback, 1);

--- a/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
@@ -67,6 +67,10 @@ public class RefundSagaOrchestrator {
             return;
         }
 
+        // Commerce fan-out (event.force-cancelled) 경로는 Refund/OrderRefund row 가 아직 없음 — 여기서 멱등 upsert.
+        // 사용자 직접 환불 경로는 RefundServiceImpl 에서 이미 만들어 두므로 findByRefundId 가 비어있지 않아 스킵됨.
+        provisionRefundRecords(event);
+
         SagaState state = SagaState.create(
             event.refundId(),
             event.orderId(),
@@ -447,5 +451,60 @@ public class RefundSagaOrchestrator {
     private SagaState requireState(UUID refundId) {
         return sagaStateRepository.findByRefundId(refundId)
             .orElseThrow(() -> new RefundException(RefundErrorCode.REFUND_NOT_FOUND));
+    }
+
+    /**
+     * Commerce fan-out 경로에서 누락되는 Refund/OrderRefund/RefundTicket 을 멱등 upsert.
+     * 사용자 직접 환불 경로는 RefundServiceImpl 가 미리 만들어두므로 여기서 모두 스킵된다.
+     *
+     * <p>TODO: 다중 이벤트 주문(한 order 에 여러 event 의 티켓이 섞인 경우) 부분 강제취소 시
+     * totalTickets 가 실제 주문 전체 티켓 수보다 작게 잡힐 수 있다. 단일 이벤트 주문(대부분의 케이스)에서는
+     * wholeOrder=true 로 ticketIds.size() == orderTickets.size() 가 성립해 정확하다.
+     */
+    private void provisionRefundRecords(RefundRequestedEvent event) {
+        if (refundRepository.findByRefundId(event.refundId()).isPresent()) {
+            return;
+        }
+
+        Payment payment = paymentRepository.findByPaymentId(event.paymentId())
+            .orElseThrow(() -> new RefundException(RefundErrorCode.PAYMENT_NOT_FOUND));
+
+        int totalTickets = (event.ticketIds() != null && !event.ticketIds().isEmpty())
+            ? event.ticketIds().size()
+            : 1;
+
+        OrderRefund ledger = orderRefundRepository.findByOrderId(event.orderId())
+            .orElseGet(() -> orderRefundRepository.save(
+                OrderRefund.create(
+                    event.orderId(),
+                    event.userId(),
+                    event.paymentId(),
+                    event.paymentMethod(),
+                    payment.getAmount(),
+                    totalTickets
+                )
+            ));
+
+        Refund refund = Refund.createWithId(
+            event.refundId(),
+            ledger.getOrderRefundId(),
+            event.orderId(),
+            event.paymentId(),
+            event.userId(),
+            event.refundAmount(),
+            event.refundRate()
+        );
+        refundRepository.save(refund);
+
+        if (event.ticketIds() != null && !event.ticketIds().isEmpty()) {
+            List<RefundTicket> rts = event.ticketIds().stream()
+                .map(tid -> RefundTicket.of(event.refundId(), tid))
+                .toList();
+            refundTicketRepository.saveAll(rts);
+        }
+
+        log.info("[Saga] Refund 레코드 프로비저닝 — refundId={}, orderId={}, amount={}, tickets={}",
+            event.refundId(), event.orderId(), event.refundAmount(),
+            event.ticketIds() == null ? 0 : event.ticketIds().size());
     }
 }

--- a/payment/src/main/java/com/devticket/payment/refund/application/saga/event/RefundRequestedEvent.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/saga/event/RefundRequestedEvent.java
@@ -17,5 +17,6 @@ public record RefundRequestedEvent(
     int refundRate,
     boolean wholeOrder,
     String reason,
-    Instant timestamp
+    Instant timestamp,
+    int totalOrderTickets
 ) {}

--- a/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/service/RefundServiceImpl.java
@@ -170,7 +170,8 @@ public class RefundServiceImpl implements RefundService {
             refundRate,
             false,
             request.reason(),
-            Instant.now()
+            Instant.now(),
+            ledger.getTotalTickets()
         );
         outboxService.save(
             refund.getRefundId().toString(),
@@ -259,7 +260,8 @@ public class RefundServiceImpl implements RefundService {
             refundRate,
             true,
             reason,                          // ← 추가: 메서드 인자의 reason 전달
-            Instant.now()
+            Instant.now(),
+            totalTickets
         );
         outboxService.save(
             refund.getRefundId().toString(),

--- a/payment/src/main/java/com/devticket/payment/refund/domain/model/Refund.java
+++ b/payment/src/main/java/com/devticket/payment/refund/domain/model/Refund.java
@@ -87,8 +87,21 @@ public class Refund extends BaseEntity {
         Integer amount,
         Integer refundRate
     ) {
+        return createWithId(UUID.randomUUID(), orderRefundId, orderId, paymentId, userId, amount, refundRate);
+    }
+
+    // Commerce fan-out (event.force-cancelled) 처럼 refundId 가 외부에서 주어지는 saga 진입점에서 사용.
+    public static Refund createWithId(
+        UUID refundId,
+        UUID orderRefundId,
+        UUID orderId,
+        UUID paymentId,
+        UUID userId,
+        Integer amount,
+        Integer refundRate
+    ) {
         Refund refund = new Refund();
-        refund.refundId = UUID.randomUUID();
+        refund.refundId = refundId;
         refund.orderRefundId = orderRefundId;
         refund.orderId = orderId;
         refund.paymentId = paymentId;

--- a/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/TicketIssueFailedHandler.java
+++ b/payment/src/main/java/com/devticket/payment/refund/presentation/consumer/TicketIssueFailedHandler.java
@@ -91,7 +91,8 @@ public class TicketIssueFailedHandler {
             RefundRateConstants.FULL,
             issuedTicketIds.isEmpty(),
             event.reason(),
-            Instant.now()
+            Instant.now(),
+            ledger.getTotalTickets()
         );
 
         outboxService.save(

--- a/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
@@ -103,14 +103,13 @@ class RefundSagaOrchestratorTest {
     }
 
     @Nested
-    @DisplayName("start")
-    class StartTest {
+    @DisplayName("start — 사용자 직접 환불 경로 (Refund 선존재)")
+    class StartUserDirectTest {
 
         @Test
-        @DisplayName("새 Saga 시작 — 사용자 직접 환불(Refund 선존재) 경로에서 SagaState 생성 + refund.order.cancel 발행")
+        @DisplayName("Refund 선존재 — provisioning 스킵, SagaState 생성 + refund.order.cancel 발행")
         void 정상_시작() {
             given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            // 사용자 직접 환불 경로 — RefundServiceImpl 가 사전에 Refund 생성한 상태
             given(refundRepository.findByRefundId(refundId)).willReturn(Optional.of(mockRefund()));
 
             orchestrator.start(newRequested(PaymentMethod.PG, false));
@@ -123,75 +122,415 @@ class RefundSagaOrchestratorTest {
                 eq(KafkaTopics.REFUND_ORDER_CANCEL),
                 any()
             );
-            // 선존재 케이스 — Refund/OrderRefund 새로 만들지 않음
             verify(refundRepository, never()).save(any(Refund.class));
             verify(orderRefundRepository, never()).save(any(OrderRefund.class));
+            verify(refundTicketRepository, never()).saveAll(any());
+            verify(paymentRepository, never()).findByPaymentId(any());
+            verify(commerceInternalClient, never()).getOrderInfo(any());
         }
 
         @Test
-        @DisplayName("Commerce fan-out 진입 — Refund/OrderRefund 가 없으면 멱등 upsert 후 saga 진행")
-        void fanout_프로비저닝() {
+        @DisplayName("발행되는 refund.order.cancel 페이로드 — refundId/orderId/wholeOrder 보존")
+        void cancel_페이로드() {
             given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            given(paymentRepository.findByPaymentId(paymentId))
-                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
-            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
-            given(commerceInternalClient.getOrderInfo(orderId))
-                .willReturn(new InternalOrderInfoResponse(
-                    orderId, userId, "test", 10_000, "PAID", "2025-01-01T00:00:00",
-                    List.of(new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), 1))
-                ));
-            given(orderRefundRepository.save(any(OrderRefund.class)))
-                .willAnswer(inv -> inv.getArgument(0));
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.of(mockRefund()));
+
+            orchestrator.start(newRequested(PaymentMethod.PG, true));
+
+            ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+            verify(outboxService).save(any(), any(), any(), any(), captor.capture());
+            com.devticket.payment.refund.application.saga.event.RefundOrderCancelEvent published =
+                (com.devticket.payment.refund.application.saga.event.RefundOrderCancelEvent) captor.getValue();
+            assertThat(published.refundId()).isEqualTo(refundId);
+            assertThat(published.orderId()).isEqualTo(orderId);
+            assertThat(published.wholeOrder()).isTrue();
+        }
+
+        @Test
+        @DisplayName("저장되는 SagaState — refundId/orderId/method/step=ORDER_CANCELLING")
+        void sagaState_초기화() {
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.of(mockRefund()));
+
+            orchestrator.start(newRequested(PaymentMethod.WALLET, false));
+
+            ArgumentCaptor<SagaState> stateCaptor = ArgumentCaptor.forClass(SagaState.class);
+            verify(sagaStateRepository).save(stateCaptor.capture());
+            SagaState saved = stateCaptor.getValue();
+            assertThat(saved.getRefundId()).isEqualTo(refundId);
+            assertThat(saved.getOrderId()).isEqualTo(orderId);
+            assertThat(saved.getPaymentMethod()).isEqualTo(PaymentMethod.WALLET);
+            assertThat(saved.getCurrentStep()).isEqualTo(SagaStep.ORDER_CANCELLING);
+        }
+    }
+
+    @Nested
+    @DisplayName("start — Commerce fan-out 경로 (Refund 미존재)")
+    class StartFanoutTest {
+
+        @Test
+        @DisplayName("아무 것도 없는 상태 — Refund/OrderRefund/RefundTicket 모두 생성")
+        void 전체_프로비저닝() {
+            stubFanout(List.of(orderItem(1)));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             orchestrator.start(newRequested(PaymentMethod.PG, false));
 
             verify(orderRefundRepository).save(any(OrderRefund.class));
-            ArgumentCaptor<Refund> refundCaptor = ArgumentCaptor.forClass(Refund.class);
-            verify(refundRepository).save(refundCaptor.capture());
-            assertThat(refundCaptor.getValue().getRefundId()).isEqualTo(refundId);
+            verify(refundRepository).save(any(Refund.class));
             verify(refundTicketRepository).saveAll(any());
             verify(sagaStateRepository).save(any(SagaState.class));
+            verify(outboxService).save(any(), any(), eq(KafkaTopics.REFUND_ORDER_CANCEL), any(), any());
         }
 
         @Test
-        @DisplayName("다중 이벤트 주문 부분 강제취소 — Commerce orderInfo 의 quantity 합으로 totalTickets 산정")
-        void fanout_다중이벤트_totalTickets() {
-            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            given(paymentRepository.findByPaymentId(paymentId))
-                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
-            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
-            // 주문에 event A(2장) + event B(3장) — 총 5장. event A 만 강제취소되어 ticketIds.size() = 2.
-            given(commerceInternalClient.getOrderInfo(orderId))
-                .willReturn(new InternalOrderInfoResponse(
-                    orderId, userId, "multi", 50_000, "PAID", "2025-01-01T00:00:00",
-                    List.of(
-                        new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), 2),
-                        new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), 3)
-                    )
-                ));
-            given(orderRefundRepository.save(any(OrderRefund.class)))
-                .willAnswer(inv -> inv.getArgument(0));
+        @DisplayName("저장되는 Refund.refundId — Commerce 가 발급한 event.refundId 와 동일")
+        void refundId_보존() {
+            stubFanout(List.of(orderItem(1)));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            orchestrator.start(newRequested(PaymentMethod.PG, false));
+
+            ArgumentCaptor<Refund> captor = ArgumentCaptor.forClass(Refund.class);
+            verify(refundRepository).save(captor.capture());
+            assertThat(captor.getValue().getRefundId()).isEqualTo(refundId);
+        }
+
+        @Test
+        @DisplayName("저장되는 Refund — orderId/paymentId/userId/refundAmount/refundRate 가 event 와 동일")
+        void refund_필드_매핑() {
+            stubFanout(List.of(orderItem(1)));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            RefundRequestedEvent event = new RefundRequestedEvent(
+                refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
+                List.of(UUID.randomUUID()), 7_777, 50, false, "reason", Instant.now()
+            );
+            orchestrator.start(event);
+
+            ArgumentCaptor<Refund> captor = ArgumentCaptor.forClass(Refund.class);
+            verify(refundRepository).save(captor.capture());
+            Refund saved = captor.getValue();
+            assertThat(saved.getOrderId()).isEqualTo(orderId);
+            assertThat(saved.getPaymentId()).isEqualTo(paymentId);
+            assertThat(saved.getUserId()).isEqualTo(userId);
+            assertThat(saved.getRefundAmount()).isEqualTo(7_777);
+            assertThat(saved.getRefundRate()).isEqualTo(50);
+        }
+
+        @Test
+        @DisplayName("저장되는 OrderRefund — totalAmount = payment.amount, totalTickets = sum(orderItem.quantity)")
+        void ledger_필드_매핑() {
+            // Payment.amount = 10_000 (mockPayment 헬퍼)
+            stubFanout(List.of(orderItem(2), orderItem(3)));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            orchestrator.start(newRequested(PaymentMethod.PG, false));
+
+            ArgumentCaptor<OrderRefund> captor = ArgumentCaptor.forClass(OrderRefund.class);
+            verify(orderRefundRepository).save(captor.capture());
+            OrderRefund saved = captor.getValue();
+            assertThat(saved.getTotalAmount()).isEqualTo(10_000);
+            assertThat(saved.getTotalTickets()).isEqualTo(5);
+            assertThat(saved.getOrderId()).isEqualTo(orderId);
+            assertThat(saved.getUserId()).isEqualTo(userId);
+            assertThat(saved.getPaymentId()).isEqualTo(paymentId);
+            assertThat(saved.getStatus()).isEqualTo(OrderRefundStatus.NONE);
+        }
+
+        @Test
+        @DisplayName("Refund 와 OrderRefund 연결 — Refund.orderRefundId = ledger.orderRefundId")
+        void refund_ledger_연결() {
+            stubFanout(List.of(orderItem(1)));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             orchestrator.start(newRequested(PaymentMethod.PG, false));
 
             ArgumentCaptor<OrderRefund> ledgerCaptor = ArgumentCaptor.forClass(OrderRefund.class);
             verify(orderRefundRepository).save(ledgerCaptor.capture());
-            assertThat(ledgerCaptor.getValue().getTotalTickets()).isEqualTo(5);
+            ArgumentCaptor<Refund> refundCaptor = ArgumentCaptor.forClass(Refund.class);
+            verify(refundRepository).save(refundCaptor.capture());
+
+            assertThat(refundCaptor.getValue().getOrderRefundId())
+                .isEqualTo(ledgerCaptor.getValue().getOrderRefundId());
         }
 
         @Test
-        @DisplayName("이미 존재하는 SagaState — 중복 진입 스킵")
-        void 중복_진입_스킵() {
+        @DisplayName("RefundTicket — event.ticketIds 의 모든 티켓에 대해 saveAll 호출")
+        void refundTicket_전체저장() {
+            UUID t1 = UUID.randomUUID();
+            UUID t2 = UUID.randomUUID();
+            UUID t3 = UUID.randomUUID();
+            stubFanout(List.of(orderItem(3)));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            RefundRequestedEvent event = new RefundRequestedEvent(
+                refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
+                List.of(t1, t2, t3), 9_000, 100, false, "r", Instant.now()
+            );
+            orchestrator.start(event);
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<RefundTicket>> captor = ArgumentCaptor.forClass(List.class);
+            verify(refundTicketRepository).saveAll(captor.capture());
+            assertThat(captor.getValue()).hasSize(3);
+            assertThat(captor.getValue())
+                .extracting(RefundTicket::getTicketId)
+                .containsExactlyInAnyOrder(t1, t2, t3);
+            assertThat(captor.getValue())
+                .extracting(RefundTicket::getRefundId)
+                .containsOnly(refundId);
+        }
+
+        @Test
+        @DisplayName("wholeOrder=true + ticketIds 비어있음 — RefundTicket.saveAll 호출 안 함")
+        void wholeOrder_빈ticketIds() {
+            stubFanout(List.of(orderItem(2)));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            orchestrator.start(newRequested(PaymentMethod.PG, true));
+
+            verify(refundTicketRepository, never()).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("OrderRefund 가 이미 존재 — 재사용, 새로 저장하지 않음 (다른 event 가 먼저 saga 시작한 케이스)")
+        void ledger_재사용() {
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(paymentRepository.findByPaymentId(paymentId))
+                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
+            OrderRefund existing = mockLedger();
+            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.of(existing));
+
+            orchestrator.start(newRequested(PaymentMethod.PG, false));
+
+            verify(orderRefundRepository, never()).save(any(OrderRefund.class));
+            verify(commerceInternalClient, never()).getOrderInfo(any());
+            ArgumentCaptor<Refund> refundCaptor = ArgumentCaptor.forClass(Refund.class);
+            verify(refundRepository).save(refundCaptor.capture());
+            assertThat(refundCaptor.getValue().getOrderRefundId())
+                .isEqualTo(existing.getOrderRefundId());
+        }
+
+        @Test
+        @DisplayName("Payment 미존재 — PAYMENT_NOT_FOUND 예외")
+        void payment_미존재() {
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(paymentRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+
+            org.assertj.core.api.Assertions.assertThatThrownBy(
+                    () -> orchestrator.start(newRequested(PaymentMethod.PG, false)))
+                .isInstanceOf(com.devticket.payment.refund.domain.exception.RefundException.class);
+
+            verify(refundRepository, never()).save(any(Refund.class));
+            verify(orderRefundRepository, never()).save(any(OrderRefund.class));
+            verify(sagaStateRepository, never()).save(any(SagaState.class));
+            verify(outboxService, never()).save(any(), any(), any(), any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("start — fan-out totalTickets 산정 (다중 이벤트 / 폴백)")
+    class StartFanoutTotalTicketsTest {
+
+        @Test
+        @DisplayName("다중 이벤트 주문 — Commerce orderInfo 의 quantity 합으로 totalTickets 산정")
+        void 다중이벤트_합산() {
+            stubFanout(List.of(orderItem(2), orderItem(3)));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            orchestrator.start(newRequested(PaymentMethod.PG, false));
+
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("단일 이벤트 — Commerce 응답 quantity 그대로")
+        void 단일이벤트() {
+            stubFanout(List.of(orderItem(4)));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            orchestrator.start(newRequested(PaymentMethod.PG, false));
+
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("Commerce 호출 예외 — ticketIds.size() 로 폴백")
+        void commerce_예외_폴백() {
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(paymentRepository.findByPaymentId(paymentId))
+                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
+            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+            given(commerceInternalClient.getOrderInfo(orderId))
+                .willThrow(new RuntimeException("commerce down"));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            UUID t1 = UUID.randomUUID();
+            UUID t2 = UUID.randomUUID();
+            RefundRequestedEvent event = new RefundRequestedEvent(
+                refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
+                List.of(t1, t2), 5_000, 100, false, "r", Instant.now()
+            );
+            orchestrator.start(event);
+
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("Commerce 응답 null — ticketIds.size() 로 폴백")
+        void commerce_null_폴백() {
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(paymentRepository.findByPaymentId(paymentId))
+                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
+            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+            given(commerceInternalClient.getOrderInfo(orderId)).willReturn(null);
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            RefundRequestedEvent event = new RefundRequestedEvent(
+                refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
+                List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()),
+                5_000, 100, false, "r", Instant.now()
+            );
+            orchestrator.start(event);
+
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("Commerce 응답 orderItems null — ticketIds.size() 로 폴백")
+        void commerce_orderItems_null_폴백() {
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(paymentRepository.findByPaymentId(paymentId))
+                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
+            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+            given(commerceInternalClient.getOrderInfo(orderId))
+                .willReturn(new InternalOrderInfoResponse(orderId, userId, "x", 1_000, "PAID", "t", null));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            RefundRequestedEvent event = new RefundRequestedEvent(
+                refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
+                List.of(UUID.randomUUID()), 5_000, 100, false, "r", Instant.now()
+            );
+            orchestrator.start(event);
+
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("Commerce 응답 orderItems 빈 리스트 — ticketIds.size() 로 폴백")
+        void commerce_orderItems_빈리스트_폴백() {
+            stubFanout(List.of());
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            RefundRequestedEvent event = new RefundRequestedEvent(
+                refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
+                List.of(UUID.randomUUID(), UUID.randomUUID()), 5_000, 100, false, "r", Instant.now()
+            );
+            orchestrator.start(event);
+
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("ticketIds 가 빈 리스트 + Commerce 폴백 — 최소값 1 보장")
+        void wholeOrder_빈ticketIds_최소값1() {
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(paymentRepository.findByPaymentId(paymentId))
+                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
+            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+            given(commerceInternalClient.getOrderInfo(orderId))
+                .willThrow(new RuntimeException("commerce down"));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            // wholeOrder=true + ticketIds 빈 리스트 — Commerce 도 실패. OrderRefund.create 가 totalTickets <= 0 이면 throw 하므로
+            // 폴백이 최소 1 을 보장해야 한다.
+            orchestrator.start(newRequested(PaymentMethod.PG, true));
+
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("start — 멱등성 / 결제수단별")
+    class StartIdempotencyTest {
+
+        @Test
+        @DisplayName("이미 존재하는 SagaState — 모든 작업 스킵")
+        void sagaState_선존재_전체스킵() {
             given(sagaStateRepository.findByRefundId(refundId))
                 .willReturn(Optional.of(state(SagaStep.ORDER_CANCELLING)));
 
             orchestrator.start(newRequested(PaymentMethod.PG, false));
 
             verify(sagaStateRepository, never()).save(any());
+            verify(refundRepository, never()).save(any(Refund.class));
+            verify(orderRefundRepository, never()).save(any(OrderRefund.class));
+            verify(refundTicketRepository, never()).saveAll(any());
             verify(outboxService, never()).save(any(), any(), any(), any(), any());
+            verify(paymentRepository, never()).findByPaymentId(any());
+            verify(commerceInternalClient, never()).getOrderInfo(any());
         }
+
+        @Test
+        @DisplayName("결제수단 WALLET — provisioning + saga 진행")
+        void wallet_정상동작() {
+            stubFanout(List.of(orderItem(1)));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            orchestrator.start(newRequested(PaymentMethod.WALLET, false));
+
+            ArgumentCaptor<SagaState> stateCaptor = ArgumentCaptor.forClass(SagaState.class);
+            verify(sagaStateRepository).save(stateCaptor.capture());
+            assertThat(stateCaptor.getValue().getPaymentMethod()).isEqualTo(PaymentMethod.WALLET);
+        }
+
+        @Test
+        @DisplayName("결제수단 WALLET_PG — provisioning + saga 진행")
+        void walletPg_정상동작() {
+            stubFanout(List.of(orderItem(1)));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            orchestrator.start(newRequested(PaymentMethod.WALLET_PG, false));
+
+            ArgumentCaptor<SagaState> stateCaptor = ArgumentCaptor.forClass(SagaState.class);
+            verify(sagaStateRepository).save(stateCaptor.capture());
+            assertThat(stateCaptor.getValue().getPaymentMethod()).isEqualTo(PaymentMethod.WALLET_PG);
+        }
+    }
+
+    // ====== 헬퍼 ======
+
+    private void stubFanout(List<InternalOrderInfoResponse.OrderItem> orderItems) {
+        given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+        given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+        given(paymentRepository.findByPaymentId(paymentId))
+            .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
+        given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+        given(commerceInternalClient.getOrderInfo(orderId))
+            .willReturn(new InternalOrderInfoResponse(
+                orderId, userId, "test", 10_000, "PAID", "2025-01-01T00:00:00", orderItems
+            ));
+    }
+
+    private InternalOrderInfoResponse.OrderItem orderItem(int quantity) {
+        return new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), quantity);
+    }
+
+    private static <T> org.mockito.stubbing.Answer<T> echo() {
+        return inv -> inv.getArgument(0);
+    }
+
+    private OrderRefund savedLedger() {
+        ArgumentCaptor<OrderRefund> captor = ArgumentCaptor.forClass(OrderRefund.class);
+        verify(orderRefundRepository).save(captor.capture());
+        return captor.getValue();
     }
 
     @Nested

--- a/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
@@ -103,9 +103,11 @@ class RefundSagaOrchestratorTest {
     class StartTest {
 
         @Test
-        @DisplayName("새 Saga 시작 — SagaState 생성 + refund.order.cancel 발행")
+        @DisplayName("새 Saga 시작 — 사용자 직접 환불(Refund 선존재) 경로에서 SagaState 생성 + refund.order.cancel 발행")
         void 정상_시작() {
             given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            // 사용자 직접 환불 경로 — RefundServiceImpl 가 사전에 Refund 생성한 상태
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.of(mockRefund()));
 
             orchestrator.start(newRequested(PaymentMethod.PG, false));
 
@@ -117,6 +119,30 @@ class RefundSagaOrchestratorTest {
                 eq(KafkaTopics.REFUND_ORDER_CANCEL),
                 any()
             );
+            // 선존재 케이스 — Refund/OrderRefund 새로 만들지 않음
+            verify(refundRepository, never()).save(any(Refund.class));
+            verify(orderRefundRepository, never()).save(any(OrderRefund.class));
+        }
+
+        @Test
+        @DisplayName("Commerce fan-out 진입 — Refund/OrderRefund 가 없으면 멱등 upsert 후 saga 진행")
+        void fanout_프로비저닝() {
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(paymentRepository.findByPaymentId(paymentId))
+                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
+            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+            given(orderRefundRepository.save(any(OrderRefund.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+
+            orchestrator.start(newRequested(PaymentMethod.PG, false));
+
+            verify(orderRefundRepository).save(any(OrderRefund.class));
+            ArgumentCaptor<Refund> refundCaptor = ArgumentCaptor.forClass(Refund.class);
+            verify(refundRepository).save(refundCaptor.capture());
+            assertThat(refundCaptor.getValue().getRefundId()).isEqualTo(refundId);
+            verify(refundTicketRepository).saveAll(any());
+            verify(sagaStateRepository).save(any(SagaState.class));
         }
 
         @Test

--- a/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
@@ -15,6 +15,8 @@ import com.devticket.payment.payment.application.dto.PgPaymentCancelResult;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
+import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
+import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderInfoResponse;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.refund.application.saga.event.RefundOrderDoneEvent;
 import com.devticket.payment.refund.application.saga.event.RefundOrderFailedEvent;
@@ -69,6 +71,8 @@ class RefundSagaOrchestratorTest {
     PgPaymentClient pgPaymentClient;
     @Mock
     WalletService walletService;
+    @Mock
+    CommerceInternalClient commerceInternalClient;
 
     @InjectMocks
     RefundSagaOrchestrator orchestrator;
@@ -132,6 +136,11 @@ class RefundSagaOrchestratorTest {
             given(paymentRepository.findByPaymentId(paymentId))
                 .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
             given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+            given(commerceInternalClient.getOrderInfo(orderId))
+                .willReturn(new InternalOrderInfoResponse(
+                    orderId, userId, "test", 10_000, "PAID", "2025-01-01T00:00:00",
+                    List.of(new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), 1))
+                ));
             given(orderRefundRepository.save(any(OrderRefund.class)))
                 .willAnswer(inv -> inv.getArgument(0));
 
@@ -143,6 +152,33 @@ class RefundSagaOrchestratorTest {
             assertThat(refundCaptor.getValue().getRefundId()).isEqualTo(refundId);
             verify(refundTicketRepository).saveAll(any());
             verify(sagaStateRepository).save(any(SagaState.class));
+        }
+
+        @Test
+        @DisplayName("다중 이벤트 주문 부분 강제취소 — Commerce orderInfo 의 quantity 합으로 totalTickets 산정")
+        void fanout_다중이벤트_totalTickets() {
+            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
+            given(paymentRepository.findByPaymentId(paymentId))
+                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
+            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+            // 주문에 event A(2장) + event B(3장) — 총 5장. event A 만 강제취소되어 ticketIds.size() = 2.
+            given(commerceInternalClient.getOrderInfo(orderId))
+                .willReturn(new InternalOrderInfoResponse(
+                    orderId, userId, "multi", 50_000, "PAID", "2025-01-01T00:00:00",
+                    List.of(
+                        new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), 2),
+                        new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), 3)
+                    )
+                ));
+            given(orderRefundRepository.save(any(OrderRefund.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+
+            orchestrator.start(newRequested(PaymentMethod.PG, false));
+
+            ArgumentCaptor<OrderRefund> ledgerCaptor = ArgumentCaptor.forClass(OrderRefund.class);
+            verify(orderRefundRepository).save(ledgerCaptor.capture());
+            assertThat(ledgerCaptor.getValue().getTotalTickets()).isEqualTo(5);
         }
 
         @Test

--- a/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
@@ -15,8 +15,6 @@ import com.devticket.payment.payment.application.dto.PgPaymentCancelResult;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
-import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
-import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderInfoResponse;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.refund.application.saga.event.RefundOrderDoneEvent;
 import com.devticket.payment.refund.application.saga.event.RefundOrderFailedEvent;
@@ -71,8 +69,6 @@ class RefundSagaOrchestratorTest {
     PgPaymentClient pgPaymentClient;
     @Mock
     WalletService walletService;
-    @Mock
-    CommerceInternalClient commerceInternalClient;
 
     @InjectMocks
     RefundSagaOrchestrator orchestrator;
@@ -91,10 +87,14 @@ class RefundSagaOrchestratorTest {
     }
 
     private RefundRequestedEvent newRequested(PaymentMethod method, boolean wholeOrder) {
+        return newRequested(method, wholeOrder, 1);
+    }
+
+    private RefundRequestedEvent newRequested(PaymentMethod method, boolean wholeOrder, int totalOrderTickets) {
         return new RefundRequestedEvent(
             refundId, UUID.randomUUID(), orderId, userId, paymentId, method,
             wholeOrder ? List.of() : List.of(UUID.randomUUID()),
-            10_000, 100, wholeOrder, "test-reason", Instant.now()
+            10_000, 100, wholeOrder, "test-reason", Instant.now(), totalOrderTickets
         );
     }
 
@@ -126,7 +126,6 @@ class RefundSagaOrchestratorTest {
             verify(orderRefundRepository, never()).save(any(OrderRefund.class));
             verify(refundTicketRepository, never()).saveAll(any());
             verify(paymentRepository, never()).findByPaymentId(any());
-            verify(commerceInternalClient, never()).getOrderInfo(any());
         }
 
         @Test
@@ -171,7 +170,7 @@ class RefundSagaOrchestratorTest {
         @Test
         @DisplayName("아무 것도 없는 상태 — Refund/OrderRefund/RefundTicket 모두 생성")
         void 전체_프로비저닝() {
-            stubFanout(List.of(orderItem(1)));
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             orchestrator.start(newRequested(PaymentMethod.PG, false));
@@ -186,7 +185,7 @@ class RefundSagaOrchestratorTest {
         @Test
         @DisplayName("저장되는 Refund.refundId — Commerce 가 발급한 event.refundId 와 동일")
         void refundId_보존() {
-            stubFanout(List.of(orderItem(1)));
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             orchestrator.start(newRequested(PaymentMethod.PG, false));
@@ -199,12 +198,12 @@ class RefundSagaOrchestratorTest {
         @Test
         @DisplayName("저장되는 Refund — orderId/paymentId/userId/refundAmount/refundRate 가 event 와 동일")
         void refund_필드_매핑() {
-            stubFanout(List.of(orderItem(1)));
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             RefundRequestedEvent event = new RefundRequestedEvent(
                 refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
-                List.of(UUID.randomUUID()), 7_777, 50, false, "reason", Instant.now()
+                List.of(UUID.randomUUID()), 7_777, 50, false, "reason", Instant.now(), 1
             );
             orchestrator.start(event);
 
@@ -219,13 +218,13 @@ class RefundSagaOrchestratorTest {
         }
 
         @Test
-        @DisplayName("저장되는 OrderRefund — totalAmount = payment.amount, totalTickets = sum(orderItem.quantity)")
+        @DisplayName("저장되는 OrderRefund — totalAmount = payment.amount, totalTickets = event.totalOrderTickets")
         void ledger_필드_매핑() {
             // Payment.amount = 10_000 (mockPayment 헬퍼)
-            stubFanout(List.of(orderItem(2), orderItem(3)));
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
-            orchestrator.start(newRequested(PaymentMethod.PG, false));
+            orchestrator.start(newRequested(PaymentMethod.PG, false, 5));
 
             ArgumentCaptor<OrderRefund> captor = ArgumentCaptor.forClass(OrderRefund.class);
             verify(orderRefundRepository).save(captor.capture());
@@ -241,7 +240,7 @@ class RefundSagaOrchestratorTest {
         @Test
         @DisplayName("Refund 와 OrderRefund 연결 — Refund.orderRefundId = ledger.orderRefundId")
         void refund_ledger_연결() {
-            stubFanout(List.of(orderItem(1)));
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             orchestrator.start(newRequested(PaymentMethod.PG, false));
@@ -261,12 +260,12 @@ class RefundSagaOrchestratorTest {
             UUID t1 = UUID.randomUUID();
             UUID t2 = UUID.randomUUID();
             UUID t3 = UUID.randomUUID();
-            stubFanout(List.of(orderItem(3)));
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             RefundRequestedEvent event = new RefundRequestedEvent(
                 refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
-                List.of(t1, t2, t3), 9_000, 100, false, "r", Instant.now()
+                List.of(t1, t2, t3), 9_000, 100, false, "r", Instant.now(), 3
             );
             orchestrator.start(event);
 
@@ -285,10 +284,10 @@ class RefundSagaOrchestratorTest {
         @Test
         @DisplayName("wholeOrder=true + ticketIds 비어있음 — RefundTicket.saveAll 호출 안 함")
         void wholeOrder_빈ticketIds() {
-            stubFanout(List.of(orderItem(2)));
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
-            orchestrator.start(newRequested(PaymentMethod.PG, true));
+            orchestrator.start(newRequested(PaymentMethod.PG, true, 2));
 
             verify(refundTicketRepository, never()).saveAll(any());
         }
@@ -306,7 +305,6 @@ class RefundSagaOrchestratorTest {
             orchestrator.start(newRequested(PaymentMethod.PG, false));
 
             verify(orderRefundRepository, never()).save(any(OrderRefund.class));
-            verify(commerceInternalClient, never()).getOrderInfo(any());
             ArgumentCaptor<Refund> refundCaptor = ArgumentCaptor.forClass(Refund.class);
             verify(refundRepository).save(refundCaptor.capture());
             assertThat(refundCaptor.getValue().getOrderRefundId())
@@ -332,48 +330,42 @@ class RefundSagaOrchestratorTest {
     }
 
     @Nested
-    @DisplayName("start — fan-out totalTickets 산정 (다중 이벤트 / 폴백)")
+    @DisplayName("start — fan-out totalOrderTickets 산정 (event 필드 / 폴백)")
     class StartFanoutTotalTicketsTest {
 
         @Test
-        @DisplayName("다중 이벤트 주문 — Commerce orderInfo 의 quantity 합으로 totalTickets 산정")
-        void 다중이벤트_합산() {
-            stubFanout(List.of(orderItem(2), orderItem(3)));
+        @DisplayName("event.totalOrderTickets > 0 — 그대로 OrderRefund.totalTickets 로 사용 (다중 이벤트 합산값)")
+        void event_필드_사용() {
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
-            orchestrator.start(newRequested(PaymentMethod.PG, false));
+            orchestrator.start(newRequested(PaymentMethod.PG, false, 5));
 
             assertThat(savedLedger().getTotalTickets()).isEqualTo(5);
         }
 
         @Test
-        @DisplayName("단일 이벤트 — Commerce 응답 quantity 그대로")
-        void 단일이벤트() {
-            stubFanout(List.of(orderItem(4)));
+        @DisplayName("event.totalOrderTickets == 1 — 단일 이벤트 단일 티켓 주문")
+        void 단일_티켓() {
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
-            orchestrator.start(newRequested(PaymentMethod.PG, false));
+            orchestrator.start(newRequested(PaymentMethod.PG, false, 1));
 
-            assertThat(savedLedger().getTotalTickets()).isEqualTo(4);
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(1);
         }
 
         @Test
-        @DisplayName("Commerce 호출 예외 — ticketIds.size() 로 폴백")
-        void commerce_예외_폴백() {
-            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            given(paymentRepository.findByPaymentId(paymentId))
-                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
-            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
-            given(commerceInternalClient.getOrderInfo(orderId))
-                .willThrow(new RuntimeException("commerce down"));
+        @DisplayName("event.totalOrderTickets == 0 (구버전 in-flight 메시지) — ticketIds.size() 로 폴백")
+        void 구버전_메시지_폴백() {
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             UUID t1 = UUID.randomUUID();
             UUID t2 = UUID.randomUUID();
             RefundRequestedEvent event = new RefundRequestedEvent(
                 refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
-                List.of(t1, t2), 5_000, 100, false, "r", Instant.now()
+                List.of(t1, t2), 5_000, 100, false, "r", Instant.now(), 0
             );
             orchestrator.start(event);
 
@@ -381,41 +373,15 @@ class RefundSagaOrchestratorTest {
         }
 
         @Test
-        @DisplayName("Commerce 응답 null — ticketIds.size() 로 폴백")
-        void commerce_null_폴백() {
-            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            given(paymentRepository.findByPaymentId(paymentId))
-                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
-            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
-            given(commerceInternalClient.getOrderInfo(orderId)).willReturn(null);
+        @DisplayName("event.totalOrderTickets == 0 + ticketIds 빈 리스트 — 최소값 1 보장 (OrderRefund.create 제약 통과)")
+        void 폴백_최소값_1() {
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
+            // 구버전 메시지에서 wholeOrder=true 인 경우 ticketIds 가 빈 리스트일 수 있음
             RefundRequestedEvent event = new RefundRequestedEvent(
                 refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
-                List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()),
-                5_000, 100, false, "r", Instant.now()
-            );
-            orchestrator.start(event);
-
-            assertThat(savedLedger().getTotalTickets()).isEqualTo(3);
-        }
-
-        @Test
-        @DisplayName("Commerce 응답 orderItems null — ticketIds.size() 로 폴백")
-        void commerce_orderItems_null_폴백() {
-            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            given(paymentRepository.findByPaymentId(paymentId))
-                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
-            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
-            given(commerceInternalClient.getOrderInfo(orderId))
-                .willReturn(new InternalOrderInfoResponse(orderId, userId, "x", 1_000, "PAID", "t", null));
-            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
-
-            RefundRequestedEvent event = new RefundRequestedEvent(
-                refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
-                List.of(UUID.randomUUID()), 5_000, 100, false, "r", Instant.now()
+                List.of(), 5_000, 100, true, "r", Instant.now(), 0
             );
             orchestrator.start(event);
 
@@ -423,35 +389,16 @@ class RefundSagaOrchestratorTest {
         }
 
         @Test
-        @DisplayName("Commerce 응답 orderItems 빈 리스트 — ticketIds.size() 로 폴백")
-        void commerce_orderItems_빈리스트_폴백() {
-            stubFanout(List.of());
+        @DisplayName("event.totalOrderTickets 음수 — 폴백 처리")
+        void 음수_방어() {
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             RefundRequestedEvent event = new RefundRequestedEvent(
                 refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
-                List.of(UUID.randomUUID(), UUID.randomUUID()), 5_000, 100, false, "r", Instant.now()
+                List.of(UUID.randomUUID()), 5_000, 100, false, "r", Instant.now(), -3
             );
             orchestrator.start(event);
-
-            assertThat(savedLedger().getTotalTickets()).isEqualTo(2);
-        }
-
-        @Test
-        @DisplayName("ticketIds 가 빈 리스트 + Commerce 폴백 — 최소값 1 보장")
-        void wholeOrder_빈ticketIds_최소값1() {
-            given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
-            given(paymentRepository.findByPaymentId(paymentId))
-                .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
-            given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
-            given(commerceInternalClient.getOrderInfo(orderId))
-                .willThrow(new RuntimeException("commerce down"));
-            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
-
-            // wholeOrder=true + ticketIds 빈 리스트 — Commerce 도 실패. OrderRefund.create 가 totalTickets <= 0 이면 throw 하므로
-            // 폴백이 최소 1 을 보장해야 한다.
-            orchestrator.start(newRequested(PaymentMethod.PG, true));
 
             assertThat(savedLedger().getTotalTickets()).isEqualTo(1);
         }
@@ -475,13 +422,12 @@ class RefundSagaOrchestratorTest {
             verify(refundTicketRepository, never()).saveAll(any());
             verify(outboxService, never()).save(any(), any(), any(), any(), any());
             verify(paymentRepository, never()).findByPaymentId(any());
-            verify(commerceInternalClient, never()).getOrderInfo(any());
         }
 
         @Test
         @DisplayName("결제수단 WALLET — provisioning + saga 진행")
         void wallet_정상동작() {
-            stubFanout(List.of(orderItem(1)));
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             orchestrator.start(newRequested(PaymentMethod.WALLET, false));
@@ -494,7 +440,7 @@ class RefundSagaOrchestratorTest {
         @Test
         @DisplayName("결제수단 WALLET_PG — provisioning + saga 진행")
         void walletPg_정상동작() {
-            stubFanout(List.of(orderItem(1)));
+            stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             orchestrator.start(newRequested(PaymentMethod.WALLET_PG, false));
@@ -507,20 +453,13 @@ class RefundSagaOrchestratorTest {
 
     // ====== 헬퍼 ======
 
-    private void stubFanout(List<InternalOrderInfoResponse.OrderItem> orderItems) {
+    /** Commerce fan-out 진입 stub — Refund/SagaState 미존재, Payment 존재, OrderRefund 미존재 */
+    private void stubFanout() {
         given(sagaStateRepository.findByRefundId(refundId)).willReturn(Optional.empty());
         given(refundRepository.findByRefundId(refundId)).willReturn(Optional.empty());
         given(paymentRepository.findByPaymentId(paymentId))
             .willReturn(Optional.of(mockPayment(PaymentMethod.PG)));
         given(orderRefundRepository.findByOrderId(orderId)).willReturn(Optional.empty());
-        given(commerceInternalClient.getOrderInfo(orderId))
-            .willReturn(new InternalOrderInfoResponse(
-                orderId, userId, "test", 10_000, "PAID", "2025-01-01T00:00:00", orderItems
-            ));
-    }
-
-    private InternalOrderInfoResponse.OrderItem orderItem(int quantity) {
-        return new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), quantity);
     }
 
     private static <T> org.mockito.stubbing.Answer<T> echo() {

--- a/payment/src/test/java/com/devticket/payment/refund/domain/model/RefundTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/domain/model/RefundTest.java
@@ -1,0 +1,176 @@
+package com.devticket.payment.refund.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.devticket.payment.refund.domain.enums.RefundStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class RefundTest {
+
+    @Nested
+    @DisplayName("create — refundId 자동 생성")
+    class CreateTest {
+
+        @Test
+        @DisplayName("refundId 가 자동으로 새 UUID 로 발급된다")
+        void refundId_자동발급() {
+            Refund a = Refund.create(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100);
+            Refund b = Refund.create(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100);
+
+            assertThat(a.getRefundId()).isNotNull();
+            assertThat(b.getRefundId()).isNotNull();
+            assertThat(a.getRefundId()).isNotEqualTo(b.getRefundId());
+        }
+
+        @Test
+        @DisplayName("초기 상태 REQUESTED, requestedAt 설정")
+        void 초기상태() {
+            LocalDateTime before = LocalDateTime.now().minusSeconds(1);
+            Refund refund = Refund.create(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100);
+            LocalDateTime after = LocalDateTime.now().plusSeconds(1);
+
+            assertThat(refund.getStatus()).isEqualTo(RefundStatus.REQUESTED);
+            assertThat(refund.getRequestedAt()).isBetween(before, after);
+            assertThat(refund.getCompletedAt()).isNull();
+            assertThat(refund.getDeletedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("orderRefundId 없는 오버로드 — null 로 저장")
+        void orderRefundId_생략() {
+            Refund refund = Refund.create(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100);
+            assertThat(refund.getOrderRefundId()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("createWithId — 외부에서 주어진 refundId 보존")
+    class CreateWithIdTest {
+
+        @Test
+        @DisplayName("event.refundId 가 그대로 entity 에 저장된다 — Commerce fan-out 보존")
+        void refundId_보존() {
+            UUID externalRefundId = UUID.randomUUID();
+            UUID orderRefundId = UUID.randomUUID();
+            UUID orderId = UUID.randomUUID();
+            UUID paymentId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            Refund refund = Refund.createWithId(
+                externalRefundId, orderRefundId, orderId, paymentId, userId, 12_000, 80
+            );
+
+            assertThat(refund.getRefundId()).isEqualTo(externalRefundId);
+            assertThat(refund.getOrderRefundId()).isEqualTo(orderRefundId);
+            assertThat(refund.getOrderId()).isEqualTo(orderId);
+            assertThat(refund.getPaymentId()).isEqualTo(paymentId);
+            assertThat(refund.getUserId()).isEqualTo(userId);
+            assertThat(refund.getRefundAmount()).isEqualTo(12_000);
+            assertThat(refund.getRefundRate()).isEqualTo(80);
+        }
+
+        @Test
+        @DisplayName("동일 refundId 로 두 번 호출해도 entity 의 refundId 는 유지된다")
+        void 동일_refundId_반복() {
+            UUID id = UUID.randomUUID();
+            Refund a = Refund.createWithId(id, null, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100);
+            Refund b = Refund.createWithId(id, null, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100);
+
+            assertThat(a.getRefundId()).isEqualTo(id);
+            assertThat(b.getRefundId()).isEqualTo(id);
+        }
+
+        @Test
+        @DisplayName("초기 상태 REQUESTED + requestedAt 설정 — create 와 동일")
+        void 초기상태() {
+            Refund refund = Refund.createWithId(
+                UUID.randomUUID(), null, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100
+            );
+
+            assertThat(refund.getStatus()).isEqualTo(RefundStatus.REQUESTED);
+            assertThat(refund.getRequestedAt()).isNotNull();
+            assertThat(refund.getCompletedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("orderRefundId null 허용")
+        void orderRefundId_null() {
+            Refund refund = Refund.createWithId(
+                UUID.randomUUID(), null, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100
+            );
+            assertThat(refund.getOrderRefundId()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 변경")
+    class StatusTransitionTest {
+
+        @Test
+        @DisplayName("complete — status COMPLETED + completedAt 설정")
+        void complete() {
+            Refund refund = Refund.createWithId(
+                UUID.randomUUID(), null, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100
+            );
+            LocalDateTime canceledAt = LocalDateTime.now();
+
+            refund.complete(canceledAt);
+
+            assertThat(refund.getStatus()).isEqualTo(RefundStatus.COMPLETED);
+            assertThat(refund.getCompletedAt()).isEqualTo(canceledAt);
+        }
+
+        @Test
+        @DisplayName("fail — status FAILED")
+        void fail() {
+            Refund refund = Refund.createWithId(
+                UUID.randomUUID(), null, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100
+            );
+
+            refund.fail();
+
+            assertThat(refund.getStatus()).isEqualTo(RefundStatus.FAILED);
+        }
+
+        @Test
+        @DisplayName("approve — status APPROVED")
+        void approve() {
+            Refund refund = Refund.createWithId(
+                UUID.randomUUID(), null, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100
+            );
+
+            refund.approve();
+
+            assertThat(refund.getStatus()).isEqualTo(RefundStatus.APPROVED);
+        }
+
+        @Test
+        @DisplayName("reject — status REJECTED")
+        void reject() {
+            Refund refund = Refund.createWithId(
+                UUID.randomUUID(), null, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100
+            );
+
+            refund.reject();
+
+            assertThat(refund.getStatus()).isEqualTo(RefundStatus.REJECTED);
+        }
+
+        @Test
+        @DisplayName("softDelete — deletedAt 설정")
+        void softDelete() {
+            Refund refund = Refund.createWithId(
+                UUID.randomUUID(), null, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 1_000, 100
+            );
+            LocalDateTime before = LocalDateTime.now().minusSeconds(1);
+
+            refund.softDelete();
+
+            assertThat(refund.getDeletedAt()).isAfter(before);
+        }
+    }
+}

--- a/payment/src/test/java/com/devticket/payment/refund/integration/RefundSagaIntegrationTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/integration/RefundSagaIntegrationTest.java
@@ -122,7 +122,8 @@ class RefundSagaIntegrationTest {
             100,
             false,
             "integration-test",
-            Instant.now()
+            Instant.now(),
+            1
         );
 
         publishOutbox(
@@ -168,7 +169,7 @@ class RefundSagaIntegrationTest {
             refund.getRefundId(), ledger.getOrderRefundId(), payment.getOrderId(),
             payment.getUserId(), payment.getPaymentId(), payment.getPaymentMethod(),
             List.of(UUID.randomUUID()), payment.getAmount(), 100, false,
-            "integration-test", Instant.now()
+            "integration-test", Instant.now(), 1
         );
         publishOutbox(
             refund.getRefundId().toString(),


### PR DESCRIPTION
## Summary

운영 로그(2026-04-30 KST) 에서 발생한 어드민/판매자 일괄 환불 saga 부정합의 근본 원인 수정.

#679 가 동일 이슈에서 재시도 의미 없는 부정합을 즉시 DLT 분류하는 사후 조치였다면, 본 PR 은 **부정합 자체가 발생하지 않도록** Payment 측 saga 진입점을 보강하고, 후속 리팩터로 saga 진입 시 동기 HTTP 호출도 제거한다.

```
ERROR --- c.d.p.r.p.consumer.RefundSagaConsumer    : [Saga.Inconsistency] refund.order.done — Refund/SagaState 레코드 미발견.
  messageId=943f64b2-..., partition=0, offset=14
  payload={"refundId":"e5ee2688-...","orderId":"f214ce96-...","timestamp":"2026-04-30T08:53:09..."}
RefundException: 환불 내역을 찾을 수 없습니다.
```

## 배경 / 문제

환불 saga 진입점은 4 가지:

| 흐름 | 진입점 | refundId 발급 | Refund row 생성 |
|---|---|---|---|
| 사용자 티켓 단건 환불 | `RefundServiceImpl.refundPgTicket` | Payment | 발행 전 Payment 가 사전 생성 ✓ |
| 사용자 주문 전체 환불 | `RefundServiceImpl.refundOrder` | Payment | 발행 전 Payment 가 사전 생성 ✓ |
| 티켓 발급 실패 → 환불 | `TicketIssueFailedHandler` | Payment | 발행 전 Payment 가 사전 생성 ✓ |
| **어드민/판매자 강제취소 fan-out** | Commerce `RefundFanoutService` | **Commerce** | **누구도 생성 안 함** ❌ |

fan-out 경로에서 Commerce 가 새 `refundId` 를 발급해 `refund.requested` 를 발행하지만 Payment `RefundSagaOrchestrator.start()` 가 SagaState 만 저장하고 Refund row 를 만들지 않음. `refund.order.done` 도착 시 `refundRepository.findByRefundId(...)` 가 비어 있어 `REFUND_NOT_FOUND` → DLT.

이게 #679 의 `[Saga.Inconsistency] refund.order.done` 마커 로그가 가리키는 정확한 케이스.

## 변경 사항 (4 커밋)

| 트랙 | 내용 | 커밋 |
|---|---|---|
| A | fan-out 경로에서 Refund/OrderRefund/RefundTicket 멱등 upsert | `fix(payment): Commerce fan-out 환불에서 Refund/OrderRefund 누락으로 saga 부정합 해결` |
| B | 다중 이벤트 주문 부분 강제취소 시 totalTickets 정확히 산정 (CommerceInternalClient 도입) | `fix(payment): 다중 이벤트 주문 강제취소 시 OrderRefund.totalTickets 정확히 산정` |
| C | `start()` 프로비저닝 + `Refund` 엔티티 테스트 보강 (22 + 12 케이스) | `test(payment): RefundSagaOrchestrator.start 프로비저닝 + Refund 엔티티 테스트 보강` |
| D | RefundRequestedEvent 에 `totalOrderTickets` 추가, Payment 의 동기 HTTP 호출 제거 | `refactor(payment): RefundRequestedEvent 자체완결화 — totalOrderTickets 필드 추가` |

### 트랙 A — fan-out 프로비저닝 멱등 upsert

- `Refund.createWithId(refundId, ...)` 팩토리 추가 — Commerce 발급 refundId 보존.
- `RefundSagaOrchestrator.start()` 안에 `provisionRefundRecords(event)` 추가:
  - `refundRepository.findByRefundId(...)` 비어있을 때만 `Payment` 조회 → `OrderRefund` upsert → `Refund` 생성 → `RefundTicket.saveAll`.
  - 사용자 직접 환불 경로는 Refund 가 이미 있어 자동 스킵 (멱등).
- `Refund` 엔티티 `create()` / `createWithId()` 분기.

### 트랙 B — 다중 이벤트 주문 totalTickets

`OrderRefund.totalTickets` 가 작게 잡히면 `applyRefund` 가 `newTickets > totalTickets` 로 거부되거나 `FULL` 상태가 되어 다음 saga 가 `ALREADY_REFUNDED` 로 거부됨. `CommerceInternalClient.getOrderInfo(orderId)` 로 OrderItem.quantity 합계 조회. 호출 실패 시 `ticketIds.size()` 폴백.

### 트랙 C — 테스트 보강

- `RefundSagaOrchestratorTest.start` 4 개 nested 그룹 (22 케이스):
  - 사용자 직접 환불 경로 (Refund 선존재) — provisioning 스킵 검증, cancel 페이로드, SagaState 초기화
  - Commerce fan-out 경로 — 전체 프로비저닝, refundId 보존, 필드 매핑, RefundTicket 저장, ledger 재사용, Payment 미존재
  - totalTickets 산정 — 다중/단일, Commerce 예외/null/orderItems null/empty 폴백, 최소값 1 보장
  - 멱등성/결제수단 — SagaState 선존재 전체 스킵, WALLET / WALLET_PG
- `RefundTest` 신규 (12 케이스): create / createWithId / approve / complete / fail / reject / softDelete

### 트랙 D — 이벤트 자체완결화 (CommerceInternalClient 의존 제거)

트랙 B 의 동기 HTTP 호출은 saga 진입 레이턴시 + Commerce 장애 시 폴백 코드 부담을 늘린다. RefundRequestedEvent 발행 시점에 발행자가 이미 totalTickets 를 알고 있으므로 이벤트 페이로드로 옮긴다.

- DTO `RefundRequestedEvent` 에 `int totalOrderTickets` 추가
- 발행자 3 곳 모두 채움:
  - `RefundServiceImpl.refundPgTicket` → `ledger.getTotalTickets()`
  - `RefundServiceImpl.refundOrder` → 기존 `totalTickets` 변수
  - `TicketIssueFailedHandler` → `ledger.getTotalTickets()`
- Commerce 측은 `RefundFanoutService` 가 OrderItem.quantity 합으로 채움 (별건 PR — Commerce 모듈)
- Orchestrator `provisionRefundRecords` 가 `event.totalOrderTickets()` 직접 사용:
  - `> 0` 이면 그대로 사용
  - `<= 0` (구버전 in-flight 메시지) 이면 `ticketIds.size()` 폴백, 최소 1 보장
- `CommerceInternalClient` 필드/import + `inferOrderTotalTickets()` 헬퍼 제거

## 변경 파일

| 파일 | 트랙 | 변경 |
|---|---|---|
| `refund/domain/model/Refund.java` | A | `createWithId()` 팩토리 추가 |
| `refund/application/saga/RefundSagaOrchestrator.java` | A, B, D | `start()` 에 `provisionRefundRecords` 추가 → CommerceInternalClient 의존 제거 → `event.totalOrderTickets()` 사용 |
| `refund/application/saga/event/RefundRequestedEvent.java` | D | `int totalOrderTickets` 필드 추가 |
| `refund/application/service/RefundServiceImpl.java` | D | 발행 시 totalOrderTickets 채움 (2 곳) |
| `refund/presentation/consumer/TicketIssueFailedHandler.java` | D | 발행 시 totalOrderTickets 채움 |
| `refund/application/saga/RefundSagaOrchestratorTest.java` | C, D | 4 nested 그룹 22 케이스 + Commerce 모킹 제거 |
| `refund/domain/model/RefundTest.java` | C | 신규 12 케이스 |
| `refund/integration/RefundSagaIntegrationTest.java` | D | 신규 시그니처 반영 |

## 호환성

`RefundRequestedEvent` 는 Java record + Jackson — 기존 in-flight 메시지에 `totalOrderTickets` 필드 없으면 missing primitive int → 0 으로 디시리얼라이즈됨. Orchestrator `resolveTotalOrderTickets` 가 `<= 0` 일 때 `ticketIds.size()` 폴백, 최소 1 보장 → 옛 메시지 안전 처리.

배포 순서 자유: Payment 먼저 배포돼도 Commerce 가 옛 페이로드로 발행 → 0 폴백. Commerce 가 먼저 배포돼도 Payment 옛 코드는 새 필드 무시.

## Test plan

- [x] `./gradlew :payment:compileJava :payment:compileTestJava` — BUILD SUCCESSFUL
- [x] `./gradlew :payment:test --tests "*Refund*" --tests "*TicketIssueFailed*"` — 99/100 통과 (1 건 실패는 `RefundPgTicketConcurrencyIntegrationTest` Testcontainers Docker 환경 의존, 본 변경과 무관)
- [x] 환불 4 진입 경로 모두 회귀 없음 확인:
  - 사용자 티켓 단건 (`RefundServiceImplSagaTest`)
  - 사용자 주문 전체 (`RefundServiceImplSagaTest`)
  - 티켓 발급 실패 → 환불 (`TicketIssueFailedHandler` 경로)
  - 어드민/판매자 fan-out (`RefundSagaIntegrationTest`, `RefundSagaInconsistencyIntegrationTest`)
- [ ] CI 통과
- [ ] 배포 후 운영(k3s `app=payment`)에서 `[Saga.Inconsistency] refund.order.done` 마커 로그 미발생 확인
  - 점검 쿼리: `{app="payment"} |~ "Saga.Inconsistency"`
- [ ] DLT 토픽(`refund.order.done.DLT`) lag 정상화 확인

## 영향 범위 (Payment 모듈 단독)

| 요소 | 변경 |
|---|---|
| `RefundRequestedEvent` 페이로드 | `int totalOrderTickets` 필드 1 개 추가 (호환성 유지) |
| `Refund` / `OrderRefund` / `RefundTicket` 엔티티 | 변경 없음 |
| DB 스키마 (`payment.refund`, `payment.order_refund`, `payment.refund_ticket`) | 변경 없음 |
| Kafka 토픽 / 헤더 / partitionKey | 변경 없음 |
| Public API | 변경 없음 |
| `CommerceInternalClient` 다른 호출처 (`RefundServiceImpl`, `WalletPgTimeoutHandler`, `PaymentServiceImpl`) | 변경 없음 — 클래스 자체는 유지, 본 모듈에선 Orchestrator 만 의존 끊음 |

## 관련 PR

- 후행 의존 — Commerce 측 `RefundFanoutService` 가 신규 필드 채워 발행하도록 함 (별건 PR)
- 선행 — #679 (`[Payment] fix: 사후 보정 readOnly TX 분리 및 환불 saga 부정합 즉시 DLT 분류`) — 본 PR 은 같은 이슈의 근본 원인 수정으로, 머지 후 #679 의 `[Saga.Inconsistency]` 마커 로그가 정상 케이스에서는 발생하지 않게 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xV2kF3RVgRXKBEHDR42S)_