### PR TITLE
[Settlement] perf: 관리자 정산서 상세 응답에 eventTitle 직접 채움

### DIFF
--- a/settlement/src/main/java/com/devticket/settlement/application/service/SettlementAdminServiceImpl.java
+++ b/settlement/src/main/java/com/devticket/settlement/application/service/SettlementAdminServiceImpl.java
@@ -11,6 +11,7 @@ import com.devticket.settlement.domain.repository.FeePolicyRepository;
 import com.devticket.settlement.domain.repository.SettlementItemRepository;
 import com.devticket.settlement.domain.repository.SettlementRepository;
 import com.devticket.settlement.infrastructure.client.SettlementToPaymentClient;
+import com.devticket.settlement.infrastructure.client.SettlementToEventClient;
 import com.devticket.settlement.infrastructure.external.dto.AdminSettlementDetailResponse;
 import com.devticket.settlement.infrastructure.external.dto.AdminSettlementDetailResponse.CarriedInSettlement;
 import com.devticket.settlement.presentation.dto.MonthlyRevenueResponse;
@@ -29,6 +30,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -48,6 +50,7 @@ public class SettlementAdminServiceImpl implements SettlementAdminService {
     private final SettlementToCommerceClient settlementToCommerceClient;
     private final SettlementToPaymentClient settlementToPaymentClient;
     private final SettlementToMemberClient settlementToMemberClient;
+    private final SettlementToEventClient settlementToEventClient;
     private final FeePolicyRepository feePolicyRepository;
     private final SettlementRepository settlementRepository;
     private final SettlementItemRepository settlementItemRepository;
@@ -170,17 +173,20 @@ public class SettlementAdminServiceImpl implements SettlementAdminService {
         Settlement settlement = settlementRepository.findBySettlementId(settlementId)
             .orElseThrow(() -> new BusinessException(SettlementErrorCode.SETTLEMENT_BAD_REQUEST));
 
-        List<EventItemResponse> settlementItems = settlementItemRepository
-            .findBySettlementId(settlementId)
-            .stream()
-            .map(item -> new EventItemResponse(
-                item.getEventId().toString(),
-                "Unknown",
-                item.getSalesAmount(),
-                item.getRefundAmount(),
-                item.getFeeAmount(),
-                item.getSettlementAmount()
-            ))
+        List<SettlementItem> items = settlementItemRepository.findBySettlementId(settlementId);
+        Map<UUID, String> eventTitles = fetchEventTitles(items);
+        List<EventItemResponse> settlementItems = items.stream()
+            .map(item -> {
+                UUID eventUUID = item.getEventUUID();
+                return new EventItemResponse(
+                    eventUUID != null ? eventUUID.toString() : null,
+                    eventTitles.getOrDefault(eventUUID, "Unknown"),
+                    item.getSalesAmount(),
+                    item.getRefundAmount(),
+                    item.getFeeAmount(),
+                    item.getSettlementAmount()
+                );
+            })
             .toList();
 
         // 이 정산서에 이월된 출처 정산서 목록 (역조회)
@@ -420,5 +426,24 @@ public class SettlementAdminServiceImpl implements SettlementAdminService {
     private String normalizeEndDate(String endDate) {
         if (endDate != null && !endDate.isBlank()) return endDate;
         return LocalDate.now().toString();
+    }
+
+    /**
+     * SettlementItem 목록의 eventUUID 를 모아 Event 서비스에 한 번에 조회한다.
+     * 단건 호출(N+1) 대신 1회 호출로 eventTitle 을 채우기 위함.
+     */
+    private Map<UUID, String> fetchEventTitles(List<SettlementItem> items) {
+        if (items.isEmpty()) {
+            return Map.of();
+        }
+        List<UUID> eventUUIDs = items.stream()
+            .map(SettlementItem::getEventUUID)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+        if (eventUUIDs.isEmpty()) {
+            return Map.of();
+        }
+        return settlementToEventClient.getEventTitles(eventUUIDs);
     }
 }

--- a/settlement/src/test/java/com/devticket/settlement/application/service/SettlementAdminServiceImplTest.java
+++ b/settlement/src/test/java/com/devticket/settlement/application/service/SettlementAdminServiceImplTest.java
@@ -23,13 +23,16 @@ import com.devticket.settlement.domain.repository.FeePolicyRepository;
 import com.devticket.settlement.domain.repository.SettlementItemRepository;
 import com.devticket.settlement.domain.repository.SettlementRepository;
 import com.devticket.settlement.infrastructure.client.SettlementToCommerceClient;
+import com.devticket.settlement.infrastructure.client.SettlementToEventClient;
 import com.devticket.settlement.infrastructure.client.SettlementToMemberClient;
 import com.devticket.settlement.infrastructure.client.SettlementToPaymentClient;
+import com.devticket.settlement.infrastructure.external.dto.AdminSettlementDetailResponse;
 import com.devticket.settlement.presentation.dto.MonthlyRevenueResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -45,6 +48,7 @@ class SettlementAdminServiceImplTest {
     @Mock private SettlementToCommerceClient settlementToCommerceClient;
     @Mock private SettlementToPaymentClient settlementToPaymentClient;
     @Mock private SettlementToMemberClient settlementToMemberClient;
+    @Mock private SettlementToEventClient settlementToEventClient;
     @Mock private FeePolicyRepository feePolicyRepository;
     @Mock private SettlementRepository settlementRepository;
     @Mock private SettlementItemRepository settlementItemRepository;
@@ -53,10 +57,6 @@ class SettlementAdminServiceImplTest {
     private SettlementAdminServiceImpl service;
 
     private final UUID sellerId = UUID.randomUUID();
-
-    // ────────────────────────────────────────────────
-    // createSettlementFromItems
-    // ────────────────────────────────────────────────
 
     @Test
     void createSettlementFromItems_최소금액충족_CONFIRMED생성() {
@@ -105,10 +105,9 @@ class SettlementAdminServiceImplTest {
 
         Settlement saved = captureNewSettlement();
         assertThat(saved.getStatus()).isEqualTo(SettlementStatus.CONFIRMED);
-        assertThat(saved.getFinalSettlementAmount()).isEqualTo(10670); // 4850 + 5820
+        assertThat(saved.getFinalSettlementAmount()).isEqualTo(10670);
         assertThat(saved.getCarriedInAmount()).isEqualTo(5820);
 
-        // 이월된 pending 정산서에 carriedToSettlementId 설정 확인
         assertThat(pending.getCarriedToSettlementId()).isEqualTo(saved.getSettlementId());
         assertThat(pending.getStatus()).isEqualTo(SettlementStatus.PENDING_MIN_AMOUNT);
     }
@@ -130,7 +129,7 @@ class SettlementAdminServiceImplTest {
 
         Settlement saved = captureNewSettlement();
         assertThat(saved.getStatus()).isEqualTo(SettlementStatus.PENDING_MIN_AMOUNT);
-        assertThat(saved.getFinalSettlementAmount()).isEqualTo(7000); // 3000 + 4000
+        assertThat(saved.getFinalSettlementAmount()).isEqualTo(7000);
     }
 
     @Test
@@ -150,7 +149,6 @@ class SettlementAdminServiceImplTest {
 
         service.createSettlementFromItems();
 
-        // 신규 정산서 save + pending의 carriedToSettlementId 업데이트 save = 2회
         verify(settlementRepository, atLeastOnce()).save(any(Settlement.class));
     }
 
@@ -217,10 +215,6 @@ class SettlementAdminServiceImplTest {
 
         verify(settlementItemRepository, never()).saveAll(anyList());
     }
-
-    // ────────────────────────────────────────────────
-    // processPayment
-    // ────────────────────────────────────────────────
 
     @Test
     void processPayment_CONFIRMED_지급성공_PAID처리() {
@@ -311,9 +305,76 @@ class SettlementAdminServiceImplTest {
                 .isEqualTo(SettlementErrorCode.SETTLEMENT_BAD_REQUEST));
     }
 
-    // ────────────────────────────────────────────────
-    // getMonthlyRevenue
-    // ────────────────────────────────────────────────
+    @Test
+    void getSettlementDetail_eventTitle_벌크조회로_채워짐_그리고_eventId는_UUID() {
+        UUID settlementId = UUID.randomUUID();
+        UUID eventUUID1 = UUID.randomUUID();
+        UUID eventUUID2 = UUID.randomUUID();
+
+        Settlement settlement = Settlement.builder()
+            .sellerId(sellerId)
+            .periodStartAt(LocalDateTime.of(2026, 3, 26, 0, 0))
+            .periodEndAt(LocalDateTime.of(2026, 4, 25, 23, 59, 59))
+            .totalSalesAmount(100000)
+            .totalRefundAmount(0)
+            .totalFeeAmount(3000)
+            .finalSettlementAmount(97000)
+            .carriedInAmount(0)
+            .status(SettlementStatus.CONFIRMED)
+            .build();
+
+        SettlementItem item1 = SettlementItem.builder()
+            .orderItemId(UUID.randomUUID())
+            .eventId(1L).eventUUID(eventUUID1).sellerId(sellerId)
+            .salesAmount(50000L).refundAmount(0L).feeAmount(1500L).settlementAmount(48500L)
+            .status(SettlementItemStatus.READY).eventDateTime(LocalDate.now().minusDays(10))
+            .build();
+        SettlementItem item2 = SettlementItem.builder()
+            .orderItemId(UUID.randomUUID())
+            .eventId(2L).eventUUID(eventUUID2).sellerId(sellerId)
+            .salesAmount(50000L).refundAmount(0L).feeAmount(1500L).settlementAmount(48500L)
+            .status(SettlementItemStatus.READY).eventDateTime(LocalDate.now().minusDays(5))
+            .build();
+
+        given(settlementRepository.findBySettlementId(settlementId)).willReturn(Optional.of(settlement));
+        given(settlementItemRepository.findBySettlementId(settlementId)).willReturn(List.of(item1, item2));
+        given(settlementRepository.findByCarriedToSettlementId(settlementId)).willReturn(List.of());
+        given(settlementToEventClient.getEventTitles(anyList()))
+            .willReturn(Map.of(eventUUID1, "이벤트 A", eventUUID2, "이벤트 B"));
+
+        AdminSettlementDetailResponse response = service.getSettlementDetail(settlementId);
+
+        assertThat(response.settlementItems()).hasSize(2);
+        assertThat(response.settlementItems())
+            .extracting("eventTitle")
+            .containsExactlyInAnyOrder("이벤트 A", "이벤트 B");
+        assertThat(response.settlementItems())
+            .extracting("eventId")
+            .containsExactlyInAnyOrder(eventUUID1.toString(), eventUUID2.toString());
+        verify(settlementToEventClient).getEventTitles(anyList());
+    }
+
+    @Test
+    void getSettlementDetail_항목없음_Event서비스_호출안함() {
+        UUID settlementId = UUID.randomUUID();
+        Settlement settlement = Settlement.builder()
+            .sellerId(sellerId)
+            .periodStartAt(LocalDateTime.of(2026, 3, 26, 0, 0))
+            .periodEndAt(LocalDateTime.of(2026, 4, 25, 23, 59, 59))
+            .totalSalesAmount(0).totalRefundAmount(0).totalFeeAmount(0)
+            .finalSettlementAmount(0).carriedInAmount(0)
+            .status(SettlementStatus.PENDING_MIN_AMOUNT)
+            .build();
+
+        given(settlementRepository.findBySettlementId(settlementId)).willReturn(Optional.of(settlement));
+        given(settlementItemRepository.findBySettlementId(settlementId)).willReturn(List.of());
+        given(settlementRepository.findByCarriedToSettlementId(settlementId)).willReturn(List.of());
+
+        AdminSettlementDetailResponse response = service.getSettlementDetail(settlementId);
+
+        assertThat(response.settlementItems()).isEmpty();
+        verify(settlementToEventClient, never()).getEventTitles(anyList());
+    }
 
     @Test
     void getMonthlyRevenue_정상조회_수수료합산반환() {
@@ -354,10 +415,6 @@ class SettlementAdminServiceImplTest {
         assertThat(fromCaptor.getValue()).isEqualTo(LocalDateTime.of(2026, 3, 26, 0, 0, 0));
         assertThat(toCaptor.getValue().toLocalDate()).isEqualTo(java.time.LocalDate.of(2026, 3, 26));
     }
-
-    // ────────────────────────────────────────────────
-    // 헬퍼
-    // ────────────────────────────────────────────────
 
     private SettlementItem buildItem(UUID sellerId, long settlementAmount) {
         return SettlementItem.builder()


### PR DESCRIPTION
## 배경

이전 PR(#702)에서 판매자 정산 응답에 `eventTitle` 을 직접 포함하도록 수정했지만, 같은 형태의 문제가 **관리자 정산서 상세 응답**(`GET /api/admin/settlements/{settlementId}`)에도 그대로 남아있었습니다. `SettlementAdminServiceImpl.getSettlementDetail` 에서 `eventTitle` 을 `"Unknown"` 으로 하드코딩하고 있었기 때문에, 관리자 화면(`AdminSettlementDetail`)이 모든 정산 항목의 이벤트명을 항상 `"Unknown"` 으로 표시하던 상황입니다.

이번 PR 은 같은 패턴(이벤트 서비스 1회 벌크 조회)을 관리자 경로에도 적용해 문제를 해결합니다.

## 변경 사항

- `SettlementAdminServiceImpl`
  - `SettlementToEventClient` 의존성 주입
  - `getSettlementDetail` 에서 `eventTitle = "Unknown"` 하드코딩 제거,
    `SettlementToEventClient.getEventTitles` 로 `eventUUID` 목록을 한 번에 조회해 채움
  - 응답의 `eventId` 필드를 `SettlementItem.eventId`(Long PK) → `eventUUID`(UUID) 로 변경
    (판매자 정산 응답과 동일한 형태로 통일)
- `SettlementAdminServiceImplTest`
  - `SettlementToEventClient` 모킹 추가
  - `getSettlementDetail_eventTitle_벌크조회로_채워짐_그리고_eventId는_UUID`
  - `getSettlementDetail_항목없음_Event서비스_호출안함`

## 영향 범위

- API: `GET /api/admin/settlements/{settlementId}` 응답
  - `settlementItems[].eventTitle`: `"Unknown"` → 실제 이벤트 제목 (응답 누락 시 `"Unknown"` fallback)
  - `settlementItems[].eventId`: Long PK 문자열 → UUID 문자열
- 화면: 관리자 정산서 상세 페이지(`AdminSettlementDetail`) — FE 변경 불필요. `item.eventTitle` 을 그대로 렌더링하므로 BE 응답 변경만으로 정상 표시됨.
- 외부 서비스 호출: 관리자 정산 상세 조회 시 Event 서비스에 `POST /internal/events/bulk` 1회 추가 호출. 항목이 0건이면 호출하지 않음.

## 테스트

- 추가된 단위 테스트 2건 통과
- 기존 `SettlementAdminServiceImplTest` 전체 통과
- `./gradlew test` 전체 그린


---
_Generated by [Claude Code](https://claude.ai/code/session_01VDJZDYZP87GspKKnPCF5or)_