### PR TITLE
[Event] fix: 종료된 이벤트 환불 시 cancelledQuantity 카운터 누적

### DIFF
--- a/event/src/main/java/com/devticket/event/application/RefundStockRestoreService.java
+++ b/event/src/main/java/com/devticket/event/application/RefundStockRestoreService.java
@@ -75,8 +75,11 @@ public class RefundStockRestoreService {
             if (target.getStatus() == EventStatus.CANCELLED
                 || target.getStatus() == EventStatus.FORCE_CANCELLED
                 || target.getStatus() == EventStatus.ENDED) {
-                log.warn("[정책적 스킵] refund 재고 복구 — eventId={}, status={}, refundId={}",
-                    item.eventId(), target.getStatus(), event.refundId());
+                // 종료된 이벤트 — 재고 복구는 스킵하되 cancelledQuantity 는 누적해서
+                // "결제됐다가 영구 환불된 티켓 수" 통계를 보존.
+                target.markCancelledStock(item.quantity());
+                log.warn("[정책적 스킵] refund 재고 복구 — eventId={}, status={}, refundId={}, cancelledQuantity={}",
+                    item.eventId(), target.getStatus(), event.refundId(), target.getCancelledQuantity());
                 continue;
             }
 

--- a/event/src/main/java/com/devticket/event/domain/model/Event.java
+++ b/event/src/main/java/com/devticket/event/domain/model/Event.java
@@ -199,6 +199,19 @@ public class Event extends BaseEntity {
         }
     }
 
+    /**
+     * 종료된 이벤트(CANCELLED / FORCE_CANCELLED / ENDED)의 환불 카운터.
+     * remainingQuantity 는 그대로 두고 cancelledQuantity 만 누적.
+     * 운영 대시보드 / 정산에서 "결제됐다가 영구 환불된 티켓 수" 추적 용도.
+     */
+    public void markCancelledStock(int quantity) {
+        if (quantity < 1) {
+            throw new BusinessException(EventErrorCode.INVALID_STOCK_QUANTITY);
+        }
+        int current = this.cancelledQuantity == null ? 0 : this.cancelledQuantity;
+        this.cancelledQuantity = current + quantity;
+    }
+
     public void expireSale() {
         if ((this.status == EventStatus.ON_SALE || this.status == EventStatus.SOLD_OUT)
                 && LocalDateTime.now().isAfter(this.saleEndAt)) {

--- a/event/src/test/java/com/devticket/event/application/RefundStockRestoreServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/RefundStockRestoreServiceTest.java
@@ -137,11 +137,11 @@ class RefundStockRestoreServiceTest {
     }
 
     @Nested
-    @DisplayName("정책적 스킵")
+    @DisplayName("정책적 스킵 — cancelledQuantity 누적")
     class PolicySkip {
 
         @Test
-        @DisplayName("FORCE_CANCELLED 이벤트는 재고 복구를 스킵하고 그래도 done 을 발행한다")
+        @DisplayName("FORCE_CANCELLED — 재고 복구 스킵 + cancelledQuantity 누적 + done 발행")
         void skip_forceCancelled() {
             ReflectionTestUtils.setField(testEvent, "status", EventStatus.FORCE_CANCELLED);
             eventRepository.saveAndFlush(testEvent);
@@ -153,7 +153,9 @@ class RefundStockRestoreServiceTest {
                 messageId, KafkaTopics.REFUND_STOCK_RESTORE, payload);
 
             Event updated = eventRepository.findByEventId(eventId).orElseThrow();
-            assertThat(updated.getRemainingQuantity()).isEqualTo(95);
+            assertThat(updated.getRemainingQuantity()).isEqualTo(95);          // 재고 복구 안 됨
+            assertThat(updated.getCancelledQuantity()).isEqualTo(5);           // cancelled 누적
+            assertThat(updated.getStatus()).isEqualTo(EventStatus.FORCE_CANCELLED);
             assertThat(processedMessageRepository.existsByMessageId(messageId.toString())).isTrue();
 
             List<Outbox> outboxes = outboxRepository.findAll();
@@ -162,7 +164,7 @@ class RefundStockRestoreServiceTest {
         }
 
         @Test
-        @DisplayName("CANCELLED 이벤트도 재고 복구를 스킵한다")
+        @DisplayName("CANCELLED — 재고 복구 스킵 + cancelledQuantity 누적")
         void skip_cancelled() {
             ReflectionTestUtils.setField(testEvent, "status", EventStatus.CANCELLED);
             eventRepository.saveAndFlush(testEvent);
@@ -175,7 +177,57 @@ class RefundStockRestoreServiceTest {
 
             Event updated = eventRepository.findByEventId(eventId).orElseThrow();
             assertThat(updated.getRemainingQuantity()).isEqualTo(95);
+            assertThat(updated.getCancelledQuantity()).isEqualTo(5);
             assertThat(outboxRepository.findAll()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("ENDED — 재고 복구 스킵 + cancelledQuantity 누적")
+        void skip_ended() {
+            ReflectionTestUtils.setField(testEvent, "status", EventStatus.ENDED);
+            eventRepository.saveAndFlush(testEvent);
+
+            UUID messageId = UUID.randomUUID();
+            String payload = buildPayload(refundId, orderId, eventId, 3);
+
+            refundStockRestoreService.handleRefundStockRestore(
+                messageId, KafkaTopics.REFUND_STOCK_RESTORE, payload);
+
+            Event updated = eventRepository.findByEventId(eventId).orElseThrow();
+            assertThat(updated.getRemainingQuantity()).isEqualTo(95);
+            assertThat(updated.getCancelledQuantity()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("정상 분기는 cancelledQuantity 변경 없음 — restoreStock 만 호출")
+        void normalRestore_doesNotTouchCancelled() {
+            UUID messageId = UUID.randomUUID();
+            String payload = buildPayload(refundId, orderId, eventId, 5);
+
+            refundStockRestoreService.handleRefundStockRestore(
+                messageId, KafkaTopics.REFUND_STOCK_RESTORE, payload);
+
+            Event updated = eventRepository.findByEventId(eventId).orElseThrow();
+            assertThat(updated.getRemainingQuantity()).isEqualTo(100);
+            assertThat(updated.getCancelledQuantity()).isZero();
+        }
+
+        @Test
+        @DisplayName("동일 messageId 재처리 — cancelledQuantity 도 dedup 으로 1회만 누적")
+        void cancelledQuantity_dedup() {
+            ReflectionTestUtils.setField(testEvent, "status", EventStatus.FORCE_CANCELLED);
+            eventRepository.saveAndFlush(testEvent);
+
+            UUID messageId = UUID.randomUUID();
+            String payload = buildPayload(refundId, orderId, eventId, 5);
+
+            refundStockRestoreService.handleRefundStockRestore(
+                messageId, KafkaTopics.REFUND_STOCK_RESTORE, payload);
+            refundStockRestoreService.handleRefundStockRestore(
+                messageId, KafkaTopics.REFUND_STOCK_RESTORE, payload);
+
+            Event updated = eventRepository.findByEventId(eventId).orElseThrow();
+            assertThat(updated.getCancelledQuantity()).isEqualTo(5);  // 5 + 5 = 10 이 아님 (dedup)
         }
     }
 

--- a/event/src/test/java/com/devticket/event/domain/model/EventDomainTest.java
+++ b/event/src/test/java/com/devticket/event/domain/model/EventDomainTest.java
@@ -218,5 +218,93 @@ class EventDomainTest {
             assertThat(event.getRemainingQuantity()).isEqualTo(8);
             assertThat(event.getStatus()).isEqualTo(EventStatus.ON_SALE);
         }
+
+        @Test
+        @DisplayName("정상 복원은 cancelledQuantity 를 변경하지 않는다 (자리 비우기 의미)")
+        void normalRestore_doesNotTouchCancelledQuantity() {
+            Event event = onSaleEvent(TOTAL_QUANTITY, MAX_PER_USER);
+            setRemaining(event, 5);
+
+            event.restoreStock(3);
+
+            assertThat(event.getCancelledQuantity()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("markCancelledStock — 종료 이벤트 환불 카운터")
+    class MarkCancelledStockTest {
+
+        @Test
+        @DisplayName("quantity < 1 이면 INVALID_STOCK_QUANTITY")
+        void invalidQuantity() {
+            Event event = onSaleEvent(TOTAL_QUANTITY, MAX_PER_USER);
+
+            assertThatThrownBy(() -> event.markCancelledStock(0))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EventErrorCode.INVALID_STOCK_QUANTITY);
+        }
+
+        @Test
+        @DisplayName("FORCE_CANCELLED 이벤트 — cancelledQuantity 누적, remainingQuantity 변동 없음")
+        void forceCancelled_accumulates() {
+            Event event = onSaleEvent(TOTAL_QUANTITY, MAX_PER_USER);
+            setStatus(event, EventStatus.FORCE_CANCELLED);
+            setRemaining(event, 6);
+
+            event.markCancelledStock(2);
+
+            assertThat(event.getCancelledQuantity()).isEqualTo(2);
+            assertThat(event.getRemainingQuantity()).isEqualTo(6);
+            assertThat(event.getStatus()).isEqualTo(EventStatus.FORCE_CANCELLED);
+        }
+
+        @Test
+        @DisplayName("CANCELLED 이벤트 — cancelledQuantity 누적, status 유지")
+        void cancelled_accumulates() {
+            Event event = onSaleEvent(TOTAL_QUANTITY, MAX_PER_USER);
+            setStatus(event, EventStatus.CANCELLED);
+            setRemaining(event, 6);
+
+            event.markCancelledStock(3);
+
+            assertThat(event.getCancelledQuantity()).isEqualTo(3);
+            assertThat(event.getRemainingQuantity()).isEqualTo(6);
+        }
+
+        @Test
+        @DisplayName("ENDED 이벤트도 cancelledQuantity 누적 가능 (운영 통계)")
+        void ended_accumulates() {
+            Event event = onSaleEvent(TOTAL_QUANTITY, MAX_PER_USER);
+            setStatus(event, EventStatus.ENDED);
+
+            event.markCancelledStock(1);
+
+            assertThat(event.getCancelledQuantity()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("연속 호출 시 누적된다 (멱등 X — 호출자가 dedup 책임)")
+        void multipleCalls_accumulate() {
+            Event event = onSaleEvent(TOTAL_QUANTITY, MAX_PER_USER);
+            setStatus(event, EventStatus.FORCE_CANCELLED);
+
+            event.markCancelledStock(2);
+            event.markCancelledStock(3);
+
+            assertThat(event.getCancelledQuantity()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("ON_SALE 이벤트에 호출되면 cancelledQuantity 만 증가 (가드 없음 — 호출처 책임)")
+        void onSale_alsoAccumulates() {
+            // RefundStockRestoreService 는 ON_SALE 분기에선 restoreStock 만 호출하므로
+            // 이 메서드가 ON_SALE 에 호출될 일은 없지만, 도메인 자체는 status 가드 없이 단순 증가만 한다.
+            Event event = onSaleEvent(TOTAL_QUANTITY, MAX_PER_USER);
+
+            event.markCancelledStock(1);
+
+            assertThat(event.getCancelledQuantity()).isEqualTo(1);
+        }
     }
 }


### PR DESCRIPTION
## Summary

운영 점검 — 셀러가 이벤트 강제취소한 후 이벤트 응답에서 `cancelledQuantity` 가 0 으로 남아 환불된 티켓 수 통계가 부재한 이슈 수정.

```json
{
  "totalQuantity": 100,
  "soldQuantity": 4,
  "remainingQuantity": 96,
  "cancelledQuantity": 0,    // ← 4여야 정상 (강제취소된 티켓 4장)
  "status": "CANCELLED"
}
```

## 배경 / 문제

`RefundStockRestoreService.handleRefundStockRestore` (line 75-81):

```java
if (target.getStatus() == EventStatus.CANCELLED
    || target.getStatus() == EventStatus.FORCE_CANCELLED
    || target.getStatus() == EventStatus.ENDED) {
    log.warn("[정책적 스킵] refund 재고 복구 — eventId={}, status={}, refundId={}", ...);
    continue;  // ← restoreStock 호출 안 함 → cancelledQuantity 도 변동 없음
}
target.restoreStock(item.quantity());
```

### 정책적 skip 자체는 합리적

- `Event.restoreStock` 이 `CANCELLED / FORCE_CANCELLED / ENDED` 상태면 `CANNOT_CHANGE_STATUS` 예외 throw (line 191-194)
- 종료된 이벤트의 재고를 복구해서 "남은 수량 96" 으로 표시하는 건 의미 없음
- saga 흐름 자체는 정상 진행 (skip 후 `refund.stock.done` 발행)

### 그러나 통계 부산물 누락

- `cancelledQuantity` 필드는 도메인에 있지만 (Event.java line 81: `private Integer cancelledQuantity = 0`), **증가시키는 메서드가 아예 없음**
- 운영 대시보드 / 정산에서 "강제취소로 환불된 티켓 누적 수" 추적 불가

## 변경 사항

### 1. `Event.markCancelledStock(int)` 도메인 메서드 신규

```java
/**
 * 종료된 이벤트(CANCELLED / FORCE_CANCELLED / ENDED)의 환불 카운터.
 * remainingQuantity 는 그대로 두고 cancelledQuantity 만 누적.
 * 운영 대시보드 / 정산에서 "결제됐다가 영구 환불된 티켓 수" 추적 용도.
 */
public void markCancelledStock(int quantity) {
    if (quantity < 1) {
        throw new BusinessException(EventErrorCode.INVALID_STOCK_QUANTITY);
    }
    int current = this.cancelledQuantity == null ? 0 : this.cancelledQuantity;
    this.cancelledQuantity = current + quantity;
}
```

### 2. `RefundStockRestoreService` skip 분기에서 호출

```java
if (target.getStatus() == CANCELLED || FORCE_CANCELLED || ENDED) {
    target.markCancelledStock(item.quantity());  // ← 추가
    log.warn("[정책적 스킵] refund 재고 복구 — eventId={}, status={}, refundId={}, cancelledQuantity={}",
        item.eventId(), target.getStatus(), event.refundId(), target.getCancelledQuantity());
    continue;
}
target.restoreStock(item.quantity());
```

### 정상 분기 (`ON_SALE / SOLD_OUT 등`) 는 의도적으로 미변경

- 정상 환불 = "자리 비우기" → `restoreStock` 으로 `remainingQuantity` 증가 → `sold` (derived = total - remaining) 가 자동 차감되어 통계 일관성 유지
- 정상 환불에서도 `cancelled++` 하면:
  - 같은 자리 환불→재판매→또 환불 시 `cancelled` 가 중복 누적 (자리는 1 개인데)
  - "취소된 이벤트의 환불 누적" 의미가 흐려짐 (정산 / 통계 노이즈)
- 따라서 cancelled 카운터는 **종료된 이벤트의 환불에만** 의미 부여 — 좁은 범위 변경으로 의도 명확화

## 시나리오별 결과

### 강제 취소 이벤트 (현 운영 케이스 재현)

```
before: total=100, remaining=96, cancelled=0, status=FORCE_CANCELLED
markCancelledStock(4):  cancelled 0→4
after:  total=100, remaining=96, cancelled=4
응답:   sold=4 (derived), cancelled=4
```

운영자가 "결제 4장 / 강제취소 환불 4장 / 실효매출 0원" 한눈에 보임 (`실효매출 = (sold - cancelled) * price`).

### 정상 이벤트 환불 (기존 동작 그대로)

```
before: total=100, remaining=96, cancelled=0, status=ON_SALE
restoreStock(1):       remaining 96→97
after:  total=100, remaining=97, cancelled=0
응답:   sold=3 (derived 자동 차감), cancelled=0
```

## 변경 파일

| 파일 | 변경 |
|---|---|
| `event/.../domain/model/Event.java` | `markCancelledStock(int)` 메서드 신규 |
| `event/.../application/RefundStockRestoreService.java` | skip 분기에서 `markCancelledStock` 호출 + 로그에 cancelled 값 추가 |
| `event/.../domain/model/EventDomainTest.java` | `MarkCancelledStockTest` nested 신규 6 케이스 + restoreStock 정상 분기 cancelled 미변경 검증 1 케이스 |
| `event/.../application/RefundStockRestoreServiceTest.java` | `PolicySkip` 그룹 갱신 5 케이스 (FORCE_CANCELLED/CANCELLED/ENDED skip + cancelled++ 검증, 정상 분기 cancelled 미변경, dedup) |

## Test plan

- [x] `./gradlew :event:compileJava :event:compileTestJava` — BUILD SUCCESSFUL
- [x] `./gradlew :event:test --tests "*EventDomainTest*" --tests "*RefundStockRestoreServiceTest*"` — 31/31 통과
- [x] `./gradlew :event:test --tests "*Refund*" --tests "*EventDomainTest*"` — 38/38 통과 (회귀 없음)
- [x] **환불 흐름 전체 모듈 sweep** (251/252 — 1 건은 Testcontainers Docker 환경 의존, 본 변경 무관):
  - Event refund 관련: 38/38 ✓
  - Payment refund/saga/wallet/ticket-issue-failed: 167/168 ✓
  - Commerce refund/event-force-cancelled: 46/46 ✓
- [ ] CI 통과
- [ ] 배포 후 운영 모니터링:
  - 셀러/어드민 강제취소 → 이벤트 응답에 `cancelledQuantity > 0` 확인
  - `[정책적 스킵] refund 재고 복구 ... cancelledQuantity=N` 로그 정상 출력 확인

## 환불 흐름 전체 매핑 (각 모듈 책임 검증)

본 PR 의 변경이 어떤 환불 흐름에 어떻게 영향 끼치는지:

| 환불 흐름 | 진입점 | Event 측 영향 |
|---|---|---|
| 사용자 티켓 단건 환불 | Payment `RefundServiceImpl.refundPgTicket` | `restoreStock` (정상 분기, 미변경) |
| 사용자 주문 전체 환불 | Payment `RefundServiceImpl.refundOrder` | `restoreStock` (정상 분기, 미변경) |
| 티켓 발급 실패 → 환불 | Payment `TicketIssueFailedHandler` | `restoreStock` (정상 분기, 미변경) |
| **판매자 강제취소** | Payment `cancelSellerEvent` → Event `forceCancel` → Commerce fan-out | **`markCancelledStock` (본 PR 추가, 통계 누적)** |
| **어드민 강제취소** | Payment `cancelAdminEvent` → Event `forceCancel` → Commerce fan-out | **`markCancelledStock` (본 PR 추가, 통계 누적)** |

## 영향 범위 (Event 모듈 단독)

| 요소 | 변경 |
|---|---|
| `Event` 도메인 | `markCancelledStock(int)` 메서드 1 개 추가 |
| `cancelledQuantity` 컬럼 | 이미 존재 (스키마 변경 없음) |
| 응답 DTO (`SellerEventSummaryResponse` 등) | 이미 `cancelledQuantity` 필드 노출 중 — 변경 없음 |
| `RefundStockRestoreService` 동작 | skip 분기에 카운터 호출 1 줄 추가, 정상 분기 변경 없음 |
| Saga 흐름 / Kafka 토픽 / Public API / 다른 모듈 | 변경 없음 |

## 관련 PR

- #695 ([Event] fix: PaymentMethod enum 에 WALLET_PG 추가) — 동일 셀러 강제취소 시나리오의 또 다른 이슈, 기 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xV2kF3RVgRXKBEHDR42S)_