### PR TITLE
[Settlement] perf: 판매자 정산 응답에 eventTitle 직접 포함하여 FE N+1 호출 제거

### DIFF
--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -75,7 +76,8 @@ public class SettlementServiceImpl implements SettlementService {
         List<SettlementItem> settlementItems = settlementItemRepository.findBySettlementId(
             settlement.getSettlementId());
 
-        return toResponse(settlement, settlementItems);
+        Map<UUID, String> eventTitles = fetchEventTitles(settlementItems);
+        return toResponse(settlement, settlementItems, eventTitles);
     }
 
     /**
@@ -236,10 +238,11 @@ public class SettlementServiceImpl implements SettlementService {
     private SettlementPeriodResponse toSettlementPeriodResponse(Settlement settlement) {
         log.debug("[toSettlementPeriodResponse] SettlementItem 조회 시작 - settlementId={}",
             settlement.getSettlementId());
-        List<EventItemResponse> items = settlementItemRepository
-            .findBySettlementId(settlement.getSettlementId())
-            .stream()
-            .map(this::toResponse)
+        List<SettlementItem> settlementItems = settlementItemRepository
+            .findBySettlementId(settlement.getSettlementId());
+        Map<UUID, String> eventTitles = fetchEventTitles(settlementItems);
+        List<EventItemResponse> items = settlementItems.stream()
+            .map(item -> toResponse(item, eventTitles))
             .toList();
         log.debug("[toSettlementPeriodResponse] SettlementItem 조회 완료 - {}건", items.size());
         return new SettlementPeriodResponse(
@@ -272,8 +275,9 @@ public class SettlementServiceImpl implements SettlementService {
 
         long finalSettlementAmount = newSettlementAmount + carriedInAmount;
 
+        Map<UUID, String> eventTitles = fetchEventTitles(readyItems);
         List<EventItemResponse> items = readyItems.stream()
-            .map(this::toResponse)
+            .map(item -> toResponse(item, eventTitles))
             .toList();
 
         return new SettlementPeriodResponse(
@@ -305,9 +309,10 @@ public class SettlementServiceImpl implements SettlementService {
         );
     }
 
-    private SellerSettlementDetailResponse toResponse(Settlement settlement, List<SettlementItem> settlementItems) {
+    private SellerSettlementDetailResponse toResponse(Settlement settlement,
+        List<SettlementItem> settlementItems, Map<UUID, String> eventTitles) {
         List<EventItemResponse> eventItems = settlementItems.stream()
-            .map(this::toResponse)
+            .map(item -> toResponse(item, eventTitles))
             .toList();
 
         return new SellerSettlementDetailResponse(
@@ -324,14 +329,35 @@ public class SettlementServiceImpl implements SettlementService {
         );
     }
 
-    private EventItemResponse toResponse(SettlementItem settlementItem) {
+    private EventItemResponse toResponse(SettlementItem settlementItem, Map<UUID, String> eventTitles) {
+        UUID eventUUID = settlementItem.getEventUUID();
+        String title = eventTitles.getOrDefault(eventUUID, "Unknown");
         return new EventItemResponse(
-            settlementItem.getEventId().toString(),
-            "Unknown",
+            eventUUID != null ? eventUUID.toString() : null,
+            title,
             settlementItem.getSalesAmount(),
             settlementItem.getRefundAmount(),
             settlementItem.getFeeAmount(),
             settlementItem.getSettlementAmount()
         );
+    }
+
+    /**
+     * SettlementItem 목록에서 eventUUID 를 모아 Event 서비스에 일괄 조회한다.
+     * 항목별 단건 호출(N+1) 대신 1회 호출로 eventTitle 을 채운다.
+     */
+    private Map<UUID, String> fetchEventTitles(List<SettlementItem> settlementItems) {
+        if (settlementItems.isEmpty()) {
+            return Map.of();
+        }
+        List<UUID> eventUUIDs = settlementItems.stream()
+            .map(SettlementItem::getEventUUID)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+        if (eventUUIDs.isEmpty()) {
+            return Map.of();
+        }
+        return settlementToEventClient.getEventTitles(eventUUIDs);
     }
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToEventClient.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToEventClient.java
@@ -2,11 +2,18 @@ package com.devticket.settlement.infrastructure.client;
 
 import com.devticket.settlement.common.exception.BusinessException;
 import com.devticket.settlement.common.exception.CommonErrorCode;
+import com.devticket.settlement.infrastructure.client.dto.req.InternalBulkEventInfoRequest;
 import com.devticket.settlement.infrastructure.client.dto.res.EndedEventResponse;
+import com.devticket.settlement.infrastructure.client.dto.res.EventInfoResponse;
 import com.devticket.settlement.infrastructure.client.dto.res.EventServiceResponse;
+import com.devticket.settlement.infrastructure.client.dto.res.InternalBulkEventInfoData;
 import com.devticket.settlement.infrastructure.client.dto.res.InternalEndedEventsData;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ParameterizedTypeReference;
@@ -59,6 +66,55 @@ public class SettlementToEventClient {
         } catch (Exception e) {
             log.error("[SettlementToEventClient] Critical Error: ", e);
             throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 이벤트 ID 목록으로 이벤트 정보를 한 번에 조회.
+     * POST /internal/events/bulk
+     * 응답: SuccessResponse<InternalBulkEventInfoResponse>
+     *   → { status, message, data: { events: [ {eventId, title, ...}, ... ] } }
+     *
+     * 정산 응답에 eventTitle 을 채우기 위해 사용한다. 없는 ID 는 응답에서 누락될 수 있어
+     * 호출 측에서 누락 ID 를 fallback 처리해야 한다.
+     * 외부 호출 실패 시 빈 Map 을 반환하여 정산 조회 자체가 실패하지 않도록 한다.
+     */
+    public Map<UUID, String> getEventTitles(List<UUID> eventIds) {
+        if (eventIds == null || eventIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        List<UUID> distinctIds = eventIds.stream().distinct().toList();
+
+        try {
+            log.debug("[SettlementToEventClient] getEventTitles - count: {}", distinctIds.size());
+
+            EventServiceResponse<InternalBulkEventInfoData> response = restClient.post()
+                .uri("/internal/events/bulk")
+                .body(new InternalBulkEventInfoRequest(distinctIds))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    log.error("[SettlementToEventClient] Bulk API Error: Status {}", res.getStatusCode());
+                    throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
+                })
+                .body(new ParameterizedTypeReference<EventServiceResponse<InternalBulkEventInfoData>>() {});
+
+            if (response == null || response.data() == null || response.data().events() == null) {
+                log.warn("[SettlementToEventClient] bulk 응답 데이터 없음 - count: {}", distinctIds.size());
+                return Collections.emptyMap();
+            }
+
+            return response.data().events().stream()
+                .filter(e -> e.eventId() != null && e.title() != null)
+                .collect(Collectors.toMap(
+                    EventInfoResponse::eventId,
+                    EventInfoResponse::title,
+                    (a, b) -> a
+                ));
+        } catch (Exception e) {
+            // 정산 조회는 본질적으로 SettlementItem 데이터로 동작 가능하므로
+            // 이벤트 제목 보강 실패가 전체 조회 실패로 이어지지 않도록 한다.
+            log.warn("[SettlementToEventClient] getEventTitles 실패 - 빈 Map 으로 fallback: {}", e.getMessage());
+            return Collections.emptyMap();
         }
     }
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/req/InternalBulkEventInfoRequest.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/req/InternalBulkEventInfoRequest.java
@@ -1,0 +1,13 @@
+package com.devticket.settlement.infrastructure.client.dto.req;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Event 서비스 POST /internal/events/bulk 호출 요청 바디.
+ */
+public record InternalBulkEventInfoRequest(
+    List<UUID> eventIds
+) {
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EventInfoResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EventInfoResponse.java
@@ -1,0 +1,16 @@
+package com.devticket.settlement.infrastructure.client.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.UUID;
+
+/**
+ * Event 서비스의 InternalEventInfoResponse에 대응하는 역직렬화 DTO.
+ * 정산에서 필요한 필드(eventId, title)만 매핑한다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record EventInfoResponse(
+    UUID eventId,
+    String title
+) {
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/InternalBulkEventInfoData.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/InternalBulkEventInfoData.java
@@ -1,0 +1,14 @@
+package com.devticket.settlement.infrastructure.client.dto.res;
+
+import java.util.List;
+
+/**
+ * Event 서비스의 InternalBulkEventInfoResponse에 대응하는 역직렬화 DTO.
+ * { "events": [ { "eventId": "uuid", "title": "..." }, ... ] }
+ * 없는 ID는 응답에서 누락될 수 있다(부분 결과).
+ */
+public record InternalBulkEventInfoData(
+    List<EventInfoResponse> events
+) {
+
+}

--- a/settlement/src/test/java/com/devticket/settlement/application/service/SettlementServiceImplTest.java
+++ b/settlement/src/test/java/com/devticket/settlement/application/service/SettlementServiceImplTest.java
@@ -3,8 +3,11 @@ package com.devticket.settlement.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.devticket.settlement.common.exception.BusinessException;
 import com.devticket.settlement.common.exception.CommonErrorCode;
@@ -21,6 +24,7 @@ import com.devticket.settlement.presentation.dto.SettlementPeriodResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -178,6 +182,43 @@ class SettlementServiceImplTest {
 
         assertThat(result.carriedInAmount()).isEqualTo(4850);
         assertThat(result.finalSettlementAmount()).isEqualTo(4850);
+    }
+
+    @Test
+    void getSettlementPreview_eventTitle_벌크조회_1회만_호출() {
+        UUID eventUUID1 = UUID.randomUUID();
+        UUID eventUUID2 = UUID.randomUUID();
+
+        SettlementItem item1 = SettlementItem.builder()
+            .orderItemId(UUID.randomUUID())
+            .eventId(1L).eventUUID(eventUUID1).sellerId(sellerId)
+            .salesAmount(50000L).refundAmount(0L).feeAmount(1500L).settlementAmount(48500L)
+            .status(SettlementItemStatus.READY).eventDateTime(LocalDate.now().minusDays(10))
+            .build();
+        SettlementItem item2 = SettlementItem.builder()
+            .orderItemId(UUID.randomUUID())
+            .eventId(2L).eventUUID(eventUUID2).sellerId(sellerId)
+            .salesAmount(30000L).refundAmount(0L).feeAmount(900L).settlementAmount(29100L)
+            .status(SettlementItemStatus.READY).eventDateTime(LocalDate.now().minusDays(5))
+            .build();
+
+        given(settlementItemRepository.findBySellerIdAndStatusAndEventDateTimeBetween(
+            eq(sellerId), eq(SettlementItemStatus.READY), any(LocalDate.class), any(LocalDate.class)))
+            .willReturn(List.of(item1, item2));
+        given(settlementRepository.findBySellerIdAndStatusAndCarriedToSettlementIdIsNull(
+            sellerId, SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of());
+        given(settlementToEventClient.getEventTitles(anyList()))
+            .willReturn(Map.of(eventUUID1, "이벤트 A", eventUUID2, "이벤트 B"));
+
+        SettlementPeriodResponse result = settlementServiceImpl.getSettlementPreview(sellerId);
+
+        assertThat(result.settlementItems()).hasSize(2);
+        assertThat(result.settlementItems())
+            .extracting("eventTitle")
+            .containsExactlyInAnyOrder("이벤트 A", "이벤트 B");
+        // N+1 제거 검증: 항목이 2건이어도 Event 서비스 호출은 1회
+        verify(settlementToEventClient, times(1)).getEventTitles(anyList());
     }
 
     @Test


### PR DESCRIPTION
## 배경

판매자 정산 화면(`/seller/settlements`, `/seller/settlements/{yearMonth}`, `/seller/settlements/preview`)은 응답으로 내려오는 `EventItemResponse.eventTitle` 값이 `"Unknown"` 으로 하드코딩되어 있어, 프론트엔드에서 `settlementItems` 의 항목별로 `getSellerEventDetail(eventId)` 를 N번 병렬 호출해 이벤트 제목을 보강하고 있었습니다. 정확하지만 항목 수만큼 요청이 발생하는 N+1 문제가 있어 백엔드에서 한 번에 채워주도록 변경합니다.

## 변경 사항

- `SettlementToEventClient.getEventTitles(List<UUID>)` 추가
  - `POST /internal/events/bulk` 한 번 호출로 `eventUUID → title` Map 을 반환
  - Event 서비스 호출 실패 시 빈 Map 으로 fallback 하여 정산 조회 자체가 실패하지 않도록 함
- `SettlementServiceImpl` 의 정산 조회 경로(seller detail / period / preview) 모두에서
  `SettlementItem` 목록의 `eventUUID` 를 모아 1회 일괄 조회하도록 수정
- `EventItemResponse.eventTitle` 을 실제 이벤트 제목으로 채움 (응답 누락 시 `"Unknown"` 으로 fallback 유지)
- `EventItemResponse.eventId` 를 `SettlementItem.eventId`(Long PK) 가 아닌 `eventUUID`(UUID) 로 노출하여 외부 서비스 호환 ID 로 통일

## 영향 범위

- API: `GET /seller/settlements/{yearMonth}`, `GET /seller/settlements/preview`, `GET /seller/settlements/{settlementId}` 응답 필드 값 변경
  - `eventTitle`: `"Unknown"` → 실제 이벤트 제목
  - `eventId`: Long PK 문자열 → UUID 문자열
- 외부 서비스 호출: 정산 조회 시 Event 서비스에 `POST /internal/events/bulk` 1회 추가 호출

## 테스트

- `SettlementServiceImplTest.getSettlementPreview_eventTitle_벌크조회_1회만_호출` 추가
  - 항목이 2건이어도 `getEventTitles` 호출은 1회임을 검증
  - 응답 항목별 `eventTitle` 이 Event 서비스 응답에서 채워지는지 검증
- 기존 단위 테스트 전체 통과 확인 (`./gradlew test`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VDJZDYZP87GspKKnPCF5or)_