### PR TITLE
[Event] fix: OpenAI Embedding 결과 Caffeine 캐시 적용

### DIFF
--- a/event/build.gradle
+++ b/event/build.gradle
@@ -61,6 +61,10 @@ dependencies {
     // Spring Retry — ES 동기화 실패 시 재시도
     implementation 'org.springframework.retry:spring-retry:2.0.11'
 
+    // Caffeine 캐시 — OpenAI Embedding 결과 캐싱으로 검색 p95 개선
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     // AWS S3
     implementation platform('software.amazon.awssdk:bom:2.26.12')
     implementation 'software.amazon.awssdk:s3'

--- a/event/src/main/java/com/devticket/event/common/config/CachingConfig.java
+++ b/event/src/main/java/com/devticket/event/common/config/CachingConfig.java
@@ -1,0 +1,9 @@
+package com.devticket.event.common.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CachingConfig {
+}

--- a/event/src/main/java/com/devticket/event/infrastructure/client/OpenAiEmbeddingClient.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/OpenAiEmbeddingClient.java
@@ -27,7 +27,7 @@ public class OpenAiEmbeddingClient {
      * @param text 임베딩할 텍스트
      * @return 1536차원 float[] 벡터, 실패 시 null
      */
-    @Cacheable(cacheNames = "embeddings", key = "#text", unless = "#result == null")
+    @Cacheable(cacheNames = "embeddings", key = "#text", unless = "#result == null", sync = true)
     public float[] embed(String text) {
         // Feature toggle 확인
         if (!openAiProperties.isEnabled()) {

--- a/event/src/main/java/com/devticket/event/infrastructure/client/OpenAiEmbeddingClient.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/OpenAiEmbeddingClient.java
@@ -27,7 +27,7 @@ public class OpenAiEmbeddingClient {
      * @param text 임베딩할 텍스트
      * @return 1536차원 float[] 벡터, 실패 시 null
      */
-    @Cacheable(cacheNames = "embeddings", key = "#text", unless = "#result == null", sync = true)
+    @Cacheable(cacheNames = "embeddings", key = "#text", unless = "#result == null")
     public float[] embed(String text) {
         // Feature toggle 확인
         if (!openAiProperties.isEnabled()) {

--- a/event/src/main/java/com/devticket/event/infrastructure/client/OpenAiEmbeddingClient.java
+++ b/event/src/main/java/com/devticket/event/infrastructure/client/OpenAiEmbeddingClient.java
@@ -5,6 +5,7 @@ import com.devticket.event.infrastructure.client.dto.EmbeddingRequest;
 import com.devticket.event.infrastructure.client.dto.EmbeddingResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -26,6 +27,7 @@ public class OpenAiEmbeddingClient {
      * @param text 임베딩할 텍스트
      * @return 1536차원 float[] 벡터, 실패 시 null
      */
+    @Cacheable(cacheNames = "embeddings", key = "#text", unless = "#result == null")
     public float[] embed(String text) {
         // Feature toggle 확인
         if (!openAiProperties.isEnabled()) {

--- a/event/src/main/resources/application.yml
+++ b/event/src/main/resources/application.yml
@@ -11,6 +11,11 @@ spring:
     multipart:
       max-file-size: 5MB
       max-request-size: 10MB
+  cache:
+    type: caffeine
+    cache-names: embeddings
+    caffeine:
+      spec: maximumSize=10000,expireAfterWrite=24h,recordStats
 
 server:
   port: 8082

--- a/event/src/main/resources/application.yml
+++ b/event/src/main/resources/application.yml
@@ -30,7 +30,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, prometheus
+        include: health, prometheus, caches
       base-path: /actuator
   endpoint:
     health:


### PR DESCRIPTION
## 관련 이슈
- close #707 

## 작업 내용
- `/api/events` 검색 API의 p95 지연을 줄이기 위해 OpenAI Embedding 결과를 Caffeine 인메모리 캐시로 저장
- 동일 keyword 재검색 시 외부 API(OpenAI `text-embedding-3-small`) 왕복을 제거
- Embedding 실패(`null` 반환) 케이스는 캐시에 저장하지 않아 기존 graceful fallback(`multi_match`) 동작 유지

## 변경 사항
- `event/build.gradle`
  - `spring-boot-starter-cache`, `caffeine` 의존성 추가
- `event/src/main/resources/application.yml`
  - `spring.cache` 설정 추가 (`type: caffeine`, `cache-names: embeddings`)
  - 캐시 스펙: `maximumSize=10000, expireAfterWrite=24h, recordStats`
- `event/src/main/java/com/devticket/event/common/config/CachingConfig.java` (신규)
  - `@EnableCaching` 활성화
- `event/src/main/java/com/devticket/event/infrastructure/client/OpenAiEmbeddingClient.java`
  - `embed(String text)`에 `@Cacheable(cacheNames="embeddings", key="#text", unless="#result == null")` 적용
