### PR TITLE
[Payment] fix: totalOrderTickets 폴백에서 다중 이벤트 주문 과소계산 방지 — Commerce 안전망 복원

### DIFF
--- a/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
+++ b/payment/src/main/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestrator.java
@@ -7,6 +7,8 @@ import com.devticket.payment.payment.application.dto.PgPaymentCancelResult;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
+import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
+import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderInfoResponse;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.refund.application.saga.event.RefundOrderCancelEvent;
 import com.devticket.payment.refund.application.saga.event.RefundOrderCompensateEvent;
@@ -56,6 +58,7 @@ public class RefundSagaOrchestrator {
     private final OutboxService outboxService;
     private final PgPaymentClient pgPaymentClient;
     private final WalletService walletService;
+    private final CommerceInternalClient commerceInternalClient;
 
     /**
      * Saga 진입점 — refund.requested 수신 또는 ticket.issue-failed 수신 시 호출. SagaState 생성 + refund.order.cancel 발행.
@@ -501,14 +504,38 @@ public class RefundSagaOrchestrator {
     }
 
     /**
-     * 이벤트의 totalOrderTickets 우선 사용. 0 이하(구버전 in-flight 메시지 호환) 인 경우만
-     * ticketIds 크기로 폴백. OrderRefund.create 의 totalTickets > 0 제약을 위해 최소 1 보장.
+     * totalTickets 산정 — 우선순위:
+     * (1) event.totalOrderTickets > 0 — 빠른 경로 (정상 케이스, HTTP 호출 없음)
+     * (2) Commerce getOrderInfo 의 OrderItem.quantity 합계 — 구버전 메시지/롤링 배포 안전망
+     * (3) ticketIds.size() — Commerce 도 실패 시 최후 폴백 (단, 다중 이벤트 주문에서는 과소계산 가능)
+     *
+     * <p>(2) 는 정상 트래픽에서 호출되지 않음 (Commerce 가 totalOrderTickets 를 채워 발행).
+     * 다만 Payment 가 Commerce 보다 먼저 배포되는 롤링 구간에서 옛 페이로드 (필드 없음 → 0) 가
+     * 들어와도 다중 이벤트 주문 부분 강제취소가 ledger 한도에 걸려 실패하지 않도록 안전망 유지.
      */
     private int resolveTotalOrderTickets(RefundRequestedEvent event) {
         if (event.totalOrderTickets() > 0) {
             return event.totalOrderTickets();
         }
+        int commerceTotal = lookupCommerceTotalTickets(event.orderId());
+        if (commerceTotal > 0) {
+            return commerceTotal;
+        }
         int fallback = event.ticketIds() == null ? 0 : event.ticketIds().size();
         return Math.max(fallback, 1);
+    }
+
+    private int lookupCommerceTotalTickets(UUID orderId) {
+        try {
+            InternalOrderInfoResponse info = commerceInternalClient.getOrderInfo(orderId);
+            if (info != null && info.orderItems() != null && !info.orderItems().isEmpty()) {
+                return info.orderItems().stream()
+                    .mapToInt(InternalOrderInfoResponse.OrderItem::quantity)
+                    .sum();
+            }
+        } catch (Exception e) {
+            log.warn("[Saga] Commerce orderInfo 조회 실패 — orderId={}, ticketIds.size() 폴백", orderId, e);
+        }
+        return 0;
     }
 }

--- a/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
+++ b/payment/src/test/java/com/devticket/payment/refund/application/saga/RefundSagaOrchestratorTest.java
@@ -15,6 +15,8 @@ import com.devticket.payment.payment.application.dto.PgPaymentCancelResult;
 import com.devticket.payment.payment.domain.enums.PaymentMethod;
 import com.devticket.payment.payment.domain.model.Payment;
 import com.devticket.payment.payment.domain.repository.PaymentRepository;
+import com.devticket.payment.payment.infrastructure.client.CommerceInternalClient;
+import com.devticket.payment.payment.infrastructure.client.dto.InternalOrderInfoResponse;
 import com.devticket.payment.payment.infrastructure.external.PgPaymentClient;
 import com.devticket.payment.refund.application.saga.event.RefundOrderDoneEvent;
 import com.devticket.payment.refund.application.saga.event.RefundOrderFailedEvent;
@@ -69,6 +71,8 @@ class RefundSagaOrchestratorTest {
     PgPaymentClient pgPaymentClient;
     @Mock
     WalletService walletService;
+    @Mock
+    CommerceInternalClient commerceInternalClient;
 
     @InjectMocks
     RefundSagaOrchestrator orchestrator;
@@ -330,22 +334,23 @@ class RefundSagaOrchestratorTest {
     }
 
     @Nested
-    @DisplayName("start — fan-out totalOrderTickets 산정 (event 필드 / 폴백)")
+    @DisplayName("start — fan-out totalOrderTickets 산정 (event > Commerce > ticketIds 폴백)")
     class StartFanoutTotalTicketsTest {
 
         @Test
-        @DisplayName("event.totalOrderTickets > 0 — 그대로 OrderRefund.totalTickets 로 사용 (다중 이벤트 합산값)")
-        void event_필드_사용() {
+        @DisplayName("(1) event.totalOrderTickets > 0 — 빠른 경로, Commerce 호출 없음")
+        void event_필드_빠른경로() {
             stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             orchestrator.start(newRequested(PaymentMethod.PG, false, 5));
 
             assertThat(savedLedger().getTotalTickets()).isEqualTo(5);
+            verify(commerceInternalClient, never()).getOrderInfo(any());
         }
 
         @Test
-        @DisplayName("event.totalOrderTickets == 1 — 단일 이벤트 단일 티켓 주문")
+        @DisplayName("(1) event.totalOrderTickets == 1 — 단일 티켓 주문, Commerce 호출 없음")
         void 단일_티켓() {
             stubFanout();
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
@@ -353,19 +358,45 @@ class RefundSagaOrchestratorTest {
             orchestrator.start(newRequested(PaymentMethod.PG, false, 1));
 
             assertThat(savedLedger().getTotalTickets()).isEqualTo(1);
+            verify(commerceInternalClient, never()).getOrderInfo(any());
         }
 
         @Test
-        @DisplayName("event.totalOrderTickets == 0 (구버전 in-flight 메시지) — ticketIds.size() 로 폴백")
-        void 구버전_메시지_폴백() {
+        @DisplayName("(2) event.totalOrderTickets == 0 (롤링 배포 옛 페이로드) — Commerce orderInfo 의 quantity 합산")
+        void 옛_페이로드_Commerce_폴백() {
             stubFanout();
+            given(commerceInternalClient.getOrderInfo(orderId))
+                .willReturn(new InternalOrderInfoResponse(
+                    orderId, userId, "x", 50_000, "PAID", "2026-01-01T00:00:00",
+                    List.of(
+                        new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), 2),
+                        new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), 3)
+                    )
+                ));
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
-            UUID t1 = UUID.randomUUID();
-            UUID t2 = UUID.randomUUID();
+            // event A 만 강제취소 → ticketIds.size()=2 지만 주문 전체는 5장
             RefundRequestedEvent event = new RefundRequestedEvent(
                 refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
-                List.of(t1, t2), 5_000, 100, false, "r", Instant.now(), 0
+                List.of(UUID.randomUUID(), UUID.randomUUID()), 5_000, 100, false, "r", Instant.now(), 0
+            );
+            orchestrator.start(event);
+
+            // ticketIds.size()=2 가 아닌 Commerce 합산값 5 사용 — 다중 이벤트 ledger 한도 거부 방지
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("(3) event=0 + Commerce 예외 — ticketIds.size() 로 최후 폴백")
+        void Commerce_예외_최후폴백() {
+            stubFanout();
+            given(commerceInternalClient.getOrderInfo(orderId))
+                .willThrow(new RuntimeException("commerce down"));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            RefundRequestedEvent event = new RefundRequestedEvent(
+                refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
+                List.of(UUID.randomUUID(), UUID.randomUUID()), 5_000, 100, false, "r", Instant.now(), 0
             );
             orchestrator.start(event);
 
@@ -373,12 +404,67 @@ class RefundSagaOrchestratorTest {
         }
 
         @Test
-        @DisplayName("event.totalOrderTickets == 0 + ticketIds 빈 리스트 — 최소값 1 보장 (OrderRefund.create 제약 통과)")
-        void 폴백_최소값_1() {
+        @DisplayName("(3) event=0 + Commerce null — ticketIds.size() 로 최후 폴백")
+        void Commerce_null_최후폴백() {
             stubFanout();
+            given(commerceInternalClient.getOrderInfo(orderId)).willReturn(null);
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
-            // 구버전 메시지에서 wholeOrder=true 인 경우 ticketIds 가 빈 리스트일 수 있음
+            RefundRequestedEvent event = new RefundRequestedEvent(
+                refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
+                List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()),
+                5_000, 100, false, "r", Instant.now(), 0
+            );
+            orchestrator.start(event);
+
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("(3) event=0 + Commerce orderItems null — ticketIds.size() 로 최후 폴백")
+        void Commerce_orderItems_null_최후폴백() {
+            stubFanout();
+            given(commerceInternalClient.getOrderInfo(orderId))
+                .willReturn(new InternalOrderInfoResponse(orderId, userId, "x", 1_000, "PAID", "t", null));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            RefundRequestedEvent event = new RefundRequestedEvent(
+                refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
+                List.of(UUID.randomUUID()), 5_000, 100, false, "r", Instant.now(), 0
+            );
+            orchestrator.start(event);
+
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("(3) event=0 + Commerce orderItems 빈 리스트 — ticketIds.size() 로 최후 폴백")
+        void Commerce_orderItems_빈리스트_최후폴백() {
+            stubFanout();
+            given(commerceInternalClient.getOrderInfo(orderId))
+                .willReturn(new InternalOrderInfoResponse(
+                    orderId, userId, "x", 1_000, "PAID", "t", List.of()
+                ));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            RefundRequestedEvent event = new RefundRequestedEvent(
+                refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
+                List.of(UUID.randomUUID(), UUID.randomUUID()), 5_000, 100, false, "r", Instant.now(), 0
+            );
+            orchestrator.start(event);
+
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("(3) event=0 + ticketIds 빈 리스트 + Commerce 도 비어있음 — 최소값 1 보장 (OrderRefund.create 제약)")
+        void 모든_폴백_실패_최소값_1() {
+            stubFanout();
+            given(commerceInternalClient.getOrderInfo(orderId))
+                .willThrow(new RuntimeException("commerce down"));
+            given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
+
+            // wholeOrder=true 옛 페이로드 + Commerce 도 실패 — 그래도 saga 자체는 진행 (최소 1)
             RefundRequestedEvent event = new RefundRequestedEvent(
                 refundId, null, orderId, userId, paymentId, PaymentMethod.PG,
                 List.of(), 5_000, 100, true, "r", Instant.now(), 0
@@ -389,9 +475,14 @@ class RefundSagaOrchestratorTest {
         }
 
         @Test
-        @DisplayName("event.totalOrderTickets 음수 — 폴백 처리")
+        @DisplayName("event.totalOrderTickets 음수 — Commerce 폴백 경로 진입 (>0 빠른 경로 가드)")
         void 음수_방어() {
             stubFanout();
+            given(commerceInternalClient.getOrderInfo(orderId))
+                .willReturn(new InternalOrderInfoResponse(
+                    orderId, userId, "x", 1_000, "PAID", "t",
+                    List.of(new InternalOrderInfoResponse.OrderItem(UUID.randomUUID(), 4))
+                ));
             given(orderRefundRepository.save(any(OrderRefund.class))).willAnswer(echo());
 
             RefundRequestedEvent event = new RefundRequestedEvent(
@@ -400,7 +491,7 @@ class RefundSagaOrchestratorTest {
             );
             orchestrator.start(event);
 
-            assertThat(savedLedger().getTotalTickets()).isEqualTo(1);
+            assertThat(savedLedger().getTotalTickets()).isEqualTo(4);
         }
     }
 
@@ -422,6 +513,7 @@ class RefundSagaOrchestratorTest {
             verify(refundTicketRepository, never()).saveAll(any());
             verify(outboxService, never()).save(any(), any(), any(), any(), any());
             verify(paymentRepository, never()).findByPaymentId(any());
+            verify(commerceInternalClient, never()).getOrderInfo(any());
         }
 
         @Test


### PR DESCRIPTION
## Summary

#690 의 follow-up. 머지 후 codex-connector 의 P1 리뷰 코멘트(https://github.com/prgrms-be-adv-devcourse/beadv5_1_HeadbuttingDinosaur_BE/pull/690#discussion_r3168630526)에서 지적된, `totalOrderTickets` 폴백이 `ticketIds.size()` 만으로는 정상 트래픽에서도 saga 실패로 이어질 수 있는 케이스 수정.

## 배경 / 문제

#690 머지된 `resolveTotalOrderTickets` 폴백:

```java
private int resolveTotalOrderTickets(RefundRequestedEvent event) {
    if (event.totalOrderTickets() > 0) {
        return event.totalOrderTickets();
    }
    int fallback = event.ticketIds() == null ? 0 : event.ticketIds().size();
    return Math.max(fallback, 1);
}
```

봇이 짚은 시나리오:
- Payment 가 Commerce 보다 먼저 배포되는 롤링 구간에서 Commerce 는 옛 포맷 (필드 없음 → `totalOrderTickets=0`) 으로 계속 발행
- 다중 이벤트 주문 (event A 2 장 + event B 3 장) 부분 강제취소:
  - event A fan-out → Payment 가 `ticketIds.size()=2` 로 `OrderRefund.totalTickets=2` 잡음 → ledger 한도 잠김
  - event B fan-out → 같은 `OrderRefund` 재사용 → `applyRefund(amount, 3)` → `newTickets(0+3) > totalTickets(2)` → `REFUND_INVALID_REQUEST` → saga 실패 → DLT
- "in-flight 옛 메시지만 안전" 이 아니라 **롤링 배포 중 정상 트래픽** 에서도 발생

## 변경 사항

폴백 체인을 3 단계로 재정비. 정상 케이스는 **빠른 경로 그대로** (Commerce HTTP 호출 없음), `totalOrderTickets <= 0` 일 때만 안전망 진입:

```java
private int resolveTotalOrderTickets(RefundRequestedEvent event) {
    if (event.totalOrderTickets() > 0) {              // (1) 빠른 경로
        return event.totalOrderTickets();
    }
    int commerceTotal = lookupCommerceTotalTickets(event.orderId());  // (2) Commerce 안전망
    if (commerceTotal > 0) {
        return commerceTotal;
    }
    int fallback = event.ticketIds() == null ? 0 : event.ticketIds().size();  // (3) 최후 폴백
    return Math.max(fallback, 1);
}

private int lookupCommerceTotalTickets(UUID orderId) {
    try {
        InternalOrderInfoResponse info = commerceInternalClient.getOrderInfo(orderId);
        if (info != null && info.orderItems() != null && !info.orderItems().isEmpty()) {
            return info.orderItems().stream()
                .mapToInt(InternalOrderInfoResponse.OrderItem::quantity)
                .sum();
        }
    } catch (Exception e) {
        log.warn("[Saga] Commerce orderInfo 조회 실패 — orderId={}, ticketIds.size() 폴백", orderId, e);
    }
    return 0;
}
```

산정 우선순위:
1. **`event.totalOrderTickets > 0`** — 빠른 경로 (정상 케이스, HTTP 호출 없음)
2. **Commerce `getOrderInfo` 의 `OrderItem.quantity` 합계** — 옛 페이로드/롤링 안전망
3. **`ticketIds.size()` (최소 1)** — Commerce 도 실패 시 최후 폴백

`CommerceInternalClient` 필드/import 복원 — `lookupCommerceTotalTickets` 헬퍼 안에서만 사용. 정상 트래픽에선 호출되지 않으므로 (1) 빠른 경로 의도 유지.

## 변경 파일

| 파일 | 변경 |
|---|---|
| `refund/application/saga/RefundSagaOrchestrator.java` | `CommerceInternalClient` 필드/import 복원, `lookupCommerceTotalTickets` 헬퍼 추가, `resolveTotalOrderTickets` 3 단계 폴백으로 재정비 |
| `refund/application/saga/RefundSagaOrchestratorTest.java` | `StartFanoutTotalTicketsTest` 8 케이스로 재구성 (Commerce 모킹 복원) |

## 테스트 — `StartFanoutTotalTicketsTest` 8 케이스

- **(1) 빠른 경로 2 건** — `verify(commerceInternalClient, never()).getOrderInfo(any())` 로 정상 트래픽에선 HTTP 호출 안 함을 명시 검증
  - `event.totalOrderTickets > 0` (5 인 경우)
  - `event.totalOrderTickets == 1` 단일 티켓 주문
- **(2) Commerce 합산 1 건** — 봇 시나리오 직접 재현
  - `event.totalOrderTickets=0` + Commerce 응답에 OrderItem(quantity=2) + OrderItem(quantity=3) → ledger.totalTickets = 5
- **(3) Commerce 폴백 실패 5 건** — 마지막 폴백 진입
  - Commerce 예외 → ticketIds.size()
  - Commerce null 응답 → ticketIds.size()
  - Commerce orderItems null → ticketIds.size()
  - Commerce orderItems 빈 리스트 → ticketIds.size()
  - ticketIds 빈 리스트 + Commerce 도 실패 → 최소값 1
- **음수 방어 1 건** — `totalOrderTickets=-3` 도 `> 0` 가드에 막혀 (2) 경로 진입 검증

## Test plan

- [x] `./gradlew :payment:compileJava :payment:compileTestJava` — BUILD SUCCESSFUL
- [x] `./gradlew :payment:test --tests "*RefundSagaOrchestratorTest*"` — 41/41 통과
- [x] `./gradlew :payment:test --tests "*Refund*" --tests "*TicketIssueFailed*"` — 103/104 통과 (1 건 실패는 Testcontainers Docker 환경 의존, 본 변경과 무관)
- [ ] CI 통과
- [ ] 배포 후 운영 모니터링:
  - `[Saga.Inconsistency] refund.order.done` 마커 로그 미발생 확인 (점검 쿼리: `{app="payment"} |~ "Saga.Inconsistency"`)
  - `[Saga] Commerce orderInfo 조회 실패` 폴백 로그 발생 빈도 — 롤링 배포 종료 후 0 건 수렴해야 정상

## 호환성

- 정상 트래픽 (`totalOrderTickets > 0`) 은 빠른 경로 — 추가 HTTP 호출 없음, 레이턴시 영향 없음
- 롤링 구간에선 (2) 경로 진입 — Commerce 측 PR (이미 머지됨) 배포 완료 시 자연 소멸
- (3) 최후 폴백은 Commerce 장애 + 옛 페이로드 동시 발생 시에만 진입 — 매우 드문 케이스

## 영향 범위 (Payment 모듈 단독)

| 요소 | 변경 |
|---|---|
| `RefundSagaOrchestrator` 의존성 | `CommerceInternalClient` 추가 (Bean 이미 등록되어 있음, `RefundServiceImpl`/`PaymentServiceImpl`/`WalletPgTimeoutHandler` 사용 중) |
| `RefundRequestedEvent` 페이로드 | 변경 없음 |
| `Refund` / `OrderRefund` / `RefundTicket` 엔티티 | 변경 없음 |
| DB 스키마 | 변경 없음 |
| Kafka 토픽 / 헤더 | 변경 없음 |
| Public API | 변경 없음 |

## 관련 PR

- #690 ([Payment] fix: Commerce fan-out 환불 saga 부정합 해결 + RefundRequestedEvent 자체완결화) — 본 PR 의 선행. 머지 후 codex-connector 가 본 케이스를 P1 리뷰로 지적
- #691 ([Commerce] feat: totalOrderTickets 추가) — Commerce 측 짝, 머지됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xV2kF3RVgRXKBEHDR42S)_