### PR TITLE
chore: 각 모듈 최신 사항(devticket-*) 메인 동기화

### DIFF
--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementServiceImpl.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -75,7 +76,8 @@ public class SettlementServiceImpl implements SettlementService {
         List<SettlementItem> settlementItems = settlementItemRepository.findBySettlementId(
             settlement.getSettlementId());
 
-        return toResponse(settlement, settlementItems);
+        Map<UUID, String> eventTitles = fetchEventTitles(settlementItems);
+        return toResponse(settlement, settlementItems, eventTitles);
     }
 
     /**
@@ -236,10 +238,11 @@ public class SettlementServiceImpl implements SettlementService {
     private SettlementPeriodResponse toSettlementPeriodResponse(Settlement settlement) {
         log.debug("[toSettlementPeriodResponse] SettlementItem 조회 시작 - settlementId={}",
             settlement.getSettlementId());
-        List<EventItemResponse> items = settlementItemRepository
-            .findBySettlementId(settlement.getSettlementId())
-            .stream()
-            .map(this::toResponse)
+        List<SettlementItem> settlementItems = settlementItemRepository
+            .findBySettlementId(settlement.getSettlementId());
+        Map<UUID, String> eventTitles = fetchEventTitles(settlementItems);
+        List<EventItemResponse> items = settlementItems.stream()
+            .map(item -> toResponse(item, eventTitles))
             .toList();
         log.debug("[toSettlementPeriodResponse] SettlementItem 조회 완료 - {}건", items.size());
         return new SettlementPeriodResponse(
@@ -272,8 +275,9 @@ public class SettlementServiceImpl implements SettlementService {
 
         long finalSettlementAmount = newSettlementAmount + carriedInAmount;
 
+        Map<UUID, String> eventTitles = fetchEventTitles(readyItems);
         List<EventItemResponse> items = readyItems.stream()
-            .map(this::toResponse)
+            .map(item -> toResponse(item, eventTitles))
             .toList();
 
         return new SettlementPeriodResponse(
@@ -305,9 +309,10 @@ public class SettlementServiceImpl implements SettlementService {
         );
     }
 
-    private SellerSettlementDetailResponse toResponse(Settlement settlement, List<SettlementItem> settlementItems) {
+    private SellerSettlementDetailResponse toResponse(Settlement settlement,
+        List<SettlementItem> settlementItems, Map<UUID, String> eventTitles) {
         List<EventItemResponse> eventItems = settlementItems.stream()
-            .map(this::toResponse)
+            .map(item -> toResponse(item, eventTitles))
             .toList();
 
         return new SellerSettlementDetailResponse(
@@ -324,14 +329,35 @@ public class SettlementServiceImpl implements SettlementService {
         );
     }
 
-    private EventItemResponse toResponse(SettlementItem settlementItem) {
+    private EventItemResponse toResponse(SettlementItem settlementItem, Map<UUID, String> eventTitles) {
+        UUID eventUUID = settlementItem.getEventUUID();
+        String title = eventTitles.getOrDefault(eventUUID, "Unknown");
         return new EventItemResponse(
-            settlementItem.getEventId().toString(),
-            "Unknown",
+            eventUUID != null ? eventUUID.toString() : null,
+            title,
             settlementItem.getSalesAmount(),
             settlementItem.getRefundAmount(),
             settlementItem.getFeeAmount(),
             settlementItem.getSettlementAmount()
         );
+    }
+
+    /**
+     * SettlementItem 목록에서 eventUUID 를 모아 Event 서비스에 일괄 조회한다.
+     * 항목별 단건 호출(N+1) 대신 1회 호출로 eventTitle 을 채운다.
+     */
+    private Map<UUID, String> fetchEventTitles(List<SettlementItem> settlementItems) {
+        if (settlementItems.isEmpty()) {
+            return Map.of();
+        }
+        List<UUID> eventUUIDs = settlementItems.stream()
+            .map(SettlementItem::getEventUUID)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+        if (eventUUIDs.isEmpty()) {
+            return Map.of();
+        }
+        return settlementToEventClient.getEventTitles(eventUUIDs);
     }
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToEventClient.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/SettlementToEventClient.java
@@ -2,11 +2,18 @@ package com.devticket.settlement.infrastructure.client;
 
 import com.devticket.settlement.common.exception.BusinessException;
 import com.devticket.settlement.common.exception.CommonErrorCode;
+import com.devticket.settlement.infrastructure.client.dto.req.InternalBulkEventInfoRequest;
 import com.devticket.settlement.infrastructure.client.dto.res.EndedEventResponse;
+import com.devticket.settlement.infrastructure.client.dto.res.EventInfoResponse;
 import com.devticket.settlement.infrastructure.client.dto.res.EventServiceResponse;
+import com.devticket.settlement.infrastructure.client.dto.res.InternalBulkEventInfoData;
 import com.devticket.settlement.infrastructure.client.dto.res.InternalEndedEventsData;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ParameterizedTypeReference;
@@ -59,6 +66,55 @@ public class SettlementToEventClient {
         } catch (Exception e) {
             log.error("[SettlementToEventClient] Critical Error: ", e);
             throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 이벤트 ID 목록으로 이벤트 정보를 한 번에 조회.
+     * POST /internal/events/bulk
+     * 응답: SuccessResponse<InternalBulkEventInfoResponse>
+     *   → { status, message, data: { events: [ {eventId, title, ...}, ... ] } }
+     *
+     * 정산 응답에 eventTitle 을 채우기 위해 사용한다. 없는 ID 는 응답에서 누락될 수 있어
+     * 호출 측에서 누락 ID 를 fallback 처리해야 한다.
+     * 외부 호출 실패 시 빈 Map 을 반환하여 정산 조회 자체가 실패하지 않도록 한다.
+     */
+    public Map<UUID, String> getEventTitles(List<UUID> eventIds) {
+        if (eventIds == null || eventIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        List<UUID> distinctIds = eventIds.stream().distinct().toList();
+
+        try {
+            log.debug("[SettlementToEventClient] getEventTitles - count: {}", distinctIds.size());
+
+            EventServiceResponse<InternalBulkEventInfoData> response = restClient.post()
+                .uri("/internal/events/bulk")
+                .body(new InternalBulkEventInfoRequest(distinctIds))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    log.error("[SettlementToEventClient] Bulk API Error: Status {}", res.getStatusCode());
+                    throw new BusinessException(CommonErrorCode.EXTERNAL_SERVICE_ERROR);
+                })
+                .body(new ParameterizedTypeReference<EventServiceResponse<InternalBulkEventInfoData>>() {});
+
+            if (response == null || response.data() == null || response.data().events() == null) {
+                log.warn("[SettlementToEventClient] bulk 응답 데이터 없음 - count: {}", distinctIds.size());
+                return Collections.emptyMap();
+            }
+
+            return response.data().events().stream()
+                .filter(e -> e.eventId() != null && e.title() != null)
+                .collect(Collectors.toMap(
+                    EventInfoResponse::eventId,
+                    EventInfoResponse::title,
+                    (a, b) -> a
+                ));
+        } catch (Exception e) {
+            // 정산 조회는 본질적으로 SettlementItem 데이터로 동작 가능하므로
+            // 이벤트 제목 보강 실패가 전체 조회 실패로 이어지지 않도록 한다.
+            log.warn("[SettlementToEventClient] getEventTitles 실패 - 빈 Map 으로 fallback: {}", e.getMessage());
+            return Collections.emptyMap();
         }
     }
 }

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/req/InternalBulkEventInfoRequest.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/req/InternalBulkEventInfoRequest.java
@@ -1,0 +1,13 @@
+package com.devticket.settlement.infrastructure.client.dto.req;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Event 서비스 POST /internal/events/bulk 호출 요청 바디.
+ */
+public record InternalBulkEventInfoRequest(
+    List<UUID> eventIds
+) {
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EventInfoResponse.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/EventInfoResponse.java
@@ -1,0 +1,16 @@
+package com.devticket.settlement.infrastructure.client.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.UUID;
+
+/**
+ * Event 서비스의 InternalEventInfoResponse에 대응하는 역직렬화 DTO.
+ * 정산에서 필요한 필드(eventId, title)만 매핑한다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record EventInfoResponse(
+    UUID eventId,
+    String title
+) {
+
+}

--- a/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/InternalBulkEventInfoData.java
+++ b/settlement/src/main/java/com/devticket/settlement/infrastructure/client/dto/res/InternalBulkEventInfoData.java
@@ -1,0 +1,14 @@
+package com.devticket.settlement.infrastructure.client.dto.res;
+
+import java.util.List;
+
+/**
+ * Event 서비스의 InternalBulkEventInfoResponse에 대응하는 역직렬화 DTO.
+ * { "events": [ { "eventId": "uuid", "title": "..." }, ... ] }
+ * 없는 ID는 응답에서 누락될 수 있다(부분 결과).
+ */
+public record InternalBulkEventInfoData(
+    List<EventInfoResponse> events
+) {
+
+}

--- a/settlement/src/test/java/com/devticket/settlement/application/service/SettlementServiceImplTest.java
+++ b/settlement/src/test/java/com/devticket/settlement/application/service/SettlementServiceImplTest.java
@@ -3,8 +3,11 @@ package com.devticket.settlement.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.devticket.settlement.common.exception.BusinessException;
 import com.devticket.settlement.common.exception.CommonErrorCode;
@@ -21,6 +24,7 @@ import com.devticket.settlement.presentation.dto.SettlementPeriodResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -178,6 +182,43 @@ class SettlementServiceImplTest {
 
         assertThat(result.carriedInAmount()).isEqualTo(4850);
         assertThat(result.finalSettlementAmount()).isEqualTo(4850);
+    }
+
+    @Test
+    void getSettlementPreview_eventTitle_벌크조회_1회만_호출() {
+        UUID eventUUID1 = UUID.randomUUID();
+        UUID eventUUID2 = UUID.randomUUID();
+
+        SettlementItem item1 = SettlementItem.builder()
+            .orderItemId(UUID.randomUUID())
+            .eventId(1L).eventUUID(eventUUID1).sellerId(sellerId)
+            .salesAmount(50000L).refundAmount(0L).feeAmount(1500L).settlementAmount(48500L)
+            .status(SettlementItemStatus.READY).eventDateTime(LocalDate.now().minusDays(10))
+            .build();
+        SettlementItem item2 = SettlementItem.builder()
+            .orderItemId(UUID.randomUUID())
+            .eventId(2L).eventUUID(eventUUID2).sellerId(sellerId)
+            .salesAmount(30000L).refundAmount(0L).feeAmount(900L).settlementAmount(29100L)
+            .status(SettlementItemStatus.READY).eventDateTime(LocalDate.now().minusDays(5))
+            .build();
+
+        given(settlementItemRepository.findBySellerIdAndStatusAndEventDateTimeBetween(
+            eq(sellerId), eq(SettlementItemStatus.READY), any(LocalDate.class), any(LocalDate.class)))
+            .willReturn(List.of(item1, item2));
+        given(settlementRepository.findBySellerIdAndStatusAndCarriedToSettlementIdIsNull(
+            sellerId, SettlementStatus.PENDING_MIN_AMOUNT))
+            .willReturn(List.of());
+        given(settlementToEventClient.getEventTitles(anyList()))
+            .willReturn(Map.of(eventUUID1, "이벤트 A", eventUUID2, "이벤트 B"));
+
+        SettlementPeriodResponse result = settlementServiceImpl.getSettlementPreview(sellerId);
+
+        assertThat(result.settlementItems()).hasSize(2);
+        assertThat(result.settlementItems())
+            .extracting("eventTitle")
+            .containsExactlyInAnyOrder("이벤트 A", "이벤트 B");
+        // N+1 제거 검증: 항목이 2건이어도 Event 서비스 호출은 1회
+        verify(settlementToEventClient, times(1)).getEventTitles(anyList());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 각 `devticket-*` 브랜치 최신 HEAD 기준으로 main 모듈 폴더 동기화
- 이번 차분: `settlement` 모듈 — 판매자 정산 응답에 `eventTitle` 직접 포함 (devticket-settlement #703 까지)
- 그 외 모듈(admin/ai/apigateway/commerce/event/fastify-log/frontend/member/payment)은 직전 통합 시점과 동일

## 반영된 devticket-* HEAD
- admin: 47e428bc
- ai: 23de6cfd
- commerce: 83bf1e0c
- event: d6c5160a
- front: 4543b428
- gateway: f8a58428
- log: 4623e045
- member: 4f36a87a
- payment: 46f0049b
- settlement: 51d91c8c

## Test plan
- [ ] settlement 모듈 빌드/테스트 통과 확인
- [ ] 판매자 정산 조회 API 응답에 eventTitle 포함 여부 확인
- [ ] FE N+1 호출 제거 동작 확인

https://claude.ai/code/session_01VkBWEsyyyCu5oTzBaYo92Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkBWEsyyyCu5oTzBaYo92Q)_