### PR TITLE
[Event] event 배포 develop/event -> devticket-event

### DIFF
--- a/event/src/main/java/com/devticket/event/application/EventCacheEvictor.java
+++ b/event/src/main/java/com/devticket/event/application/EventCacheEvictor.java
@@ -1,0 +1,27 @@
+package com.devticket.event.application;
+
+import com.devticket.event.common.config.CachingConfig;
+import java.util.Collection;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EventCacheEvictor {
+
+    private final CacheManager cacheManager;
+
+    public void evictEvents(Collection<UUID> eventIds) {
+        Cache detailCache = cacheManager.getCache(CachingConfig.EVENT_DETAIL);
+        if (detailCache != null) {
+            eventIds.forEach(detailCache::evict);
+        }
+        Cache listCache = cacheManager.getCache(CachingConfig.EVENT_LIST);
+        if (listCache != null) {
+            listCache.clear();
+        }
+    }
+}

--- a/event/src/main/java/com/devticket/event/application/EventInternalService.java
+++ b/event/src/main/java/com/devticket/event/application/EventInternalService.java
@@ -47,6 +47,7 @@ public class EventInternalService {
     private final EventRepository eventRepository;
     private final EventSearchRepository eventSearchRepository;
     private final MemberClient memberClient;
+    private final EventCacheEvictor eventCacheEvictor;
 
     @Transactional(readOnly = true)
     public InternalPagedEventResponse searchEvents(
@@ -228,6 +229,7 @@ public class EventInternalService {
         }
 
         statusChangedIds.forEach(this::syncToElasticsearch);
+        eventCacheEvictor.evictEvents(uniqueSortedIds);
 
         return new InternalStockAdjustmentResponse(Arrays.asList(results));
     }

--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -4,6 +4,7 @@ import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import com.devticket.event.application.event.ActionLogDomainEvent;
+import com.devticket.event.common.config.CachingConfig;
 import com.devticket.event.common.exception.BusinessException;
 import com.devticket.event.common.messaging.KafkaTopics;
 import com.devticket.event.common.messaging.event.EventForceCancelledEvent;
@@ -44,6 +45,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -70,6 +74,7 @@ public class EventService {
     private final ApplicationEventPublisher eventPublisher;
     private final EventViewRepository eventViewRepository;
 
+    @CacheEvict(value = CachingConfig.EVENT_LIST, allEntries = true)
     @Transactional
     public SellerEventCreateResponse createEvent(UUID sellerId, SellerEventCreateRequest request) {
 
@@ -137,21 +142,25 @@ public class EventService {
             .collect(Collectors.toMap(TechStackItem::id, TechStackItem::name));
     }
 
-    @Transactional
+    @Cacheable(value = CachingConfig.EVENT_DETAIL, key = "#eventId")
+    @Transactional(readOnly = true)
     public EventDetailResponse getEvent(UUID eventId) {
 
         Event event = eventRepository.findWithDetailsByEventId(eventId)
             .orElseThrow(() -> new BusinessException(EventErrorCode.EVENT_NOT_FOUND));
 
-        // 1. 조회수 증가 : eventView 가져오기
-        EventView eventView = eventViewRepository.findByEvent(event)
-            .orElseGet(() -> eventViewRepository.save(EventView.of(event)));
-        // 2. 조회수 증가 : eventView 증가
-        eventView.increaseViewCount();
-
         String nickname = memberClient.getNickname(event.getSellerId());
 
         return EventDetailResponse.from(event, nickname);
+    }
+
+    @Transactional
+    public void recordView(UUID eventId) {
+        Event event = eventRepository.findByEventId(eventId)
+            .orElseThrow(() -> new BusinessException(EventErrorCode.EVENT_NOT_FOUND));
+        EventView eventView = eventViewRepository.findByEvent(event)
+            .orElseGet(() -> eventViewRepository.save(EventView.of(event)));
+        eventView.increaseViewCount();
     }
 
     public void logDetailView(UUID userId, UUID eventId) {
@@ -178,6 +187,10 @@ public class EventService {
             null, null, null, Instant.now()));
     }
 
+    @Cacheable(
+        value = CachingConfig.EVENT_LIST,
+        key = "#request.toString() + ':' + #pageable.pageNumber + ':' + #pageable.pageSize + ':' + (#currentUserId == null ? 'anon' : #currentUserId.toString())"
+    )
     @Transactional(readOnly = true)
     public EventListResponse getEventList(EventListRequest request, UUID currentUserId, Pageable pageable) {
 
@@ -323,6 +336,10 @@ public class EventService {
             status == EventStatus.DRAFT;
     }
 
+    @Caching(evict = {
+        @CacheEvict(value = CachingConfig.EVENT_LIST, allEntries = true),
+        @CacheEvict(value = CachingConfig.EVENT_DETAIL, key = "#eventId")
+    })
     @Transactional
     public SellerEventUpdateResponse updateEvent(UUID sellerId, UUID eventId,
         SellerEventUpdateRequest request) {
@@ -433,6 +450,10 @@ public class EventService {
      * <p><b>본 액션은 환불을 동반</b>한다. 단순 신규 판매 중단 (Action B — 기존 구매자 영향 없음)은
      * {@link #updateEvent} 의 {@code status=CANCELLED} 분기로 호출 (별개 흐름).
      */
+    @Caching(evict = {
+        @CacheEvict(value = CachingConfig.EVENT_LIST, allEntries = true),
+        @CacheEvict(value = CachingConfig.EVENT_DETAIL, key = "#eventId")
+    })
     @Transactional
     public void forceCancel(UUID userId, String userRole, UUID eventId, String reason) {
         Event event = eventRepository.findByEventIdWithLock(eventId)

--- a/event/src/main/java/com/devticket/event/application/EventService.java
+++ b/event/src/main/java/com/devticket/event/application/EventService.java
@@ -189,7 +189,7 @@ public class EventService {
 
     @Cacheable(
         value = CachingConfig.EVENT_LIST,
-        key = "#request.toString() + ':' + #pageable.pageNumber + ':' + #pageable.pageSize + ':' + (#currentUserId == null ? 'anon' : #currentUserId.toString())"
+        key = "#request.toString() + ':' + #pageable.pageNumber + ':' + #pageable.pageSize + ':' + #pageable.sort.toString() + ':' + (#currentUserId == null ? 'anon' : #currentUserId.toString())"
     )
     @Transactional(readOnly = true)
     public EventListResponse getEventList(EventListRequest request, UUID currentUserId, Pageable pageable) {

--- a/event/src/main/java/com/devticket/event/application/OrderCancelledService.java
+++ b/event/src/main/java/com/devticket/event/application/OrderCancelledService.java
@@ -22,6 +22,7 @@ public class OrderCancelledService {
     private final EventRepository eventRepository;
     private final MessageDeduplicationService deduplicationService;
     private final ObjectMapper objectMapper;
+    private final EventCacheEvictor eventCacheEvictor;
 
     @Transactional
     public void restoreStockForOrderCancelled(UUID messageId, String topic, String payload) {
@@ -72,6 +73,7 @@ public class OrderCancelledService {
 
         // Step 4. Dedup 기록 (같은 트랜잭션)
         deduplicationService.markProcessed(messageId, topic);
+        eventCacheEvictor.evictEvents(sortedEventIds);
     }
 
     private OrderCancelledEvent deserializeOrderCancelled(String payload) {

--- a/event/src/main/java/com/devticket/event/application/StockRestoreService.java
+++ b/event/src/main/java/com/devticket/event/application/StockRestoreService.java
@@ -23,6 +23,7 @@ public class StockRestoreService {
     private final EventRepository eventRepository;
     private final MessageDeduplicationService deduplicationService;
     private final ObjectMapper objectMapper;
+    private final EventCacheEvictor eventCacheEvictor;
 
     @Transactional
     public void restoreStockForPaymentFailed(UUID messageId, String topic, String payload) {
@@ -74,6 +75,7 @@ public class StockRestoreService {
 
         // Step 4. Dedup 기록 (같은 트랜잭션)
         deduplicationService.markProcessed(messageId, topic);
+        eventCacheEvictor.evictEvents(sortedEventIds);
     }
 
     private PaymentFailedEvent deserialize(String payload) {

--- a/event/src/main/java/com/devticket/event/common/config/CachingConfig.java
+++ b/event/src/main/java/com/devticket/event/common/config/CachingConfig.java
@@ -1,9 +1,41 @@
 package com.devticket.event.common.config;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import java.util.List;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableCaching
 public class CachingConfig {
+
+    public static final String EMBEDDINGS = "embeddings";
+    public static final String EVENT_LIST = "event:list";
+    public static final String EVENT_DETAIL = "event:detail";
+
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager manager = new SimpleCacheManager();
+        manager.setCaches(List.of(
+            buildCache(EMBEDDINGS, 10_000, Duration.ofHours(24)),
+            buildCache(EVENT_LIST, 1_000, Duration.ofSeconds(10)),
+            buildCache(EVENT_DETAIL, 5_000, Duration.ofSeconds(30))
+        ));
+        return manager;
+    }
+
+    private CaffeineCache buildCache(String name, long maximumSize, Duration ttl) {
+        return new CaffeineCache(name,
+            Caffeine.newBuilder()
+                .maximumSize(maximumSize)
+                .expireAfterWrite(ttl)
+                .recordStats()
+                .build()
+        );
+    }
 }

--- a/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
+++ b/event/src/main/java/com/devticket/event/presentation/controller/EventController.java
@@ -27,6 +27,7 @@ public class EventController {
         @RequestHeader(value = "X-User-Id", required = false) UUID currentUserId,
         @PathVariable("eventId") UUID eventId) {
         EventDetailResponse response = eventService.getEvent(eventId);
+        eventService.recordView(eventId);
         eventService.logDetailView(currentUserId, eventId);
         return ResponseEntity.ok(SuccessResponse.success(response));
     }

--- a/event/src/test/java/com/devticket/event/application/EventInternalServiceConcurrencyTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventInternalServiceConcurrencyTest.java
@@ -55,6 +55,7 @@ class EventInternalServiceConcurrencyTest {
 
     @MockitoBean private MemberClient memberClient;
     @MockitoBean private EventSearchRepository eventSearchRepository;
+    @MockitoBean private EventCacheEvictor eventCacheEvictor;
 
     @AfterEach
     void cleanup() {

--- a/event/src/test/java/com/devticket/event/application/EventServiceCacheIntegrationTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventServiceCacheIntegrationTest.java
@@ -1,0 +1,96 @@
+package com.devticket.event.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.devticket.event.common.config.CachingConfig;
+import com.devticket.event.common.outbox.OutboxService;
+import com.devticket.event.domain.model.Event;
+import com.devticket.event.fixture.EventTestFixture;
+import com.devticket.event.infrastructure.client.AdminClient;
+import com.devticket.event.infrastructure.client.MemberClient;
+import com.devticket.event.infrastructure.client.OpenAiEmbeddingClient;
+import com.devticket.event.infrastructure.persistence.EventRepository;
+import com.devticket.event.infrastructure.persistence.EventViewRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * EventService의 @Cacheable / @CacheEvict 동작을 검증한다.
+ * 캐시 hit 시 메서드 본문이 실행되지 않아 repository 호출이 생략되어야 한다.
+ * mutation 메서드(forceCancel 등) 호출 후에는 evict로 인해 다음 read에서 repo가 재호출되어야 한다.
+ */
+@SpringBootTest(
+    classes = {EventService.class, CachingConfig.class},
+    webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+class EventServiceCacheIntegrationTest {
+
+    @MockitoBean private EventRepository eventRepository;
+    @MockitoBean private MemberClient memberClient;
+    @MockitoBean private AdminClient adminClient;
+    @MockitoBean private ElasticsearchOperations elasticsearchOperations;
+    @MockitoBean private ElasticsearchSyncService elasticsearchSyncService;
+    @MockitoBean private OpenAiEmbeddingClient openAiEmbeddingClient;
+    @MockitoBean private OutboxService outboxService;
+    @MockitoBean private MessageDeduplicationService deduplicationService;
+    @MockitoBean private EventViewRepository eventViewRepository;
+
+    @Autowired private EventService eventService;
+    @Autowired private CacheManager cacheManager;
+
+    @BeforeEach
+    void clearCaches() {
+        cacheManager.getCacheNames().forEach(name -> {
+            var cache = cacheManager.getCache(name);
+            if (cache != null) {
+                cache.clear();
+            }
+        });
+    }
+
+    @Test
+    @DisplayName("getEvent — 동일 eventId 2회 호출 시 repository는 1회만 호출된다 (cache hit)")
+    void getEventCachesByEventId() {
+        UUID sellerId = UUID.randomUUID();
+        Event event = EventTestFixture.createEvent(sellerId);
+        UUID eventId = event.getEventId();
+        when(eventRepository.findWithDetailsByEventId(eventId)).thenReturn(Optional.of(event));
+        when(memberClient.getNickname(sellerId)).thenReturn("tester");
+
+        var first = eventService.getEvent(eventId);
+        var second = eventService.getEvent(eventId);
+
+        assertThat(first.eventId()).isEqualTo(eventId);
+        assertThat(second.eventId()).isEqualTo(eventId);
+        verify(eventRepository, times(1)).findWithDetailsByEventId(eventId);
+        verify(memberClient, times(1)).getNickname(sellerId);
+    }
+
+    @Test
+    @DisplayName("event:detail 캐시 evict 후 동일 eventId 호출 시 repository가 재호출된다")
+    void evictTriggersRepoReload() {
+        UUID sellerId = UUID.randomUUID();
+        Event event = EventTestFixture.createEvent(sellerId);
+        UUID eventId = event.getEventId();
+        when(eventRepository.findWithDetailsByEventId(eventId)).thenReturn(Optional.of(event));
+        when(memberClient.getNickname(any())).thenReturn("tester");
+
+        eventService.getEvent(eventId);  // 캐시 적재
+        cacheManager.getCache(CachingConfig.EVENT_DETAIL).evict(eventId);
+        eventService.getEvent(eventId);  // 캐시 miss → repo 재호출
+
+        verify(eventRepository, times(2)).findWithDetailsByEventId(eventId);
+    }
+}

--- a/event/src/test/java/com/devticket/event/application/EventServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/EventServiceTest.java
@@ -211,7 +211,6 @@ class EventServiceTest {
         // memberClient.getNickname() 은 기본 null 반환 — CI 환경에서 일부 응답 합성 경로가 null 을 허용하지 않을 수 있어
         // 명시적 stub 으로 NPE 재발 방지 (CI run 24766734663 재현 차단)
         when(memberClient.getNickname(sellerId)).thenReturn("tester");
-        when(eventViewRepository.findByEvent(event)).thenReturn(Optional.of(EventView.of(event)));
 
         // when
         EventDetailResponse response = eventService.getEvent(eventId);

--- a/event/src/test/java/com/devticket/event/application/OrderCancelledServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/OrderCancelledServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
@@ -30,6 +31,9 @@ class OrderCancelledServiceTest {
 
     @Autowired
     private OrderCancelledService orderCancelledService;
+
+    @MockitoBean
+    private EventCacheEvictor eventCacheEvictor;
 
     @Autowired
     private EventRepository eventRepository;

--- a/event/src/test/java/com/devticket/event/application/StockRestoreServiceTest.java
+++ b/event/src/test/java/com/devticket/event/application/StockRestoreServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
@@ -30,6 +31,9 @@ class StockRestoreServiceTest {
 
     @Autowired
     private StockRestoreService stockRestoreService;
+
+    @MockitoBean
+    private EventCacheEvictor eventCacheEvictor;
 
     @Autowired
     private EventRepository eventRepository;


### PR DESCRIPTION
## 배포 범위

`develop/event` → `devticket-event` 머지 (3 커밋 / 1 PR)

## 포함 PR

### #711 — list/detail @Cacheable 적용 (closes #710)
- `4c5eec4f` perf(event): list/detail @Cacheable 추가 (#710)
- `5e8b4bab` fix(event): event:list 캐시 키에 정렬 조건 포함

## 변경 요약

부하 테스트 ⑨단계에서 list/detail p95 SLO 미달(1455ms / 429ms)에 대한 캐시 도입.

### 캐시 정책 (Caffeine, 변동 빈도 차등 TTL)
| 캐시 | TTL | maxSize | 용도 |
|---|---|---|---|
| `embeddings` | 24h | 10,000 | 기존 (#708) |
| `event:list` | 10s | 1,000 | `getEventList()` ES round-trip 회피 |
| `event:detail` | 30s | 5,000 | `getEvent()` ES round-trip 회피 |

### 주요 변경
- `CachingConfig` 재작성 — `SimpleCacheManager` + `CaffeineCache` 빌더로 캐시별 정책 분리
- `EventService.getEvent()` — `@Cacheable("event:detail", key="#eventId")`
  - viewCount 증가 side effect를 `recordView()`로 분리 → cache hit 시에도 조회수 정확 (controller가 별도 호출)
- `EventService.getEventList()` — `@Cacheable("event:list", key=request+page+size+sort+user)`
- 재고/상태 변경 경로 전수에 `@CacheEvict` 또는 `EventCacheEvictor` 적용
  - `createEvent` / `updateEvent` / `forceCancel` — 어노테이션 기반
  - `adjustStockBulk` / `OrderCancelledService` / `StockRestoreService` — `EventCacheEvictor` 헬퍼 기반 (payload에서 eventId 추출)
- 정렬 조건 캐시 키 누락 버그 수정 — `pageable.sort.toString()`을 키에 포함하여 sort 변경 시 stale 데이터 방지

## 테스트

- [x] `develop/event` 기준 CI 통과
- [x] `EventServiceCacheIntegrationTest` 2/2 PASS (cache hit / cache evict 검증)
- [x] 전체 회귀 233/233 PASS

## 검증 결과 (PR #711 시점)

- Actuator `/actuator/caches` — `embeddings` / `event:list` / `event:detail` 정상 등록 확인
- 동일 keyword 2회 호출 응답 시간: 845ms → 20ms (40배 개선)

## 배포 후 확인

- 부하 테스트 ⑩단계 재실행 — list p95 < 300ms, detail p95 < 350ms 목표
- 운영 로그에서 `/actuator/caches/event:list`, `/actuator/caches/event:detail` hit/miss 비율 모니터링
- 재고 차감/이벤트 수정 후 클라이언트 응답 stale 데이터 없는지 확인 (TTL 10~30초 + evict 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
