### PR TITLE
[Commerce] feat: RefundRequestedEvent 에 totalOrderTickets 추가 — Payment 동기 HTTP 호출 제거

### DIFF
--- a/commerce/src/main/java/com/devticket/commerce/common/messaging/event/refund/RefundRequestedEvent.java
+++ b/commerce/src/main/java/com/devticket/commerce/common/messaging/event/refund/RefundRequestedEvent.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 // Commerce fan-out → Payment Orchestrator 진입점.
 // orderRefundId 는 null 로 보내면 Payment 가 upsert (Payment 가 원장 소유).
+// totalOrderTickets 는 주문 전체 티켓 수 — Payment 가 OrderRefund 원장의 totalTickets 로 사용.
 public record RefundRequestedEvent(
     UUID refundId,
     UUID orderRefundId,
@@ -19,7 +20,8 @@ public record RefundRequestedEvent(
     int refundRate,
     boolean wholeOrder,
     String reason,
-    Instant timestamp
+    Instant timestamp,
+    int totalOrderTickets
 ) {
 
 }

--- a/commerce/src/main/java/com/devticket/commerce/order/application/service/RefundFanoutService.java
+++ b/commerce/src/main/java/com/devticket/commerce/order/application/service/RefundFanoutService.java
@@ -81,8 +81,8 @@ public class RefundFanoutService {
             // 환불 금액 — 대상 티켓 합계로 한정 (다중 이벤트 주문의 과환불 방지).
             // 티켓 : OrderItem = N:1 (결제 완료 시 OrderItem.quantity 만큼 티켓 생성),
             // 각 티켓의 단가는 해당 OrderItem.price 와 동일하므로 단가 × 티켓수 로 산정.
-            Map<UUID, Integer> priceByOrderItemId = orderItemRepository.findAllByOrderId(order.getId())
-                .stream()
+            List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(order.getId());
+            Map<UUID, Integer> priceByOrderItemId = orderItems.stream()
                 .collect(Collectors.toMap(OrderItem::getOrderItemId, OrderItem::getPrice));
             int refundAmount = targetTickets.stream()
                 .mapToInt(t -> priceByOrderItemId.getOrDefault(t.getOrderItemId(), 0))
@@ -96,6 +96,9 @@ public class RefundFanoutService {
 
             List<UUID> ticketIds = targetTickets.stream().map(Ticket::getTicketId).toList();
             boolean wholeOrder = ticketIds.size() == orderTickets.size();
+            // 주문 전체 티켓 수 — Payment 가 OrderRefund 원장의 totalTickets 로 사용.
+            // 다중 이벤트 주문 부분 강제취소 시에도 원장이 정확하도록 모든 OrderItem.quantity 합계로 산정.
+            int totalOrderTickets = orderItems.stream().mapToInt(OrderItem::getQuantity).sum();
 
             RefundRequestedEvent request = new RefundRequestedEvent(
                 UUID.randomUUID(),           // refundId — Commerce 생성
@@ -109,7 +112,8 @@ public class RefundFanoutService {
                 100,                          // refundRate — 강제 취소는 100%
                 wholeOrder,                   // 대상 티켓이 주문 전체 티켓과 일치할 때만 true
                 reason,
-                now
+                now,
+                totalOrderTickets
             );
             outboxService.save(
                 order.getOrderId().toString(),

--- a/commerce/src/test/java/com/devticket/commerce/order/application/service/RefundFanoutServiceTest.java
+++ b/commerce/src/test/java/com/devticket/commerce/order/application/service/RefundFanoutServiceTest.java
@@ -160,6 +160,9 @@ class RefundFanoutServiceTest {
             .containsExactlyInAnyOrder(c1.getTicketId(), c2.getTicketId());
         // 다른 이벤트 티켓이 남아있으므로 wholeOrder = false
         org.assertj.core.api.Assertions.assertThat(published.wholeOrder()).isFalse();
+        // 주문 전체 티켓 수 — Payment 의 OrderRefund 원장 totalTickets 계산용
+        // cancelledItem.quantity(2) + otherItem.quantity(3) = 5
+        org.assertj.core.api.Assertions.assertThat(published.totalOrderTickets()).isEqualTo(5);
     }
 
     @Test
@@ -267,6 +270,8 @@ class RefundFanoutServiceTest {
         org.assertj.core.api.Assertions.assertThat(published.refundAmount()).isEqualTo(20_000);
         org.assertj.core.api.Assertions.assertThat(published.ticketIds()).hasSize(2);
         org.assertj.core.api.Assertions.assertThat(published.refundRate()).isEqualTo(100);
+        // 단일 이벤트 단일 OrderItem(quantity=2) — totalOrderTickets = 2
+        org.assertj.core.api.Assertions.assertThat(published.totalOrderTickets()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Payment 가 강제취소 fan-out 환불 saga 진입 시 `OrderRefund.totalTickets` 산정을 위해 `CommerceInternalClient.getOrderInfo()` 동기 HTTP 호출을 하던 것을 제거한다. Commerce 가 fan-out 시점에 이미 OrderItem 들을 로딩하므로 주문 전체 티켓 수를 이벤트 페이로드에 담아 발행하면 Payment 가 self-contained 로 saga 진행 가능.

#690 ([Payment] PR) 와 한 쌍.

## 배경 / 문제

#690 트랙 B 에서 다중 이벤트 주문 부분 강제취소 시 `OrderRefund.totalTickets` 가 작게 잡혀 `applyRefund` 가 `newTickets > totalTickets` 로 거부되거나 `FULL` 상태가 되어 다음 saga 가 `ALREADY_REFUNDED` 로 거부되는 엣지 케이스를 해결하려고 Payment 가 `CommerceInternalClient.getOrderInfo(orderId)` 로 OrderItem.quantity 합계를 조회하도록 함.

문제점:
- saga 가 이벤트 기반인데 진입점에서 동기 HTTP 호출 — 디자인 어색
- Commerce 장애 시 폴백(`ticketIds.size()`) 코드 부담
- Payment → Commerce 호출 레이턴시 + 장애 전파

해결: Commerce 가 발행하는 `RefundRequestedEvent` 에 `totalOrderTickets` 를 한 필드 추가하면 Payment 는 HTTP 호출 없이 saga 진행 가능. Commerce 는 fan-out 루프에서 이미 `orderItemRepository.findAllByOrderId(...)` 로 OrderItem 들을 로딩하고 있어 추가 DB 쿼리도 불필요.

## 변경 사항

### DTO

`commerce/.../common/messaging/event/refund/RefundRequestedEvent.java` 에 `int totalOrderTickets` 필드 추가.

```java
public record RefundRequestedEvent(
    UUID refundId,
    UUID orderRefundId,
    UUID orderId,
    UUID userId,
    UUID paymentId,
    PaymentMethod paymentMethod,
    List<UUID> ticketIds,
    int refundAmount,
    int refundRate,
    boolean wholeOrder,
    String reason,
    Instant timestamp,
    int totalOrderTickets  // ← 추가
) { }
```

### Producer

`RefundFanoutService.processEventForceCancelled` 가 fan-out 루프에서 이미 `orderItemRepository.findAllByOrderId(order.getId())` 로 OrderItem 들을 로딩하고 있어 추가 쿼리 없이 quantity 합계 산정.

```java
List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(order.getId());
Map<UUID, Integer> priceByOrderItemId = orderItems.stream()
    .collect(Collectors.toMap(OrderItem::getOrderItemId, OrderItem::getPrice));
int refundAmount = ...;

// 주문 전체 티켓 수 — Payment 가 OrderRefund 원장의 totalTickets 로 사용.
// 다중 이벤트 주문 부분 강제취소 시에도 원장이 정확하도록 모든 OrderItem.quantity 합계로 산정.
int totalOrderTickets = orderItems.stream().mapToInt(OrderItem::getQuantity).sum();

RefundRequestedEvent request = new RefundRequestedEvent(
    UUID.randomUUID(), null, order.getOrderId(), order.getUserId(),
    order.getPaymentId(), order.getPaymentMethod(),
    ticketIds, refundAmount, 100, wholeOrder, reason, now,
    totalOrderTickets   // ← 추가
);
```

### 다중 이벤트 주문 시나리오 검증

주문 1 건에 event A (quantity=2) + event B (quantity=3) 의 OrderItem 이 섞여 있고 event A 만 강제취소되면:
- 기존: Payment 가 ticketIds.size() = 2 로 totalTickets 잡음 → ledger.status=FULL → event B 의 다음 fan-out 이 ALREADY_REFUNDED 로 거부 ❌
- 변경: Commerce 가 totalOrderTickets = 5 (2+3) 로 발행 → Payment ledger.totalTickets = 5 → event A fan-out 후 PARTIAL, event B fan-out 후 FULL ✓

## 변경 파일

| 파일 | 변경 |
|---|---|
| `commerce/.../common/messaging/event/refund/RefundRequestedEvent.java` | `int totalOrderTickets` 필드 추가 + 주석 |
| `commerce/.../order/application/service/RefundFanoutService.java` | `findAllByOrderId` 결과를 변수로 보존 → quantity 합계 산정 → 이벤트 페이로드 전달 |
| `commerce/.../order/application/service/RefundFanoutServiceTest.java` | 발행 이벤트의 `totalOrderTickets` assertion 추가 (다중 이벤트 합산 / 단일 이벤트 단일 OrderItem) |

## 호환성

`RefundRequestedEvent` 는 Java record + Jackson — Payment 측 옛 버전은 새 필드를 무시 (`FAIL_ON_UNKNOWN_PROPERTIES=false` 가정). Payment 새 버전은 옛 페이로드(필드 없음 → primitive int = 0) 를 폴백 처리 (#690 Orchestrator `resolveTotalOrderTickets` 가 `<= 0` 일 때 `ticketIds.size()` 사용, 최소 1 보장).

배포 순서 자유 — 어느 쪽이 먼저 배포돼도 saga 진행에 문제 없음.

## Test plan

- [x] `./gradlew :commerce:compileJava :commerce:compileTestJava` — BUILD SUCCESSFUL
- [x] `./gradlew :commerce:test --tests "*RefundFanoutServiceTest*"` — 통과
  - 다중 이벤트 주문(cancelledItem.quantity=2 + otherItem.quantity=3) → `totalOrderTickets=5` assertion
  - 단일 이벤트 단일 OrderItem(quantity=2) → `totalOrderTickets=2` assertion
- [x] `./gradlew :commerce:test` 전체 회귀 — 161/161 통과
- [ ] CI 통과
- [ ] 배포 후 Payment 측 `[Saga.Inconsistency]` 마커 로그 + DLT lag 정상화 확인 (#690 Test plan)

## 영향 범위 (Commerce 모듈 단독)

| 요소 | 변경 |
|---|---|
| `RefundRequestedEvent` 페이로드 | `int totalOrderTickets` 필드 1 개 추가 (호환성 유지) |
| `RefundFanoutService` 동작 | 추가 DB 쿼리 없음 — 기존 `findAllByOrderId` 결과 재사용 |
| Outbox / Kafka 토픽 / 헤더 | 변경 없음 |
| Public API / 다른 도메인 | 변경 없음 |
| DB 스키마 | 변경 없음 |

## 관련 PR

- #690 ([Payment]) — 본 PR 의 짝. Payment 가 새 필드를 사용하고 `CommerceInternalClient` 의존을 제거함. 두 PR 은 어느 순서로 머지/배포돼도 호환됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xV2kF3RVgRXKBEHDR42S)_