### PR TITLE
[Event] fix: 셀러 강제취소도 환불 fan-out 트리거 — Action A(강제취소+환불) / B(판매중지) 의도 분리

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -334,7 +334,8 @@ public class EventService {
             throw new BusinessException(EventErrorCode.UNAUTHORIZED_SELLER);
         }
 
-        // 판매중지 분기
+        // 판매 중지 분기 (Action B) — 신규 판매만 차단, 기존 구매자 환불 X.
+        // 환불 동반 강제 취소가 필요하면 forceCancel(...) 호출 (Payment.cancelSellerEvent 경유).
         if (EventStatus.CANCELLED.equals(request.status())) {
             if (!event.canBeCancelled()) {
                 throw new BusinessException(EventErrorCode.CANNOT_CHANGE_STATUS);
@@ -420,42 +421,45 @@ public class EventService {
     }
 
     /**
-     * 어드민 강제 취소 — 이벤트 상태를 FORCE_CANCELLED 로 전이하고 event.force-cancelled Outbox 발행.
-     * Commerce 가 이를 수신해 해당 이벤트의 PAID 주문에 대해 환불 fan-out 을 수행한다.
+     * 강제 취소 (Action A) — 이벤트를 FORCE_CANCELLED 로 전이하고 event.force-cancelled Outbox 발행.
+     * Commerce 가 수신해 해당 이벤트의 PAID 주문에 대해 환불 fan-out 을 수행한다.
+     *
+     * <p>호출자별 권한:
+     * <ul>
+     *   <li>ADMIN — 모든 이벤트 가능 (관리자 권한은 gateway/admin-service 에서 사전 검증)</li>
+     *   <li>SELLER — 본인 이벤트만 가능 (소유권 검증)</li>
+     * </ul>
+     *
+     * <p><b>본 액션은 환불을 동반</b>한다. 단순 신규 판매 중단 (Action B — 기존 구매자 영향 없음)은
+     * {@link #updateEvent} 의 {@code status=CANCELLED} 분기로 호출 (별개 흐름).
      */
     @Transactional
     public void forceCancel(UUID userId, String userRole, UUID eventId, String reason) {
         Event event = eventRepository.findByEventIdWithLock(eventId)
             .orElseThrow(() -> new BusinessException(EventErrorCode.EVENT_NOT_FOUND));
 
-        if("ADMIN".equals(userRole)){
-            event.forceCancel();
-            outboxService.save(
-                event.getEventId().toString(),
-                event.getEventId().toString(),
-                "EVENT_FORCE_CANCELLED",
-                KafkaTopics.EVENT_FORCE_CANCELLED,
-                new EventForceCancelledEvent(event.getEventId(), event.getSellerId(), reason, Instant.now())
-            );
-        }
-        else {
+        // SELLER 는 본인 이벤트만 가능 — ADMIN 은 gateway 에서 사전 검증되므로 도메인 검증 생략
+        if ("SELLER".equals(userRole)) {
             if (!event.getSellerId().equals(userId)) {
                 throw new BusinessException(EventErrorCode.UNAUTHORIZED_SELLER);
             }
-            if (!event.canBeCancelled()) {
-                throw new BusinessException(EventErrorCode.CANNOT_CHANGE_STATUS);
-            }
-
-
-        event.cancel();
-            outboxService.save(
-                event.getEventId().toString(),
-                event.getEventId().toString(),
-                "EVENT_SALE_STOPPED",
-                KafkaTopics.EVENT_SALE_STOPPED,
-                new EventSaleStoppedEvent(event.getEventId(), event.getSellerId(), Instant.now())
-            );
+        } else if (!"ADMIN".equals(userRole)) {
+            // 알 수 없는 role — 방어적 거부
+            throw new BusinessException(EventErrorCode.UNAUTHORIZED_SELLER);
         }
+
+        if (!event.canBeCancelled()) {
+            throw new BusinessException(EventErrorCode.CANNOT_CHANGE_STATUS);
+        }
+
+        event.forceCancel();
+        outboxService.save(
+            event.getEventId().toString(),
+            event.getEventId().toString(),
+            "EVENT_FORCE_CANCELLED",
+            KafkaTopics.EVENT_FORCE_CANCELLED,
+            new EventForceCancelledEvent(event.getEventId(), event.getSellerId(), reason, Instant.now())
+        );
 
         elasticsearchSyncService.sync(event);
     }

--- a/event/src/main/java/com/devticket/event/domain/model/Event.java
+++ b/event/src/main/java/com/devticket/event/domain/model/Event.java
@@ -150,10 +150,26 @@ public class Event extends BaseEntity {
         this.category = category;
     }
 
+    /**
+     * 판매 중지 (Action B) — status=CANCELLED 로 전이.
+     * 신규 판매만 차단하고 기존 구매자에게는 영향 없음 — 환불 트리거 X.
+     *
+     * <p>셀러가 "이벤트 수정" 화면에서 status 를 CANCELLED 로 명시 변경할 때만 호출됨
+     * ({@code EventService.updateEvent} 경로).
+     * 기존 구매자 환불을 동반하는 강제 취소는 {@link #forceCancel()} 사용.
+     */
     public void cancel() {
         this.status = EventStatus.CANCELLED;
     }
 
+    /**
+     * 강제 취소 (Action A) — status=FORCE_CANCELLED 로 전이.
+     * 환불 fan-out 을 트리거하므로 기존 구매자에게 환불 처리됨.
+     *
+     * <p>어드민 또는 셀러(본인 이벤트) 의 강제 취소 시 호출됨
+     * ({@code EventService.forceCancel} 경로).
+     * 단순 판매 중단은 {@link #cancel()} 사용.
+     */
     public void forceCancel() {
         if (!canBeCancelled()) {
             throw new BusinessException(EventErrorCode.CANNOT_CHANGE_STATUS);

--- a/event/src/test/java/com/devticket/event/application/EventServiceRefundTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventServiceRefundTest.java
@@ -146,23 +146,41 @@ class EventServiceRefundTest {
         }
 
         @Test
-        @DisplayName("판매자가 본인 이벤트를 취소하면 CANCELLED 로 전이하고 event.sale-stopped Outbox 를 발행한다")
-        void forceCancel_seller_publishesSaleStopped() {
+        @DisplayName("판매자가 본인 이벤트를 강제 취소하면 FORCE_CANCELLED 로 전이하고 event.force-cancelled Outbox 를 발행한다 (환불 트리거)")
+        void forceCancel_seller_publishesForceCancel() {
             given(eventRepository.findByEventIdWithLock(eventId)).willReturn(Optional.of(event));
 
-            eventService.forceCancel(sellerId, "SELLER", eventId, null);
+            eventService.forceCancel(sellerId, "SELLER", eventId, "셀러 본인 강제취소");
 
-            assertThat(event.getStatus()).isEqualTo(EventStatus.CANCELLED);
+            assertThat(event.getStatus()).isEqualTo(EventStatus.FORCE_CANCELLED);
             verify(outboxService, times(1)).save(
                 eq(eventId.toString()),
                 eq(eventId.toString()),
-                eq("EVENT_SALE_STOPPED"),
-                eq(KafkaTopics.EVENT_SALE_STOPPED),
-                argThat(payload -> payload instanceof EventSaleStoppedEvent e
+                eq("EVENT_FORCE_CANCELLED"),
+                eq(KafkaTopics.EVENT_FORCE_CANCELLED),
+                argThat(payload -> payload instanceof EventForceCancelledEvent e
                     && e.eventId().equals(eventId)
                     && e.sellerId().equals(sellerId)
+                    && "셀러 본인 강제취소".equals(e.reason())
                     && e.occurredAt() != null)
             );
+            // sale-stopped 는 발행 안 됨 — 강제취소는 force-cancelled 만
+            verify(outboxService, never()).save(
+                any(), any(), eq("EVENT_SALE_STOPPED"), eq(KafkaTopics.EVENT_SALE_STOPPED), any());
+        }
+
+        @Test
+        @DisplayName("알 수 없는 role 은 UNAUTHORIZED_SELLER 로 거부 (방어적)")
+        void forceCancel_unknownRole_rejected() {
+            given(eventRepository.findByEventIdWithLock(eventId)).willReturn(Optional.of(event));
+
+            assertThatThrownBy(() ->
+                eventService.forceCancel(sellerId, "USER", eventId, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(EventErrorCode.UNAUTHORIZED_SELLER);
+
+            verify(outboxService, never()).save(any(), any(), any(), any(), any());
         }
 
         @Test


### PR DESCRIPTION
## Summary

운영 점검 — 셀러가 본인 이벤트를 Payment `cancelSellerEvent` API 로 강제취소했는데 **환불이 진행 안 되고 status 만 CANCELLED 로 남는 케이스**. `cancelledQuantity=0`, `remainingQuantity` 미증가, 결제완료 사용자 돈 묶임.

```json
{
  "eventId": "57742e5a-18ab-42dc-b2b1-571be7aa481d",
  "status": "CANCELLED",
  "totalQuantity": 100, "remainingQuantity": 96,
  "soldQuantity": 4,
  "cancelledQuantity": 0     // ← 환불 fan-out 자체가 트리거 안 됨
}
```

## 배경 / 원인

### 두 가지 셀러 취소 경로가 있음 — 의도가 명확히 다름

| | Action A — 강제취소 (환불 동반) | Action B — 판매중지 (환불 없음) |
|---|---|---|
| 의도 | 어드민/셀러가 이벤트 자체를 닫으면서 **기존 구매자 환불** | 신규 판매만 차단, **기존 구매자 영향 없음** |
| API | Payment `POST /api/refunds/seller/events/{id}/cancel` (셀러)<br>또는 Payment `POST /api/refunds/admin/events/{id}/cancel` (어드민) | Event `PATCH /api/events/{id}` body `{"status":"CANCELLED"}` (셀러가 본인 이벤트 수정 화면) |
| Event 도메인 | `Event.forceCancel()` → status=`FORCE_CANCELLED` | `Event.cancel()` → status=`CANCELLED` |
| Outbox | `event.force-cancelled` | `event.sale-stopped` (감사 로그용, 컨슈머 의도된 0개) |
| Commerce fan-out | ✓ 환불 진행 | ✗ 처리 안 함 |

### 그러나 코드가 두 경로를 잘못 섞음

`EventService.forceCancel(role, ...)` 가 role 별로 분기:

```java
if ("ADMIN".equals(userRole)) {
    event.forceCancel();    // ✓ 환불 트리거
    outboxService.save(...EVENT_FORCE_CANCELLED...);
} else {
    // SELLER 분기인데 Action B (sale-stopped) 처리로 잘못 라우팅 ❌
    event.cancel();
    outboxService.save(...EVENT_SALE_STOPPED...);  // 컨슈머 0개 → 환불 안 됨
}
```

Payment 의 `cancelSellerEvent` 는 `eventInternalClient.forceCancel(eventId, sellerId, "SELLER", reason)` 호출 — **"강제취소+환불" 의도**. 그런데 Event 측 `forceCancel` 메서드가 SELLER 면 `event.cancel()` 으로 처리해버려 환불이 누락됨.

## 변경 사항

### `EventService.forceCancel` — SELLER 도 ADMIN 과 동일 처리

```java
@Transactional
public void forceCancel(UUID userId, String userRole, UUID eventId, String reason) {
    Event event = eventRepository.findByEventIdWithLock(eventId)
        .orElseThrow(() -> new BusinessException(EventErrorCode.EVENT_NOT_FOUND));

    // SELLER 만 소유권 검증 — ADMIN 은 gateway/admin-service 에서 사전 검증
    if ("SELLER".equals(userRole)) {
        if (!event.getSellerId().equals(userId)) {
            throw new BusinessException(EventErrorCode.UNAUTHORIZED_SELLER);
        }
    } else if (!"ADMIN".equals(userRole)) {
        // 알 수 없는 role 방어적 거부
        throw new BusinessException(EventErrorCode.UNAUTHORIZED_SELLER);
    }

    if (!event.canBeCancelled()) {
        throw new BusinessException(EventErrorCode.CANNOT_CHANGE_STATUS);
    }

    event.forceCancel();  // ADMIN/SELLER 둘 다 동일 — 환불 트리거
    outboxService.save(...EVENT_FORCE_CANCELLED...);
    elasticsearchSyncService.sync(event);
}
```

### Action B (`updateEvent` 의 cancel 분기) — 그대로 유지

신규 판매 차단 의도의 별개 액션. javadoc/주석으로 의도 명확화만:

```java
// 판매 중지 분기 (Action B) — 신규 판매만 차단, 기존 구매자 환불 X.
// 환불 동반 강제 취소가 필요하면 forceCancel(...) 호출 (Payment.cancelSellerEvent 경유).
if (EventStatus.CANCELLED.equals(request.status())) {
    event.cancel();
    outboxService.save(...EVENT_SALE_STOPPED...);  // 감사 로그용, 컨슈머 의도된 0개
    ...
}
```

### `Event.cancel()` / `Event.forceCancel()` javadoc 보강

두 도메인 메서드의 의도 구분 명시 — 향후 호출자가 헷갈리지 않도록.

## 변경 파일

| 파일 | 변경 |
|---|---|
| `event/.../application/EventService.java` | `forceCancel` 의 role 분기 통합 (둘 다 force-cancelled), `updateEvent` cancel 분기 주석 보강 + javadoc |
| `event/.../domain/model/Event.java` | `cancel()` / `forceCancel()` javadoc 보강 (Action A vs B) |
| `event/.../application/EventServiceRefundTest.java` | "셀러가 본인 이벤트 → CANCELLED" 테스트를 "FORCE_CANCELLED + force-cancelled (환불 트리거)" 로 수정, sale-stopped 미발행 verify 추가, 알 수 없는 role 방어적 거부 테스트 추가 |

## Test plan

- [x] `./gradlew :event:compileJava :event:compileTestJava` — BUILD SUCCESSFUL
- [x] `./gradlew :event:test --tests "*EventServiceRefundTest*" --tests "*EventDomainTest*"` — 통과
- [x] `./gradlew :event:test --tests "*RefundStockRestoreServiceTest*"` — 회귀 없음
- [x] **단위 테스트 전체** — 39/39 통과 (33 환경 의존 실패는 Elasticsearch/Kafka 통합 — 본 변경 무관)
- [ ] CI 통과
- [ ] 배포 후 운영 검증:
  - 셀러 강제취소 → 응답 status=`FORCE_CANCELLED` 확인 (이전엔 `CANCELLED`)
  - `event.force-cancelled` Outbox 발행 확인
  - Commerce `RefundFanoutService` 가 fan-out 처리 확인
  - 환불 saga 완료 → `cancelledQuantity > 0` 확인 (#697 와 결합 동작)

## 환불 흐름 매트릭스 (수정 후)

| 진입점 | Event 메서드 | status | Outbox | 환불 |
|---|---|---|---|---|
| Payment `cancelAdminEvent` | `forceCancel("ADMIN")` | FORCE_CANCELLED | force-cancelled | ✓ |
| Payment `cancelSellerEvent` | `forceCancel("SELLER")` (소유권 검증) | **FORCE_CANCELLED** ← 본 PR 수정 | **force-cancelled** ← 본 PR 수정 | **✓** ← 본 PR 수정 |
| Event `updateEvent` (status=CANCELLED) | `Event.cancel()` | CANCELLED | sale-stopped (no-op) | ✗ (의도) |
| Event `updateEvent` 외 일반 수정 | n/a | 변동 없음 | 없음 | ✗ |

## 호환성

- Payment 측 `cancelSellerEvent` API 시그니처/동작 변경 없음 — Event 내부 동작만 수정
- Action B (`updateEvent` 의 cancel 분기) 는 그대로 — 셀러 본인이 "이벤트 수정 → 판매 중지" 액션 그대로 동작
- `event.sale-stopped` 토픽 발행 그대로 (감사 로그용, 컨슈머 의도된 0개)

## 후속 (별건 — 본 PR 범위 밖)

### 1. DB 보정

이 버그로 누락된 환불 데이터 보정 필요:

- 이 버그로 status=CANCELLED 로 잘못 처리된 이벤트 식별 (Action A 의도였는데 sale-stopped 로 처리된 케이스)
- 해당 이벤트의 PAID 주문에 대해 수동 환불 트리거 또는 운영 보정
- `event.events.status` 값 정정 (CANCELLED → FORCE_CANCELLED) + `cancelledQuantity` 보정 (#697 보정 쿼리 활용)

### 2. cancelledQuantity 데이터 정합성

이전 보정에서 `cancelledQuantity > soldQuantity` 같은 어긋남이 발견됨. `payment.refund_ticket` 의 같은 ticket_id 가 여러 COMPLETED row 로 있는지 진단 필요 (DISTINCT 산정 vs 중복 row).

## 관련 PR

- #697 ([Event] fix: cancelledQuantity 카운터 누적) — 본 PR 의 환불 fan-out 정상화 후 `markCancelledStock` 이 정상 호출되어야 의미가 살아남
- #695 ([Event] fix: PaymentMethod enum WALLET_PG) — 같은 셀러 강제취소 시나리오에서 발견된 다른 버그

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xV2kF3RVgRXKBEHDR42S)_